### PR TITLE
Fix empty space after code block in Firefox 

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -111,10 +111,10 @@ module.exports = {
           lineHeight: 'inherit',
         },
         'pre code::before': {
-          content: '""',
+          content: 'none',
         },
         'pre code::after': {
-          content: '""',
+          content: 'none',
         },
         table: {
           width: '100%',


### PR DESCRIPTION
There was an empty space after all code blocks in Firefox,

![Screenshot 2020-07-25 at 5 31 29 PM](https://user-images.githubusercontent.com/13696888/88456808-7caba600-ce9e-11ea-84fe-10dffb157254.png)

this was due to setting `content: ""` in `pre code::after`. It works normally in all browsers after setting it to  `content: none`