### PR TITLE
Use the implicit `list-item` counter

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -25,15 +25,11 @@ module.exports = {
           color: defaultTheme.colors.gray[900],
           fontWeight: '600',
         },
-        ol: {
-          counterReset: 'list-counter',
-        },
         'ol > li': {
           position: 'relative',
-          counterIncrement: 'list-counter',
         },
         'ol > li::before': {
-          content: 'counter(list-counter) "."',
+          content: 'counter(list-item) "."',
           position: 'absolute',
           fontWeight: '400',
           color: defaultTheme.colors.gray[500],


### PR DESCRIPTION
This solution preserves the `start` and `reversed` attribute of the `<ol>` element and  the `value` attribute of the `<li>` element.

**Implementation details:**
Uses the [implicit list counter](https://drafts.csswg.org/css-lists-3/#list-item-counter) instead of custom one.

An alternative solution to PR https://github.com/tailwindlabs/tailwindcss-typography/pull/75

Resolve #71 