### PR TITLE
First test with a no-prose stop class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,17 +18,17 @@ function configToCss(config) {
 }
 
 module.exports = plugin.withOptions(
-  ({ modifiers = ['sm', 'lg', 'xl', '2xl'], className = 'prose' } = {}) => {
+  ({ modifiers = ['sm', 'lg', 'xl', '2xl'], className = 'prose', stopClassName = 'no-prose } = {}) => {
     return function ({ addComponents, theme, variants }) {
       const config = theme('typography', {})
 
       addComponents(
         [
           {
-            [`.${className}`]: merge(...castArray(styles.default.css), configToCss(config.default || {})),
+            [`.${className} *:not(.${stopClassName})`]: merge(...castArray(styles.default.css), configToCss(config.default || {})),
           },
           ...modifiers.map((modifier) => ({
-            [`.${className}-${modifier}`]: merge(
+            [`.${className}-${modifier} *:not(.${stopClassName})`]: merge(
               ...castArray(styles[modifier].css),
               configToCss(config[modifier] || {})
             ),
@@ -36,7 +36,7 @@ module.exports = plugin.withOptions(
           ...Object.keys(config)
             .filter((key) => !['default', ...modifiers].includes(key))
             .map((modifier) => ({
-              [`.${className}-${modifier}`]: configToCss(config[modifier]),
+              [`.${className}-${modifier} *:not(.${stopClassName})`]: configToCss(config[modifier]),
             })),
         ],
         variants('typography')


### PR DESCRIPTION
Hi, 
This is just to set a place to iterate on a way to stop and reset prose styling as said in https://twitter.com/mathieutu/status/1306156743962099712.

Actually it's not totally working, but I'm trying to understand why, and it's the best result I had.

EDIT : 
>This selector only applies to one element; you cannot use it to exclude all ancestors. For instance, body :not(table) a will still apply to links inside of a table, since <tr> will match with the :not() part of the selector.

So start again from begining.. 😞 (even if actually it did work on some tags (ex: it removed the color of links), so weird. 😅)


Related issue: 
- #32
- #62