### PR TITLE
Preserve `type` attribute of the `ol` element

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -28,12 +28,39 @@ module.exports = {
         ol: {
           counterReset: 'list-counter',
         },
+        'ol[type=A]': {
+          '--list-counter-style': 'upper-alpha',
+        },
+        'ol[type=a]': {
+          '--list-counter-style': 'lower-alpha',
+        },
+        'ol[type=A s]': {
+          '--list-counter-style': 'upper-alpha',
+        },
+        'ol[type=a s]': {
+          '--list-counter-style': 'lower-alpha',
+        },
+        'ol[type=I]': {
+          '--list-counter-style': 'upper-roman',
+        },
+        'ol[type=i]': {
+          '--list-counter-style': 'lower-roman',
+        },
+        'ol[type=I s]': {
+          '--list-counter-style': 'upper-roman',
+        },
+        'ol[type=i s]': {
+          '--list-counter-style': 'lower-roman',
+        },
+        'ol[type=1]': {
+          '--list-counter-style': 'decimal',
+        },
         'ol > li': {
           position: 'relative',
           counterIncrement: 'list-counter',
         },
         'ol > li::before': {
-          content: 'counter(list-counter) "."',
+          content: 'counter(list-counter, var(--list-counter-style, decimal)) "."',
           position: 'absolute',
           fontWeight: '400',
           color: defaultTheme.colors.gray[600],


### PR DESCRIPTION
This solution preserves the `type` attribute of the `ol` element.

Due to css case-insensitivity I came up with a solution like this:

```js
'ol[type=A]': {
  '--list-counter-style': 'upper-alpha',
},
'ol[type=a]': {
  '--list-counter-style': 'lower-alpha',
},
'ol[type=A s]': {
  '--list-counter-style': 'upper-alpha',
},
'ol[type=a s]': {
  '--list-counter-style': 'lower-alpha',
},
'ol[type=I]': {
  '--list-counter-style': 'upper-roman',
},
'ol[type=i]': {
  '--list-counter-style': 'lower-roman',
},
'ol[type=I s]': {
  '--list-counter-style': 'upper-roman',
},
'ol[type=i s]': {
  '--list-counter-style': 'lower-roman',
},
'ol[type=1]': {
  '--list-counter-style': 'decimal',
}
```

Browsers, that supports case-sensitive modifier in attribute selector (Firefox) will use:

```js
'ol[type=A s]': {
  '--list-counter-style': 'upper-alpha',
},
'ol[type=a s]': {
  '--list-counter-style': 'lower-alpha',
},
```

so this will behave correctly:

```html
<ol type="a"></ol>
<ol type="A"></ol>
```

Browsers, that does not supports case-sensitive modifier in attribute selector, but support case-sensitivity will use:

```js
'ol[type=A]': {
  '--list-counter-style': 'upper-alpha',
},
'ol[type=a]': {
  '--list-counter-style': 'lower-alpha',
},
```

And at last browsers, that does not supports case-sensitivity will use the last selector:

```js
'ol[type=a]': {
  '--list-counter-style': 'lower-alpha',
},
```

Similar for `type="i"` and `type="I"`.

Links:
[W3C | Selectors | Case-sensitivity](https://drafts.csswg.org/selectors-4/#attribute-case)
[MDN | Attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)

Resolve #70 