### PR TITLE
Use package `files` instead of `.npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-docs
-node_modules
-.next
-package-lock.json
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "description": "A Tailwind CSS plugin for automatically styling plain HTML content with beautiful typographic defaults.",
   "main": "src/index.js",
+  "files": [
+    "src/*.js"
+  ],
   "repository": "https://github.com/tailwindcss/typography",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
The [npm package](https://www.npmjs.com/package/@tailwindcss/typography) currently weights **18.9MB** with 62 files in total. This is (mostly) due to the Next demo being published (it was part of `.gitignore` but not of `.npmignore`).

This PR reduces the package size to **39.4 kB** and 4 files by selecting specific files of the final package instead of removing unwanted ones.

*Note 1: I left out `scripts` and CSS from `dist` as it isn't being used in the current form of the plugin.

*Note 2:  that the following comparison shows significant smaller bundle (before) because I didn't build the demo.

Before:
```sh
> @tailwindcss/typography@0.2.0 prepare .
> node scripts/build.js

Building CSS...
Finished building CSS.

package: @tailwindcss/typography@0.2.0    
=== Tarball Contents === 
104.5kB dist/typography.css
78.0kB  dist/typography.min.css
15.1kB  demo/public/favicon.ico
255B    demo/pages/_app.js
936B    scripts/build.js
6.5kB   demo/pages/index.js
1.5kB   src/index.js
115B    demo/next.config.js
131B    demo/postcss.config.js
27.9kB  src/styles.js
927B    demo/tailwind.config.js
999B    package.json
9.0kB   README.md
10.8kB  demo/components/MarkdownSample.mdx
1.0kB   demo/public/favicon-16x16.png
1.3kB   demo/public/favicon-32x32.png
3.8kB   .github/logo.svg
=== Tarball Details ===
name:          @tailwindcss/typography
version:       0.2.0
package size:  36.5 kB
unpacked size: 262.8 kB
shasum:        fdbef09f0487e2c971accf02ad37d144dc82f762
integrity:     sha512-mt0Uucoj+J+i6[...]ZNzw63A/1nKOw==
total files:   17

+ @tailwindcss/typography@0.2.0
```

After:
```sh
> @tailwindcss/typography@0.2.0 prepare .
> node scripts/build.js

Building CSS...
Finished building CSS.
npm notice
package: @tailwindcss/typography@0.2.0
=== Tarball Contents ===
1.5kB  src/index.js
27.9kB src/styles.js
1.0kB  package.json
9.0kB  README.md
=== Tarball Details ===
name:          @tailwindcss/typography
version:       0.2.0
package size:  6.8 kB
unpacked size: 39.4 kB
shasum:        b4170d7d246b5ecde7c77a5f20d780eab0645d85
integrity:     sha512-h/LM47GDxQsyA[...]jeBAaGL5RLbYQ==
total files:   4

+ @tailwindcss/typography@0.2.0
```

Resulting data provided by `npm publish --dry-run`