### PR TITLE
Add color modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "snapshot-diff": "^0.8.1",
-    "tailwindcss": "^2.0.0-alpha.4"
+    "tailwindcss": "^2.0.0-alpha.16"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,5 +41,8 @@ module.exports = plugin.withOptions(
       )
     }
   },
-  () => ({ theme: { typography: styles }, variants: { typography: ['responsive'] } })
+  () => ({
+    theme: { typography: styles },
+    variants: { typography: ['responsive'] },
+  })
 )

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const merge = require('lodash/merge')
 const castArray = require('lodash/castArray')
 const uniq = require('lodash/uniq')
 const styles = require('./styles')
+const { isUsableColor } = require('./utils')
 
 const computed = {
   // Reserved for future "magic properties", for example:
@@ -19,10 +20,22 @@ function configToCss(config = {}) {
   )
 }
 
-const DEFAULT_MODIFIERS = ['DEFAULT', 'sm', 'lg', 'xl', '2xl']
 module.exports = plugin.withOptions(
-  ({ modifiers = DEFAULT_MODIFIERS, className = 'prose' } = {}) => {
+  ({ modifiers, className = 'prose' } = {}) => {
     return function ({ addComponents, theme, variants }) {
+      const DEFAULT_MODIFIERS = [
+        'DEFAULT',
+        'sm',
+        'lg',
+        'xl',
+        '2xl',
+        ...Object.entries(theme('colors'))
+          .filter(([color, values]) => {
+            return isUsableColor(color, values)
+          })
+          .map(([color]) => color),
+      ]
+      modifiers = modifiers === undefined ? DEFAULT_MODIFIERS : modifiers
       const config = theme('typography')
 
       const all = uniq([

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -47,6 +47,7 @@ it('should generate the default classes for the typography components', async ()
     .prose a {
       color: #18181b;
       text-decoration: underline;
+      font-weight: 500;
     }
 
     .prose strong {
@@ -171,6 +172,10 @@ it('should generate the default classes for the typography components', async ()
 
     .prose code::after {
       content: \\"\`\\";
+    }
+
+    .prose a code {
+      color: #18181b;
     }
 
     .prose pre {
@@ -1255,6 +1260,54 @@ it('should generate the default classes for the typography components', async ()
       margin-bottom: 0;
     }
 
+    .prose-red a {
+      color: #dc2626;
+    }
+
+    .prose-red a code {
+      color: #dc2626;
+    }
+
+    .prose-yellow a {
+      color: #d97706;
+    }
+
+    .prose-yellow a code {
+      color: #d97706;
+    }
+
+    .prose-green a {
+      color: #059669;
+    }
+
+    .prose-green a code {
+      color: #059669;
+    }
+
+    .prose-blue a {
+      color: #2563eb;
+    }
+
+    .prose-blue a code {
+      color: #2563eb;
+    }
+
+    .prose-purple a {
+      color: #7c3aed;
+    }
+
+    .prose-purple a code {
+      color: #7c3aed;
+    }
+
+    .prose-pink a {
+      color: #db2777;
+    }
+
+    .prose-pink a code {
+      color: #db2777;
+    }
+
     @media (min-width: 640px) {
       .sm\\\\:prose {
         color: #3f3f46;
@@ -1272,6 +1325,7 @@ it('should generate the default classes for the typography components', async ()
       .sm\\\\:prose a {
         color: #18181b;
         text-decoration: underline;
+        font-weight: 500;
       }
 
       .sm\\\\:prose strong {
@@ -1396,6 +1450,10 @@ it('should generate the default classes for the typography components', async ()
 
       .sm\\\\:prose code::after {
         content: \\"\`\\";
+      }
+
+      .sm\\\\:prose a code {
+        color: #18181b;
       }
 
       .sm\\\\:prose pre {
@@ -2479,6 +2537,54 @@ it('should generate the default classes for the typography components', async ()
       .sm\\\\:prose-2xl > :last-child {
         margin-bottom: 0;
       }
+
+      .sm\\\\:prose-red a {
+        color: #dc2626;
+      }
+
+      .sm\\\\:prose-red a code {
+        color: #dc2626;
+      }
+
+      .sm\\\\:prose-yellow a {
+        color: #d97706;
+      }
+
+      .sm\\\\:prose-yellow a code {
+        color: #d97706;
+      }
+
+      .sm\\\\:prose-green a {
+        color: #059669;
+      }
+
+      .sm\\\\:prose-green a code {
+        color: #059669;
+      }
+
+      .sm\\\\:prose-blue a {
+        color: #2563eb;
+      }
+
+      .sm\\\\:prose-blue a code {
+        color: #2563eb;
+      }
+
+      .sm\\\\:prose-purple a {
+        color: #7c3aed;
+      }
+
+      .sm\\\\:prose-purple a code {
+        color: #7c3aed;
+      }
+
+      .sm\\\\:prose-pink a {
+        color: #db2777;
+      }
+
+      .sm\\\\:prose-pink a code {
+        color: #db2777;
+      }
     }
 
     @media (min-width: 768px) {
@@ -2498,6 +2604,7 @@ it('should generate the default classes for the typography components', async ()
       .md\\\\:prose a {
         color: #18181b;
         text-decoration: underline;
+        font-weight: 500;
       }
 
       .md\\\\:prose strong {
@@ -2622,6 +2729,10 @@ it('should generate the default classes for the typography components', async ()
 
       .md\\\\:prose code::after {
         content: \\"\`\\";
+      }
+
+      .md\\\\:prose a code {
+        color: #18181b;
       }
 
       .md\\\\:prose pre {
@@ -3705,6 +3816,54 @@ it('should generate the default classes for the typography components', async ()
       .md\\\\:prose-2xl > :last-child {
         margin-bottom: 0;
       }
+
+      .md\\\\:prose-red a {
+        color: #dc2626;
+      }
+
+      .md\\\\:prose-red a code {
+        color: #dc2626;
+      }
+
+      .md\\\\:prose-yellow a {
+        color: #d97706;
+      }
+
+      .md\\\\:prose-yellow a code {
+        color: #d97706;
+      }
+
+      .md\\\\:prose-green a {
+        color: #059669;
+      }
+
+      .md\\\\:prose-green a code {
+        color: #059669;
+      }
+
+      .md\\\\:prose-blue a {
+        color: #2563eb;
+      }
+
+      .md\\\\:prose-blue a code {
+        color: #2563eb;
+      }
+
+      .md\\\\:prose-purple a {
+        color: #7c3aed;
+      }
+
+      .md\\\\:prose-purple a code {
+        color: #7c3aed;
+      }
+
+      .md\\\\:prose-pink a {
+        color: #db2777;
+      }
+
+      .md\\\\:prose-pink a code {
+        color: #db2777;
+      }
     }
 
     @media (min-width: 1024px) {
@@ -3724,6 +3883,7 @@ it('should generate the default classes for the typography components', async ()
       .lg\\\\:prose a {
         color: #18181b;
         text-decoration: underline;
+        font-weight: 500;
       }
 
       .lg\\\\:prose strong {
@@ -3848,6 +4008,10 @@ it('should generate the default classes for the typography components', async ()
 
       .lg\\\\:prose code::after {
         content: \\"\`\\";
+      }
+
+      .lg\\\\:prose a code {
+        color: #18181b;
       }
 
       .lg\\\\:prose pre {
@@ -4931,6 +5095,54 @@ it('should generate the default classes for the typography components', async ()
       .lg\\\\:prose-2xl > :last-child {
         margin-bottom: 0;
       }
+
+      .lg\\\\:prose-red a {
+        color: #dc2626;
+      }
+
+      .lg\\\\:prose-red a code {
+        color: #dc2626;
+      }
+
+      .lg\\\\:prose-yellow a {
+        color: #d97706;
+      }
+
+      .lg\\\\:prose-yellow a code {
+        color: #d97706;
+      }
+
+      .lg\\\\:prose-green a {
+        color: #059669;
+      }
+
+      .lg\\\\:prose-green a code {
+        color: #059669;
+      }
+
+      .lg\\\\:prose-blue a {
+        color: #2563eb;
+      }
+
+      .lg\\\\:prose-blue a code {
+        color: #2563eb;
+      }
+
+      .lg\\\\:prose-purple a {
+        color: #7c3aed;
+      }
+
+      .lg\\\\:prose-purple a code {
+        color: #7c3aed;
+      }
+
+      .lg\\\\:prose-pink a {
+        color: #db2777;
+      }
+
+      .lg\\\\:prose-pink a code {
+        color: #db2777;
+      }
     }
 
     @media (min-width: 1280px) {
@@ -4950,6 +5162,7 @@ it('should generate the default classes for the typography components', async ()
       .xl\\\\:prose a {
         color: #18181b;
         text-decoration: underline;
+        font-weight: 500;
       }
 
       .xl\\\\:prose strong {
@@ -5074,6 +5287,10 @@ it('should generate the default classes for the typography components', async ()
 
       .xl\\\\:prose code::after {
         content: \\"\`\\";
+      }
+
+      .xl\\\\:prose a code {
+        color: #18181b;
       }
 
       .xl\\\\:prose pre {
@@ -6157,6 +6374,54 @@ it('should generate the default classes for the typography components', async ()
       .xl\\\\:prose-2xl > :last-child {
         margin-bottom: 0;
       }
+
+      .xl\\\\:prose-red a {
+        color: #dc2626;
+      }
+
+      .xl\\\\:prose-red a code {
+        color: #dc2626;
+      }
+
+      .xl\\\\:prose-yellow a {
+        color: #d97706;
+      }
+
+      .xl\\\\:prose-yellow a code {
+        color: #d97706;
+      }
+
+      .xl\\\\:prose-green a {
+        color: #059669;
+      }
+
+      .xl\\\\:prose-green a code {
+        color: #059669;
+      }
+
+      .xl\\\\:prose-blue a {
+        color: #2563eb;
+      }
+
+      .xl\\\\:prose-blue a code {
+        color: #2563eb;
+      }
+
+      .xl\\\\:prose-purple a {
+        color: #7c3aed;
+      }
+
+      .xl\\\\:prose-purple a code {
+        color: #7c3aed;
+      }
+
+      .xl\\\\:prose-pink a {
+        color: #db2777;
+      }
+
+      .xl\\\\:prose-pink a code {
+        color: #db2777;
+      }
     }
 
     @media (min-width: 1536px) {
@@ -6176,6 +6441,7 @@ it('should generate the default classes for the typography components', async ()
       .\\\\32xl\\\\:prose a {
         color: #18181b;
         text-decoration: underline;
+        font-weight: 500;
       }
 
       .\\\\32xl\\\\:prose strong {
@@ -6300,6 +6566,10 @@ it('should generate the default classes for the typography components', async ()
 
       .\\\\32xl\\\\:prose code::after {
         content: \\"\`\\";
+      }
+
+      .\\\\32xl\\\\:prose a code {
+        color: #18181b;
       }
 
       .\\\\32xl\\\\:prose pre {
@@ -7383,6 +7653,54 @@ it('should generate the default classes for the typography components', async ()
       .\\\\32xl\\\\:prose-2xl > :last-child {
         margin-bottom: 0;
       }
+
+      .\\\\32xl\\\\:prose-red a {
+        color: #dc2626;
+      }
+
+      .\\\\32xl\\\\:prose-red a code {
+        color: #dc2626;
+      }
+
+      .\\\\32xl\\\\:prose-yellow a {
+        color: #d97706;
+      }
+
+      .\\\\32xl\\\\:prose-yellow a code {
+        color: #d97706;
+      }
+
+      .\\\\32xl\\\\:prose-green a {
+        color: #059669;
+      }
+
+      .\\\\32xl\\\\:prose-green a code {
+        color: #059669;
+      }
+
+      .\\\\32xl\\\\:prose-blue a {
+        color: #2563eb;
+      }
+
+      .\\\\32xl\\\\:prose-blue a code {
+        color: #2563eb;
+      }
+
+      .\\\\32xl\\\\:prose-purple a {
+        color: #7c3aed;
+      }
+
+      .\\\\32xl\\\\:prose-purple a code {
+        color: #7c3aed;
+      }
+
+      .\\\\32xl\\\\:prose-pink a {
+        color: #db2777;
+      }
+
+      .\\\\32xl\\\\:prose-pink a code {
+        color: #db2777;
+      }
     }"
   `)
 })
@@ -7493,6 +7811,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       - .prose code::after {
       + .markdown code::after {
+
+      ---
+
+      - .prose a code {
+      + .markdown a code {
 
       ---
 
@@ -8556,6 +8879,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       ---
 
+      - .prose-red a {
+      + .markdown-red a {
+
+      ---
+
+      - .prose-red a code {
+      + .markdown-red a code {
+
+      ---
+
+      - .prose-yellow a {
+      + .markdown-yellow a {
+
+      ---
+
+      - .prose-yellow a code {
+      + .markdown-yellow a code {
+
+      ---
+
+      - .prose-green a {
+      + .markdown-green a {
+
+      ---
+
+      - .prose-green a code {
+      + .markdown-green a code {
+
+      ---
+
+      - .prose-blue a {
+      + .markdown-blue a {
+
+      ---
+
+      - .prose-blue a code {
+      + .markdown-blue a code {
+
+      ---
+
+      - .prose-purple a {
+      + .markdown-purple a {
+
+      ---
+
+      - .prose-purple a code {
+      + .markdown-purple a code {
+
+      ---
+
+      - .prose-pink a {
+      + .markdown-pink a {
+
+      ---
+
+      - .prose-pink a code {
+      + .markdown-pink a code {
+
+      ---
+
       -   .sm\\\\:prose {
       +   .sm\\\\:markdown {
 
@@ -8658,6 +9041,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       -   .sm\\\\:prose code::after {
       +   .sm\\\\:markdown code::after {
+
+      ---
+
+      -   .sm\\\\:prose a code {
+      +   .sm\\\\:markdown a code {
 
       ---
 
@@ -9721,6 +10109,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       ---
 
+      -   .sm\\\\:prose-red a {
+      +   .sm\\\\:markdown-red a {
+
+      ---
+
+      -   .sm\\\\:prose-red a code {
+      +   .sm\\\\:markdown-red a code {
+
+      ---
+
+      -   .sm\\\\:prose-yellow a {
+      +   .sm\\\\:markdown-yellow a {
+
+      ---
+
+      -   .sm\\\\:prose-yellow a code {
+      +   .sm\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .sm\\\\:prose-green a {
+      +   .sm\\\\:markdown-green a {
+
+      ---
+
+      -   .sm\\\\:prose-green a code {
+      +   .sm\\\\:markdown-green a code {
+
+      ---
+
+      -   .sm\\\\:prose-blue a {
+      +   .sm\\\\:markdown-blue a {
+
+      ---
+
+      -   .sm\\\\:prose-blue a code {
+      +   .sm\\\\:markdown-blue a code {
+
+      ---
+
+      -   .sm\\\\:prose-purple a {
+      +   .sm\\\\:markdown-purple a {
+
+      ---
+
+      -   .sm\\\\:prose-purple a code {
+      +   .sm\\\\:markdown-purple a code {
+
+      ---
+
+      -   .sm\\\\:prose-pink a {
+      +   .sm\\\\:markdown-pink a {
+
+      ---
+
+      -   .sm\\\\:prose-pink a code {
+      +   .sm\\\\:markdown-pink a code {
+
+      ---
+
       -   .md\\\\:prose {
       +   .md\\\\:markdown {
 
@@ -9823,6 +10271,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       -   .md\\\\:prose code::after {
       +   .md\\\\:markdown code::after {
+
+      ---
+
+      -   .md\\\\:prose a code {
+      +   .md\\\\:markdown a code {
 
       ---
 
@@ -10886,6 +11339,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       ---
 
+      -   .md\\\\:prose-red a {
+      +   .md\\\\:markdown-red a {
+
+      ---
+
+      -   .md\\\\:prose-red a code {
+      +   .md\\\\:markdown-red a code {
+
+      ---
+
+      -   .md\\\\:prose-yellow a {
+      +   .md\\\\:markdown-yellow a {
+
+      ---
+
+      -   .md\\\\:prose-yellow a code {
+      +   .md\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .md\\\\:prose-green a {
+      +   .md\\\\:markdown-green a {
+
+      ---
+
+      -   .md\\\\:prose-green a code {
+      +   .md\\\\:markdown-green a code {
+
+      ---
+
+      -   .md\\\\:prose-blue a {
+      +   .md\\\\:markdown-blue a {
+
+      ---
+
+      -   .md\\\\:prose-blue a code {
+      +   .md\\\\:markdown-blue a code {
+
+      ---
+
+      -   .md\\\\:prose-purple a {
+      +   .md\\\\:markdown-purple a {
+
+      ---
+
+      -   .md\\\\:prose-purple a code {
+      +   .md\\\\:markdown-purple a code {
+
+      ---
+
+      -   .md\\\\:prose-pink a {
+      +   .md\\\\:markdown-pink a {
+
+      ---
+
+      -   .md\\\\:prose-pink a code {
+      +   .md\\\\:markdown-pink a code {
+
+      ---
+
       -   .lg\\\\:prose {
       +   .lg\\\\:markdown {
 
@@ -10988,6 +11501,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       -   .lg\\\\:prose code::after {
       +   .lg\\\\:markdown code::after {
+
+      ---
+
+      -   .lg\\\\:prose a code {
+      +   .lg\\\\:markdown a code {
 
       ---
 
@@ -12051,6 +12569,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       ---
 
+      -   .lg\\\\:prose-red a {
+      +   .lg\\\\:markdown-red a {
+
+      ---
+
+      -   .lg\\\\:prose-red a code {
+      +   .lg\\\\:markdown-red a code {
+
+      ---
+
+      -   .lg\\\\:prose-yellow a {
+      +   .lg\\\\:markdown-yellow a {
+
+      ---
+
+      -   .lg\\\\:prose-yellow a code {
+      +   .lg\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .lg\\\\:prose-green a {
+      +   .lg\\\\:markdown-green a {
+
+      ---
+
+      -   .lg\\\\:prose-green a code {
+      +   .lg\\\\:markdown-green a code {
+
+      ---
+
+      -   .lg\\\\:prose-blue a {
+      +   .lg\\\\:markdown-blue a {
+
+      ---
+
+      -   .lg\\\\:prose-blue a code {
+      +   .lg\\\\:markdown-blue a code {
+
+      ---
+
+      -   .lg\\\\:prose-purple a {
+      +   .lg\\\\:markdown-purple a {
+
+      ---
+
+      -   .lg\\\\:prose-purple a code {
+      +   .lg\\\\:markdown-purple a code {
+
+      ---
+
+      -   .lg\\\\:prose-pink a {
+      +   .lg\\\\:markdown-pink a {
+
+      ---
+
+      -   .lg\\\\:prose-pink a code {
+      +   .lg\\\\:markdown-pink a code {
+
+      ---
+
       -   .xl\\\\:prose {
       +   .xl\\\\:markdown {
 
@@ -12153,6 +12731,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       -   .xl\\\\:prose code::after {
       +   .xl\\\\:markdown code::after {
+
+      ---
+
+      -   .xl\\\\:prose a code {
+      +   .xl\\\\:markdown a code {
 
       ---
 
@@ -13216,6 +13799,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       ---
 
+      -   .xl\\\\:prose-red a {
+      +   .xl\\\\:markdown-red a {
+
+      ---
+
+      -   .xl\\\\:prose-red a code {
+      +   .xl\\\\:markdown-red a code {
+
+      ---
+
+      -   .xl\\\\:prose-yellow a {
+      +   .xl\\\\:markdown-yellow a {
+
+      ---
+
+      -   .xl\\\\:prose-yellow a code {
+      +   .xl\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .xl\\\\:prose-green a {
+      +   .xl\\\\:markdown-green a {
+
+      ---
+
+      -   .xl\\\\:prose-green a code {
+      +   .xl\\\\:markdown-green a code {
+
+      ---
+
+      -   .xl\\\\:prose-blue a {
+      +   .xl\\\\:markdown-blue a {
+
+      ---
+
+      -   .xl\\\\:prose-blue a code {
+      +   .xl\\\\:markdown-blue a code {
+
+      ---
+
+      -   .xl\\\\:prose-purple a {
+      +   .xl\\\\:markdown-purple a {
+
+      ---
+
+      -   .xl\\\\:prose-purple a code {
+      +   .xl\\\\:markdown-purple a code {
+
+      ---
+
+      -   .xl\\\\:prose-pink a {
+      +   .xl\\\\:markdown-pink a {
+
+      ---
+
+      -   .xl\\\\:prose-pink a code {
+      +   .xl\\\\:markdown-pink a code {
+
+      ---
+
       -   .\\\\32xl\\\\:prose {
       +   .\\\\32xl\\\\:markdown {
 
@@ -13318,6 +13961,11 @@ it('should be possilbe to change the default className from `prose` to `markdown
 
       -   .\\\\32xl\\\\:prose code::after {
       +   .\\\\32xl\\\\:markdown code::after {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose a code {
+      +   .\\\\32xl\\\\:markdown a code {
 
       ---
 
@@ -14379,6 +15027,66 @@ it('should be possilbe to change the default className from `prose` to `markdown
       -   .\\\\32xl\\\\:prose-2xl > :last-child {
       +   .\\\\32xl\\\\:markdown-2xl > :last-child {
 
+      ---
+
+      -   .\\\\32xl\\\\:prose-red a {
+      +   .\\\\32xl\\\\:markdown-red a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-red a code {
+      +   .\\\\32xl\\\\:markdown-red a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow a {
+      +   .\\\\32xl\\\\:markdown-yellow a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow a code {
+      +   .\\\\32xl\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green a {
+      +   .\\\\32xl\\\\:markdown-green a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green a code {
+      +   .\\\\32xl\\\\:markdown-green a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue a {
+      +   .\\\\32xl\\\\:markdown-blue a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue a code {
+      +   .\\\\32xl\\\\:markdown-blue a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple a {
+      +   .\\\\32xl\\\\:markdown-purple a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple a code {
+      +   .\\\\32xl\\\\:markdown-purple a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink a {
+      +   .\\\\32xl\\\\:markdown-pink a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink a code {
+      +   .\\\\32xl\\\\:markdown-pink a code {
+
     "
   `)
 })
@@ -14719,7 +15427,6 @@ it('should be possilbe to change the default modifiers', async () => {
 
       ---
 
-      -
       -   .sm\\\\:prose-2xl ol {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
@@ -14842,6 +15549,7 @@ it('should be possilbe to change the default modifiers', async () => {
       -   .sm\\\\:prose-2xl > :last-child {
       -     margin-bottom: 0;
       -   }
+      -
 
       ---
 
@@ -15861,6 +16569,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      - .prose a code {
+      + .markdown a code {
+
+      ---
+
       - .prose pre {
       + .markdown pre {
 
@@ -16031,10 +16744,13 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
-      - .prose > :first-child {
-      -   margin-top: 0;
       - }
       -
+      - .prose > :first-child {
+      -   margin-top: 0;
+
+      ---
+
       - .prose > :last-child {
       -   margin-bottom: 0;
       - }
@@ -16927,6 +17643,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      - .prose-red a {
+      + .markdown-red a {
+
+      ---
+
+      - .prose-red a code {
+      + .markdown-red a code {
+
+      ---
+
+      - .prose-yellow a {
+      + .markdown-yellow a {
+
+      ---
+
+      - .prose-yellow a code {
+      + .markdown-yellow a code {
+
+      ---
+
+      - .prose-green a {
+      + .markdown-green a {
+
+      ---
+
+      - .prose-green a code {
+      + .markdown-green a code {
+
+      ---
+
+      - .prose-blue a {
+      + .markdown-blue a {
+
+      ---
+
+      - .prose-blue a code {
+      + .markdown-blue a code {
+
+      ---
+
+      - .prose-purple a {
+      + .markdown-purple a {
+
+      ---
+
+      - .prose-purple a code {
+      + .markdown-purple a code {
+
+      ---
+
+      - .prose-pink a {
+      + .markdown-pink a {
+
+      ---
+
+      - .prose-pink a code {
+      + .markdown-pink a code {
+
+      ---
+
       -   .sm\\\\:prose {
       +   .sm\\\\:markdown {
 
@@ -17029,6 +17805,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .sm\\\\:prose code::after {
       +   .sm\\\\:markdown code::after {
+
+      ---
+
+      -   .sm\\\\:prose a code {
+      +   .sm\\\\:markdown a code {
 
       ---
 
@@ -17163,9 +17944,10 @@ it('should be possilbe to change the default modifiers and change the className'
       ---
 
       -   .sm\\\\:prose hr + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown hr + * {
+
+      ---
+
       -   .sm\\\\:prose h2 + * {
       -     margin-top: 0;
       -   }
@@ -17195,7 +17977,10 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose > :first-child {
-      -     margin-top: 0;
+      +   .sm\\\\:markdown h2 + * {
+
+      ---
+
       -   }
       -
       -   .sm\\\\:prose > :last-child {
@@ -17205,8 +17990,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -   .sm\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-      -   }
-      -
+
+      ---
+
       -   .sm\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -17227,11 +18013,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      -     margin-top: 0;
+      +   .sm\\\\:markdown h3 + * {
+
+      ---
+
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
-      -   }
-      -
+
+      ---
+
       -   .sm\\\\:prose-sm h2 {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
@@ -17268,7 +18058,7 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm figure > * {
-      +   .sm\\\\:markdown hr + * {
+      +   .sm\\\\:markdown h4 + * {
 
       ---
 
@@ -17287,9 +18077,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-sm h2 code {
       -     font-size: 0.9em;
-
-      ---
-
+      -   }
+      -
       -   .sm\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
       -   }
@@ -17347,8 +18136,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-sm > ul > li > *:first-child {
       -     margin-top: 1.1428571em;
-      -   }
-      -
+
+      ---
+
       -   .sm\\\\:prose-sm > ul > li > *:last-child {
       -     margin-bottom: 1.1428571em;
       -   }
@@ -17376,20 +18166,17 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm h2 + * {
-      +   .sm\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm h3 + * {
-      +   .sm\\\\:markdown h3 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm h4 + * {
-      +   .sm\\\\:markdown h4 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
@@ -18098,6 +18885,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   .sm\\\\:prose-red a {
+      +   .sm\\\\:markdown-red a {
+
+      ---
+
+      -   .sm\\\\:prose-red a code {
+      +   .sm\\\\:markdown-red a code {
+
+      ---
+
+      -   .sm\\\\:prose-yellow a {
+      +   .sm\\\\:markdown-yellow a {
+
+      ---
+
+      -   .sm\\\\:prose-yellow a code {
+      +   .sm\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .sm\\\\:prose-green a {
+      +   .sm\\\\:markdown-green a {
+
+      ---
+
+      -   .sm\\\\:prose-green a code {
+      +   .sm\\\\:markdown-green a code {
+
+      ---
+
+      -   .sm\\\\:prose-blue a {
+      +   .sm\\\\:markdown-blue a {
+
+      ---
+
+      -   .sm\\\\:prose-blue a code {
+      +   .sm\\\\:markdown-blue a code {
+
+      ---
+
+      -   .sm\\\\:prose-purple a {
+      +   .sm\\\\:markdown-purple a {
+
+      ---
+
+      -   .sm\\\\:prose-purple a code {
+      +   .sm\\\\:markdown-purple a code {
+
+      ---
+
+      -   .sm\\\\:prose-pink a {
+      +   .sm\\\\:markdown-pink a {
+
+      ---
+
+      -   .sm\\\\:prose-pink a code {
+      +   .sm\\\\:markdown-pink a code {
+
+      ---
+
       -   .md\\\\:prose {
       +   .md\\\\:markdown {
 
@@ -18200,6 +19047,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .md\\\\:prose code::after {
       +   .md\\\\:markdown code::after {
+
+      ---
+
+      -   .md\\\\:prose a code {
+      +   .md\\\\:markdown a code {
 
       ---
 
@@ -18334,50 +19186,63 @@ it('should be possilbe to change the default modifiers and change the className'
       ---
 
       -   .md\\\\:prose hr + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .md\\\\:markdown hr + * {
+
+      ---
+
       -   .md\\\\:prose h2 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .md\\\\:markdown h2 + * {
+
+      ---
+
       -   .md\\\\:prose h3 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .md\\\\:markdown h3 + * {
+
+      ---
+
       -   .md\\\\:prose h4 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .md\\\\:markdown h4 + * {
+
+      ---
+
       -   .md\\\\:prose thead th:first-child {
-      -     padding-left: 0;
-      -   }
-      -
+      +   .md\\\\:markdown thead th:first-child {
+
+      ---
+
       -   .md\\\\:prose thead th:last-child {
-      -     padding-right: 0;
-      -   }
-      -
+      +   .md\\\\:markdown thead th:last-child {
+
+      ---
+
       -   .md\\\\:prose tbody td:first-child {
-      -     padding-left: 0;
-      -   }
-      -
+      +   .md\\\\:markdown tbody td:first-child {
+
+      ---
+
       -   .md\\\\:prose tbody td:last-child {
-      -     padding-right: 0;
-      -   }
-      -
+      +   .md\\\\:markdown tbody td:last-child {
+
+      ---
+
       -   .md\\\\:prose > :first-child {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .md\\\\:markdown > :first-child {
+
+      ---
+
       -   .md\\\\:prose > :last-child {
-      -     margin-bottom: 0;
+      +   .md\\\\:markdown > :last-child {
+
+      ---
+
       -   }
       -
       -   .md\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-      -   }
-      -
+
+      ---
+
       -   .md\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -18539,25 +19404,21 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .md\\\\:prose-sm hr + * {
-      +   .md\\\\:markdown hr + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm h2 + * {
-      +   .md\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm h3 + * {
-      +   .md\\\\:markdown h3 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm h4 + * {
-      +   .md\\\\:markdown h4 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
@@ -18570,15 +19431,13 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .md\\\\:prose-sm thead th:first-child {
-      +   .md\\\\:markdown thead th:first-child {
-
-      ---
-
+      -     padding-left: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm thead th:last-child {
-      +   .md\\\\:markdown thead th:last-child {
-
-      ---
-
+      -     padding-right: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm tbody td {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
@@ -18587,25 +19446,21 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .md\\\\:prose-sm tbody td:first-child {
-      +   .md\\\\:markdown tbody td:first-child {
-
-      ---
-
+      -     padding-left: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm tbody td:last-child {
-      +   .md\\\\:markdown tbody td:last-child {
-
-      ---
-
+      -     padding-right: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm > :first-child {
-      +   .md\\\\:markdown > :first-child {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .md\\\\:prose-sm > :last-child {
-      +   .md\\\\:markdown > :last-child {
-
-      ---
-
+      -     margin-bottom: 0;
+      -   }
+      -
       -   .md\\\\:prose-lg {
       +   .md\\\\:markdown-lg {
 
@@ -19266,6 +20121,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   .md\\\\:prose-red a {
+      +   .md\\\\:markdown-red a {
+
+      ---
+
+      -   .md\\\\:prose-red a code {
+      +   .md\\\\:markdown-red a code {
+
+      ---
+
+      -   .md\\\\:prose-yellow a {
+      +   .md\\\\:markdown-yellow a {
+
+      ---
+
+      -   .md\\\\:prose-yellow a code {
+      +   .md\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .md\\\\:prose-green a {
+      +   .md\\\\:markdown-green a {
+
+      ---
+
+      -   .md\\\\:prose-green a code {
+      +   .md\\\\:markdown-green a code {
+
+      ---
+
+      -   .md\\\\:prose-blue a {
+      +   .md\\\\:markdown-blue a {
+
+      ---
+
+      -   .md\\\\:prose-blue a code {
+      +   .md\\\\:markdown-blue a code {
+
+      ---
+
+      -   .md\\\\:prose-purple a {
+      +   .md\\\\:markdown-purple a {
+
+      ---
+
+      -   .md\\\\:prose-purple a code {
+      +   .md\\\\:markdown-purple a code {
+
+      ---
+
+      -   .md\\\\:prose-pink a {
+      +   .md\\\\:markdown-pink a {
+
+      ---
+
+      -   .md\\\\:prose-pink a code {
+      +   .md\\\\:markdown-pink a code {
+
+      ---
+
       -   .lg\\\\:prose {
       +   .lg\\\\:markdown {
 
@@ -19368,6 +20283,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .lg\\\\:prose code::after {
       +   .lg\\\\:markdown code::after {
+
+      ---
+
+      -   .lg\\\\:prose a code {
+      +   .lg\\\\:markdown a code {
 
       ---
 
@@ -19580,9 +20500,8 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
-
-      ---
-
+      -   }
+      -
       -   .lg\\\\:prose-sm h2 {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
@@ -19601,8 +20520,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
-      -   }
-      -
+
+      ---
+
       -   .lg\\\\:prose-sm img {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
@@ -19630,17 +20550,17 @@ it('should be possilbe to change the default modifiers and change the className'
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
-      -   }
-      -
+
+      ---
+
       -   .lg\\\\:prose-sm code {
       -     font-size: 0.8571429em;
       -   }
       -
       -   .lg\\\\:prose-sm h2 code {
       -     font-size: 0.9em;
-
-      ---
-
+      -   }
+      -
       -   .lg\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
       -   }
@@ -20440,6 +21360,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   .lg\\\\:prose-red a {
+      +   .lg\\\\:markdown-red a {
+
+      ---
+
+      -   .lg\\\\:prose-red a code {
+      +   .lg\\\\:markdown-red a code {
+
+      ---
+
+      -   .lg\\\\:prose-yellow a {
+      +   .lg\\\\:markdown-yellow a {
+
+      ---
+
+      -   .lg\\\\:prose-yellow a code {
+      +   .lg\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .lg\\\\:prose-green a {
+      +   .lg\\\\:markdown-green a {
+
+      ---
+
+      -   .lg\\\\:prose-green a code {
+      +   .lg\\\\:markdown-green a code {
+
+      ---
+
+      -   .lg\\\\:prose-blue a {
+      +   .lg\\\\:markdown-blue a {
+
+      ---
+
+      -   .lg\\\\:prose-blue a code {
+      +   .lg\\\\:markdown-blue a code {
+
+      ---
+
+      -   .lg\\\\:prose-purple a {
+      +   .lg\\\\:markdown-purple a {
+
+      ---
+
+      -   .lg\\\\:prose-purple a code {
+      +   .lg\\\\:markdown-purple a code {
+
+      ---
+
+      -   .lg\\\\:prose-pink a {
+      +   .lg\\\\:markdown-pink a {
+
+      ---
+
+      -   .lg\\\\:prose-pink a code {
+      +   .lg\\\\:markdown-pink a code {
+
+      ---
+
       -   .xl\\\\:prose {
       +   .xl\\\\:markdown {
 
@@ -20542,6 +21522,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .xl\\\\:prose code::after {
       +   .xl\\\\:markdown code::after {
+
+      ---
+
+      -   .xl\\\\:prose a code {
+      +   .xl\\\\:markdown a code {
 
       ---
 
@@ -20715,16 +21700,14 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .xl\\\\:prose > :first-child {
-      +   .xl\\\\:markdown > :first-child {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .xl\\\\:prose > :last-child {
-      +   .xl\\\\:markdown > :last-child {
-
-      ---
-
+      -     margin-bottom: 0;
       -   }
       -
       -   .xl\\\\:prose-sm {
@@ -20753,11 +21736,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .xl\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      -     margin-top: 0;
+      +   .xl\\\\:markdown > :first-child {
+
+      ---
+
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
-      -   }
-      -
+
+      ---
+
       -   .xl\\\\:prose-sm h2 {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
@@ -20795,9 +21782,10 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .xl\\\\:prose-sm figure > * {
       -     margin-top: 0;
-      -     margin-bottom: 0;
-      -   }
-      -
+      +   .xl\\\\:markdown > :last-child {
+
+      ---
+
       -   .xl\\\\:prose-sm figure figcaption {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
@@ -21611,6 +22599,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   .xl\\\\:prose-red a {
+      +   .xl\\\\:markdown-red a {
+
+      ---
+
+      -   .xl\\\\:prose-red a code {
+      +   .xl\\\\:markdown-red a code {
+
+      ---
+
+      -   .xl\\\\:prose-yellow a {
+      +   .xl\\\\:markdown-yellow a {
+
+      ---
+
+      -   .xl\\\\:prose-yellow a code {
+      +   .xl\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .xl\\\\:prose-green a {
+      +   .xl\\\\:markdown-green a {
+
+      ---
+
+      -   .xl\\\\:prose-green a code {
+      +   .xl\\\\:markdown-green a code {
+
+      ---
+
+      -   .xl\\\\:prose-blue a {
+      +   .xl\\\\:markdown-blue a {
+
+      ---
+
+      -   .xl\\\\:prose-blue a code {
+      +   .xl\\\\:markdown-blue a code {
+
+      ---
+
+      -   .xl\\\\:prose-purple a {
+      +   .xl\\\\:markdown-purple a {
+
+      ---
+
+      -   .xl\\\\:prose-purple a code {
+      +   .xl\\\\:markdown-purple a code {
+
+      ---
+
+      -   .xl\\\\:prose-pink a {
+      +   .xl\\\\:markdown-pink a {
+
+      ---
+
+      -   .xl\\\\:prose-pink a code {
+      +   .xl\\\\:markdown-pink a code {
+
+      ---
+
       -   .\\\\32xl\\\\:prose {
       +   .\\\\32xl\\\\:markdown {
 
@@ -21713,6 +22761,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .\\\\32xl\\\\:prose code::after {
       +   .\\\\32xl\\\\:markdown code::after {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose a code {
+      +   .\\\\32xl\\\\:markdown a code {
 
       ---
 
@@ -21846,56 +22899,49 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .\\\\32xl\\\\:prose hr + * {
-      +   .\\\\32xl\\\\:markdown hr + * {
+      -     margin-top: 0;
 
       ---
 
       -   .\\\\32xl\\\\:prose h2 + * {
-      +   .\\\\32xl\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose h3 + * {
-      +   .\\\\32xl\\\\:markdown h3 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose h4 + * {
-      +   .\\\\32xl\\\\:markdown h4 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose thead th:first-child {
-      +   .\\\\32xl\\\\:markdown thead th:first-child {
-
-      ---
-
+      -     padding-left: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose thead th:last-child {
-      +   .\\\\32xl\\\\:markdown thead th:last-child {
-
-      ---
-
+      -     padding-right: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown tbody td:first-child {
-
-      ---
-
+      -     padding-left: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown tbody td:last-child {
-
-      ---
-
+      -     padding-right: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose > :first-child {
-      +   .\\\\32xl\\\\:markdown > :first-child {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose > :last-child {
-      +   .\\\\32xl\\\\:markdown > :last-child {
-
-      ---
-
+      -     margin-bottom: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
@@ -21921,7 +22967,10 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      -     margin-top: 0;
+      +   .\\\\32xl\\\\:markdown hr + * {
+
+      ---
+
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
@@ -21931,8 +22980,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm h3 {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
@@ -21962,7 +23012,10 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm figure > * {
-      -     margin-top: 0;
+      +   .\\\\32xl\\\\:markdown h2 + * {
+
+      ---
+
       -     margin-bottom: 0;
       -   }
       -
@@ -21978,8 +23031,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose-sm h2 code {
       -     font-size: 0.9em;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
       -   }
@@ -22062,13 +23116,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm hr + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown h3 + * {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm h2 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown h4 + * {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm h3 + * {
       -     margin-top: 0;
       -   }
@@ -22089,13 +23145,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm thead th:first-child {
-      -     padding-left: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown thead th:first-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm thead th:last-child {
-      -     padding-right: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown thead th:last-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm tbody td {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
@@ -22104,21 +23162,25 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm tbody td:first-child {
-      -     padding-left: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown tbody td:first-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm tbody td:last-child {
-      -     padding-right: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown tbody td:last-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm > :first-child {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown > :first-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm > :last-child {
-      -     margin-bottom: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown > :last-child {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-lg {
       +   .\\\\32xl\\\\:markdown-lg {
 
@@ -22776,6 +23838,66 @@ it('should be possilbe to change the default modifiers and change the className'
 
       -   .\\\\32xl\\\\:prose-2xl > :last-child {
       +   .\\\\32xl\\\\:markdown-2xl > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-red a {
+      +   .\\\\32xl\\\\:markdown-red a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-red a code {
+      +   .\\\\32xl\\\\:markdown-red a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow a {
+      +   .\\\\32xl\\\\:markdown-yellow a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow a code {
+      +   .\\\\32xl\\\\:markdown-yellow a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green a {
+      +   .\\\\32xl\\\\:markdown-green a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green a code {
+      +   .\\\\32xl\\\\:markdown-green a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue a {
+      +   .\\\\32xl\\\\:markdown-blue a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue a code {
+      +   .\\\\32xl\\\\:markdown-blue a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple a {
+      +   .\\\\32xl\\\\:markdown-purple a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple a code {
+      +   .\\\\32xl\\\\:markdown-purple a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink a {
+      +   .\\\\32xl\\\\:markdown-pink a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink a code {
+      +   .\\\\32xl\\\\:markdown-pink a code {
 
     "
   `)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7705,7 +7705,7 @@ it('should generate the default classes for the typography components', async ()
   `)
 })
 
-it('should be possilbe to change the default className from `prose` to `markdown`', async () => {
+it('should be possible to change the default className from `prose` to `markdown`', async () => {
   expect(await diffOnly({ className: 'markdown' })).toMatchInlineSnapshot(`
     "
 
@@ -15091,7 +15091,7 @@ it('should be possilbe to change the default className from `prose` to `markdown
   `)
 })
 
-it('should be possilbe to change the default modifiers', async () => {
+it('should be possible to change the default modifiers', async () => {
   expect(await diffOnly({ modifiers: ['sm', 'lg', 'xl' /**, '2xl' */] })).toMatchInlineSnapshot(`
     "
 
@@ -15318,6 +15318,54 @@ it('should be possilbe to change the default modifiers', async () => {
       -   margin-bottom: 0;
       - }
       -
+      - .prose-red a {
+      -   color: #dc2626;
+      - }
+      -
+      - .prose-red a code {
+      -   color: #dc2626;
+      - }
+      -
+      - .prose-yellow a {
+      -   color: #d97706;
+      - }
+      -
+      - .prose-yellow a code {
+      -   color: #d97706;
+      - }
+      -
+      - .prose-green a {
+      -   color: #059669;
+      - }
+      -
+      - .prose-green a code {
+      -   color: #059669;
+      - }
+      -
+      - .prose-blue a {
+      -   color: #2563eb;
+      - }
+      -
+      - .prose-blue a code {
+      -   color: #2563eb;
+      - }
+      -
+      - .prose-purple a {
+      -   color: #7c3aed;
+      - }
+      -
+      - .prose-purple a code {
+      -   color: #7c3aed;
+      - }
+      -
+      - .prose-pink a {
+      -   color: #db2777;
+      - }
+      -
+      - .prose-pink a code {
+      -   color: #db2777;
+      - }
+      -
 
       ---
 
@@ -15424,9 +15472,8 @@ it('should be possilbe to change the default modifiers', async () => {
       -     padding-right: 1.6em;
       -     padding-bottom: 1.2em;
       -     padding-left: 1.6em;
-
-      ---
-
+      -   }
+      -
       -   .sm\\\\:prose-2xl ol {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
@@ -15435,7 +15482,9 @@ it('should be possilbe to change the default modifiers', async () => {
       -   .sm\\\\:prose-2xl ul {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
-      -   }
+
+      ---
+
       -
       -   .sm\\\\:prose-2xl li {
       -     margin-top: 0.5em;
@@ -15550,6 +15599,53 @@ it('should be possilbe to change the default modifiers', async () => {
       -     margin-bottom: 0;
       -   }
       -
+      -   .sm\\\\:prose-red a {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .sm\\\\:prose-red a code {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .sm\\\\:prose-yellow a {
+      -     color: #d97706;
+      -   }
+      -
+      -   .sm\\\\:prose-yellow a code {
+      -     color: #d97706;
+      -   }
+      -
+      -   .sm\\\\:prose-green a {
+      -     color: #059669;
+      -   }
+      -
+      -   .sm\\\\:prose-green a code {
+      -     color: #059669;
+      -   }
+      -
+      -   .sm\\\\:prose-blue a {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .sm\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .sm\\\\:prose-purple a {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .sm\\\\:prose-purple a code {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .sm\\\\:prose-pink a {
+      -     color: #db2777;
+      -   }
+      -
+      -   .sm\\\\:prose-pink a code {
+      -     color: #db2777;
+      -   }
 
       ---
 
@@ -15779,6 +15875,57 @@ it('should be possilbe to change the default modifiers', async () => {
 
       ---
 
+      -   }
+      -
+      -   .md\\\\:prose-red a {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .md\\\\:prose-red a code {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .md\\\\:prose-yellow a {
+      -     color: #d97706;
+      -   }
+      -
+      -   .md\\\\:prose-yellow a code {
+      -     color: #d97706;
+      -   }
+      -
+      -   .md\\\\:prose-green a {
+      -     color: #059669;
+      -   }
+      -
+      -   .md\\\\:prose-green a code {
+      -     color: #059669;
+      -   }
+      -
+      -   .md\\\\:prose-blue a {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .md\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .md\\\\:prose-purple a {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .md\\\\:prose-purple a code {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .md\\\\:prose-pink a {
+      -     color: #db2777;
+      -   }
+      -
+      -   .md\\\\:prose-pink a code {
+      -     color: #db2777;
+
+      ---
+
       -     margin-bottom: 0;
       -   }
       -
@@ -16002,6 +16149,60 @@ it('should be possilbe to change the default modifiers', async () => {
       -   }
       -
       -   .lg\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   }
+      -
+      -   .lg\\\\:prose-red a {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .lg\\\\:prose-red a code {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .lg\\\\:prose-yellow a {
+      -     color: #d97706;
+      -   }
+      -
+      -   .lg\\\\:prose-yellow a code {
+      -     color: #d97706;
+      -   }
+      -
+      -   .lg\\\\:prose-green a {
+      -     color: #059669;
+      -   }
+      -
+      -   .lg\\\\:prose-green a code {
+      -     color: #059669;
+      -   }
+      -
+      -   .lg\\\\:prose-blue a {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .lg\\\\:prose-blue a code {
+      -     color: #2563eb;
+
+      ---
+
+      -
+      -   .lg\\\\:prose-purple a {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .lg\\\\:prose-purple a code {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .lg\\\\:prose-pink a {
+      -     color: #db2777;
+      -   }
+      -
+      -   .lg\\\\:prose-pink a code {
+      -     color: #db2777;
+      -   }
 
       ---
 
@@ -16231,7 +16432,60 @@ it('should be possilbe to change the default modifiers', async () => {
 
       ---
 
-      -     margin-bottom: 0;
+      -   }
+      -
+      -   .xl\\\\:prose-red a {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .xl\\\\:prose-red a code {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .xl\\\\:prose-yellow a {
+      -     color: #d97706;
+      -   }
+      -
+      -   .xl\\\\:prose-yellow a code {
+      -     color: #d97706;
+
+      ---
+
+      -
+      -   .xl\\\\:prose-green a {
+      -     color: #059669;
+      -   }
+      -
+      -   .xl\\\\:prose-green a code {
+      -     color: #059669;
+      -   }
+      -
+      -   .xl\\\\:prose-blue a {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .xl\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .xl\\\\:prose-purple a {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .xl\\\\:prose-purple a code {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .xl\\\\:prose-pink a {
+      -     color: #db2777;
+      -   }
+      -
+      -   .xl\\\\:prose-pink a code {
+      -     color: #db2777;
+      -   }
+
+      ---
+
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl {
@@ -16454,12 +16708,61 @@ it('should be possilbe to change the default modifiers', async () => {
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl > :last-child {
+      -     margin-bottom: 0;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-red a {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-red a code {
+      -     color: #dc2626;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-yellow a {
+      -     color: #d97706;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-yellow a code {
+      -     color: #d97706;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-green a {
+      -     color: #059669;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-green a code {
+      -     color: #059669;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-blue a {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-purple a {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-purple a code {
+      -     color: #7c3aed;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-pink a {
+      -     color: #db2777;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-pink a code {
+      -     color: #db2777;
 
     "
   `)
 })
 
-it('should be possilbe to change the default modifiers and change the className', async () => {
+it('should be possible to change the default modifiers and change the className', async () => {
   expect(await diffOnly({ modifiers: [/** 'sm', */ 'lg', 'xl', '2xl'], className: 'markdown' }))
     .toMatchInlineSnapshot(`
     "
@@ -16744,17 +17047,16 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
-      - }
-      -
       - .prose > :first-child {
-      -   margin-top: 0;
+      + .markdown > :first-child {
 
       ---
 
       - .prose > :last-child {
-      -   margin-bottom: 0;
-      - }
-      -
+      + .markdown > :last-child {
+
+      ---
+
       - .prose-sm {
       -   font-size: 0.875rem;
       -   line-height: 1.7142857;
@@ -16780,15 +17082,11 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       - .prose-sm h1 {
       -   font-size: 2.1428571em;
-      + .markdown > :first-child {
-
-      ---
-
+      -   margin-top: 0;
       -   margin-bottom: 0.8em;
       -   line-height: 1.2;
-
-      ---
-
+      - }
+      -
       - .prose-sm h2 {
       -   font-size: 1.4285714em;
       -   margin-top: 1.6em;
@@ -16826,10 +17124,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       - .prose-sm figure > * {
       -   margin-top: 0;
-      + .markdown > :last-child {
-
-      ---
-
+      -   margin-bottom: 0;
+      - }
+      -
       - .prose-sm figure figcaption {
       -   font-size: 0.8571429em;
       -   line-height: 1.3333333;
@@ -17643,63 +17940,57 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      - }
+      -
       - .prose-red a {
-      + .markdown-red a {
+      -   color: #dc2626;
 
       ---
 
       - .prose-red a code {
-      + .markdown-red a code {
-
-      ---
-
+      -   color: #dc2626;
+      - }
+      -
       - .prose-yellow a {
-      + .markdown-yellow a {
-
-      ---
-
+      -   color: #d97706;
+      - }
+      -
       - .prose-yellow a code {
-      + .markdown-yellow a code {
-
-      ---
-
+      -   color: #d97706;
+      - }
+      -
       - .prose-green a {
-      + .markdown-green a {
-
-      ---
-
+      -   color: #059669;
+      - }
+      -
       - .prose-green a code {
-      + .markdown-green a code {
-
-      ---
-
+      -   color: #059669;
+      - }
+      -
       - .prose-blue a {
-      + .markdown-blue a {
-
-      ---
-
+      -   color: #2563eb;
+      - }
+      -
       - .prose-blue a code {
-      + .markdown-blue a code {
-
-      ---
-
+      -   color: #2563eb;
+      - }
+      -
       - .prose-purple a {
-      + .markdown-purple a {
-
-      ---
-
+      -   color: #7c3aed;
+      - }
+      -
       - .prose-purple a code {
-      + .markdown-purple a code {
-
-      ---
-
+      -   color: #7c3aed;
+      - }
+      -
       - .prose-pink a {
-      + .markdown-pink a {
-
-      ---
-
+      -   color: #db2777;
+      - }
+      -
       - .prose-pink a code {
-      + .markdown-pink a code {
+      -   color: #db2777;
+      - }
+      -
 
       ---
 
@@ -17943,11 +18234,12 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .sm\\\\:prose hr + * {
-      +   .sm\\\\:markdown hr + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose h2 + * {
       -     margin-top: 0;
       -   }
@@ -17970,17 +18262,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose tbody td:first-child {
       -     padding-left: 0;
-      -   }
-      -
+
+      ---
+
       -   .sm\\\\:prose tbody td:last-child {
       -     padding-right: 0;
       -   }
       -
       -   .sm\\\\:prose > :first-child {
-      +   .sm\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
       -   }
       -
       -   .sm\\\\:prose > :last-child {
@@ -17990,9 +18280,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -   .sm\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-
-      ---
-
+      -   }
+      -
       -   .sm\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -18013,15 +18302,11 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      +   .sm\\\\:markdown h3 + * {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
-
-      ---
-
+      -   }
+      -
       -   .sm\\\\:prose-sm h2 {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
@@ -18058,10 +18343,7 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm figure > * {
-      +   .sm\\\\:markdown h4 + * {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
@@ -18136,9 +18418,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-sm > ul > li > *:first-child {
       -     margin-top: 1.1428571em;
-
-      ---
-
+      -   }
+      -
       -   .sm\\\\:prose-sm > ul > li > *:last-child {
       -     margin-bottom: 1.1428571em;
       -   }
@@ -18162,21 +18443,25 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm hr + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown hr + * {
+
+      ---
+
       -   .sm\\\\:prose-sm h2 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h2 + * {
+
+      ---
+
       -   .sm\\\\:prose-sm h3 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h3 + * {
+
+      ---
+
       -   .sm\\\\:prose-sm h4 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h4 + * {
+
+      ---
+
       -   .sm\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
@@ -18885,63 +19170,57 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .sm\\\\:prose-red a {
-      +   .sm\\\\:markdown-red a {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .sm\\\\:prose-red a code {
-      +   .sm\\\\:markdown-red a code {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .sm\\\\:prose-yellow a {
-      +   .sm\\\\:markdown-yellow a {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .sm\\\\:prose-yellow a code {
-      +   .sm\\\\:markdown-yellow a code {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .sm\\\\:prose-green a {
-      +   .sm\\\\:markdown-green a {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .sm\\\\:prose-green a code {
-      +   .sm\\\\:markdown-green a code {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .sm\\\\:prose-blue a {
-      +   .sm\\\\:markdown-blue a {
+      -     color: #2563eb;
 
       ---
 
+      -
       -   .sm\\\\:prose-blue a code {
-      +   .sm\\\\:markdown-blue a code {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .sm\\\\:prose-purple a {
-      +   .sm\\\\:markdown-purple a {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .sm\\\\:prose-purple a code {
-      +   .sm\\\\:markdown-purple a code {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .sm\\\\:prose-pink a {
-      +   .sm\\\\:markdown-pink a {
-
-      ---
-
+      -     color: #db2777;
+      -   }
+      -
       -   .sm\\\\:prose-pink a code {
-      +   .sm\\\\:markdown-pink a code {
+      -     color: #db2777;
+      -   }
 
       ---
 
@@ -19235,14 +19514,11 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .md\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-
-      ---
-
+      -   }
+      -
       -   .md\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -20121,63 +20397,54 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .md\\\\:prose-red a {
-      +   .md\\\\:markdown-red a {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .md\\\\:prose-red a code {
-      +   .md\\\\:markdown-red a code {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .md\\\\:prose-yellow a {
-      +   .md\\\\:markdown-yellow a {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .md\\\\:prose-yellow a code {
-      +   .md\\\\:markdown-yellow a code {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .md\\\\:prose-green a {
-      +   .md\\\\:markdown-green a {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .md\\\\:prose-green a code {
-      +   .md\\\\:markdown-green a code {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .md\\\\:prose-blue a {
-      +   .md\\\\:markdown-blue a {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .md\\\\:prose-blue a code {
-      +   .md\\\\:markdown-blue a code {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .md\\\\:prose-purple a {
-      +   .md\\\\:markdown-purple a {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .md\\\\:prose-purple a code {
-      +   .md\\\\:markdown-purple a code {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .md\\\\:prose-pink a {
-      +   .md\\\\:markdown-pink a {
-
-      ---
-
+      -     color: #db2777;
+      -   }
+      -
       -   .md\\\\:prose-pink a code {
-      +   .md\\\\:markdown-pink a code {
+      -     color: #db2777;
 
       ---
 
@@ -20462,18 +20729,23 @@ it('should be possilbe to change the default modifiers and change the className'
       ---
 
       -   .lg\\\\:prose > :first-child {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .lg\\\\:markdown > :first-child {
+
+      ---
+
       -   .lg\\\\:prose > :last-child {
-      -     margin-bottom: 0;
+      +   .lg\\\\:markdown > :last-child {
+
+      ---
+
       -   }
       -
       -   .lg\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-      -   }
-      -
+
+      ---
+
       -   .lg\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -20494,10 +20766,7 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .lg\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      +   .lg\\\\:markdown > :first-child {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
@@ -20520,9 +20789,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
-
-      ---
-
+      -   }
+      -
       -   .lg\\\\:prose-sm img {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
@@ -20540,19 +20808,15 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .lg\\\\:prose-sm figure > * {
       -     margin-top: 0;
-      +   .lg\\\\:markdown > :last-child {
-
-      ---
-
+      -     margin-bottom: 0;
       -   }
       -
       -   .lg\\\\:prose-sm figure figcaption {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
-
-      ---
-
+      -   }
+      -
       -   .lg\\\\:prose-sm code {
       -     font-size: 0.8571429em;
       -   }
@@ -21360,63 +21624,57 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .lg\\\\:prose-red a {
-      +   .lg\\\\:markdown-red a {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .lg\\\\:prose-red a code {
-      +   .lg\\\\:markdown-red a code {
+      -     color: #dc2626;
 
       ---
 
+      -
       -   .lg\\\\:prose-yellow a {
-      +   .lg\\\\:markdown-yellow a {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .lg\\\\:prose-yellow a code {
-      +   .lg\\\\:markdown-yellow a code {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .lg\\\\:prose-green a {
-      +   .lg\\\\:markdown-green a {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .lg\\\\:prose-green a code {
-      +   .lg\\\\:markdown-green a code {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .lg\\\\:prose-blue a {
-      +   .lg\\\\:markdown-blue a {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .lg\\\\:prose-blue a code {
-      +   .lg\\\\:markdown-blue a code {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .lg\\\\:prose-purple a {
-      +   .lg\\\\:markdown-purple a {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .lg\\\\:prose-purple a code {
-      +   .lg\\\\:markdown-purple a code {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .lg\\\\:prose-pink a {
-      +   .lg\\\\:markdown-pink a {
-
-      ---
-
+      -     color: #db2777;
+      -   }
+      -
       -   .lg\\\\:prose-pink a code {
-      +   .lg\\\\:markdown-pink a code {
+      -     color: #db2777;
+      -   }
 
       ---
 
@@ -21713,9 +21971,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -   .xl\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-
-      ---
-
+      -   }
+      -
       -   .xl\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -21732,8 +21989,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
-      -   }
-      -
+
+      ---
+
       -   .xl\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
       +   .xl\\\\:markdown > :first-child {
@@ -21786,6 +22044,8 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .xl\\\\:prose-sm figure figcaption {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
@@ -21802,8 +22062,9 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .xl\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
-      -   }
-      -
+
+      ---
+
       -   .xl\\\\:prose-sm pre {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
@@ -22599,63 +22860,57 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .xl\\\\:prose-red a {
-      +   .xl\\\\:markdown-red a {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .xl\\\\:prose-red a code {
-      +   .xl\\\\:markdown-red a code {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .xl\\\\:prose-yellow a {
-      +   .xl\\\\:markdown-yellow a {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .xl\\\\:prose-yellow a code {
-      +   .xl\\\\:markdown-yellow a code {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .xl\\\\:prose-green a {
-      +   .xl\\\\:markdown-green a {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .xl\\\\:prose-green a code {
-      +   .xl\\\\:markdown-green a code {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .xl\\\\:prose-blue a {
-      +   .xl\\\\:markdown-blue a {
+      -     color: #2563eb;
 
       ---
 
+      -
       -   .xl\\\\:prose-blue a code {
-      +   .xl\\\\:markdown-blue a code {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .xl\\\\:prose-purple a {
-      +   .xl\\\\:markdown-purple a {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .xl\\\\:prose-purple a code {
-      +   .xl\\\\:markdown-purple a code {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .xl\\\\:prose-pink a {
-      +   .xl\\\\:markdown-pink a {
-
-      ---
-
+      -     color: #db2777;
+      -   }
+      -
       -   .xl\\\\:prose-pink a code {
-      +   .xl\\\\:markdown-pink a code {
+      -     color: #db2777;
+      -   }
 
       ---
 
@@ -22899,13 +23154,10 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .\\\\32xl\\\\:prose hr + * {
       -     margin-top: 0;
-
-      ---
-
+      -   }
+      -
       -   .\\\\32xl\\\\:prose h2 + * {
       -     margin-top: 0;
       -   }
@@ -22967,10 +23219,7 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      +   .\\\\32xl\\\\:markdown hr + * {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
@@ -22980,9 +23229,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
-
-      ---
-
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm h3 {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
@@ -23012,10 +23260,7 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm figure > * {
-      +   .\\\\32xl\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
@@ -23031,9 +23276,8 @@ it('should be possilbe to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose-sm h2 code {
       -     font-size: 0.9em;
-
-      ---
-
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
       -   }
@@ -23116,28 +23360,33 @@ it('should be possilbe to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm hr + * {
-      +   .\\\\32xl\\\\:markdown h3 + * {
+      +   .\\\\32xl\\\\:markdown hr + * {
 
       ---
 
       -   .\\\\32xl\\\\:prose-sm h2 + * {
-      +   .\\\\32xl\\\\:markdown h4 + * {
+      +   .\\\\32xl\\\\:markdown h2 + * {
 
       ---
 
       -   .\\\\32xl\\\\:prose-sm h3 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .\\\\32xl\\\\:markdown h3 + * {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm h4 + * {
-      -     margin-top: 0;
+      +   .\\\\32xl\\\\:markdown h4 + * {
+
+      ---
+
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm thead th {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
@@ -23154,13 +23403,16 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm tbody td {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm tbody td:first-child {
       +   .\\\\32xl\\\\:markdown tbody td:first-child {
 
@@ -23841,63 +24093,54 @@ it('should be possilbe to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-red a {
-      +   .\\\\32xl\\\\:markdown-red a {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-red a code {
-      +   .\\\\32xl\\\\:markdown-red a code {
-
-      ---
-
+      -     color: #dc2626;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-yellow a {
-      +   .\\\\32xl\\\\:markdown-yellow a {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-yellow a code {
-      +   .\\\\32xl\\\\:markdown-yellow a code {
-
-      ---
-
+      -     color: #d97706;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-green a {
-      +   .\\\\32xl\\\\:markdown-green a {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-green a code {
-      +   .\\\\32xl\\\\:markdown-green a code {
-
-      ---
-
+      -     color: #059669;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-blue a {
-      +   .\\\\32xl\\\\:markdown-blue a {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-blue a code {
-      +   .\\\\32xl\\\\:markdown-blue a code {
-
-      ---
-
+      -     color: #2563eb;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-purple a {
-      +   .\\\\32xl\\\\:markdown-purple a {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-purple a code {
-      +   .\\\\32xl\\\\:markdown-purple a code {
-
-      ---
-
+      -     color: #7c3aed;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-pink a {
-      +   .\\\\32xl\\\\:markdown-pink a {
-
-      ---
-
+      -     color: #db2777;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-pink a code {
-      +   .\\\\32xl\\\\:markdown-pink a code {
+      -     color: #db2777;
 
     "
   `)
@@ -24151,7 +24394,7 @@ it('should be possible to only update a single value from a different modifier',
   `)
 })
 
-it('should be possilbe to override backticks for the inline `code` tag', async () => {
+it('should be possible to override backticks for the inline `code` tag', async () => {
   expect(
     await diffOnly(
       {},

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -32,12 +32,12 @@ async function diffOnly(options = {}, config = {}) {
 it('should generate the default classes for the typography components', async () => {
   expect(await run()).toMatchInlineSnapshot(`
     ".prose {
-      color: #3f3f46;
+      color: #374151;
       max-width: 65ch;
     }
 
     .prose [class~=\\"lead\\"] {
-      color: #52525b;
+      color: #4b5563;
       font-size: 1.25em;
       line-height: 1.6;
       margin-top: 1.2em;
@@ -45,13 +45,13 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose a {
-      color: #18181b;
+      color: #111827;
       text-decoration: underline;
       font-weight: 500;
     }
 
     .prose strong {
-      color: #18181b;
+      color: #111827;
       font-weight: 600;
     }
 
@@ -71,7 +71,7 @@ it('should generate the default classes for the typography components', async ()
       content: counter(list-counter) \\".\\";
       position: absolute;
       font-weight: 400;
-      color: #71717a;
+      color: #6b7280;
       left: 0;
     }
 
@@ -83,7 +83,7 @@ it('should generate the default classes for the typography components', async ()
     .prose ul > li::before {
       content: \\"\\";
       position: absolute;
-      background-color: #d4d4d8;
+      background-color: #d1d5db;
       border-radius: 50%;
       width: 0.375em;
       height: 0.375em;
@@ -92,7 +92,7 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose hr {
-      border-color: #e4e4e7;
+      border-color: #e5e7eb;
       border-top-width: 1px;
       margin-top: 3em;
       margin-bottom: 3em;
@@ -101,9 +101,9 @@ it('should generate the default classes for the typography components', async ()
     .prose blockquote {
       font-weight: 500;
       font-style: italic;
-      color: #18181b;
+      color: #111827;
       border-left-width: 0.25rem;
-      border-left-color: #e4e4e7;
+      border-left-color: #e5e7eb;
       quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
       margin-top: 1.6em;
       margin-bottom: 1.6em;
@@ -119,7 +119,7 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose h1 {
-      color: #18181b;
+      color: #111827;
       font-weight: 800;
       font-size: 2.25em;
       margin-top: 0;
@@ -128,7 +128,7 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose h2 {
-      color: #18181b;
+      color: #111827;
       font-weight: 700;
       font-size: 1.5em;
       margin-top: 2em;
@@ -137,7 +137,7 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose h3 {
-      color: #18181b;
+      color: #111827;
       font-weight: 600;
       font-size: 1.25em;
       margin-top: 1.6em;
@@ -146,7 +146,7 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose h4 {
-      color: #18181b;
+      color: #111827;
       font-weight: 600;
       margin-top: 1.5em;
       margin-bottom: 0.5em;
@@ -154,14 +154,14 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose figure figcaption {
-      color: #71717a;
+      color: #6b7280;
       font-size: 0.875em;
       line-height: 1.4285714;
       margin-top: 0.8571429em;
     }
 
     .prose code {
-      color: #18181b;
+      color: #111827;
       font-weight: 600;
       font-size: 0.875em;
     }
@@ -175,12 +175,12 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose a code {
-      color: #18181b;
+      color: #111827;
     }
 
     .prose pre {
-      color: #e4e4e7;
-      background-color: #27272a;
+      color: #e5e7eb;
+      background-color: #1f2937;
       overflow-x: auto;
       font-size: 0.875em;
       line-height: 1.7142857;
@@ -224,10 +224,10 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose thead {
-      color: #18181b;
+      color: #111827;
       font-weight: 600;
       border-bottom-width: 1px;
-      border-bottom-color: #d4d4d8;
+      border-bottom-color: #d1d5db;
     }
 
     .prose thead th {
@@ -239,7 +239,7 @@ it('should generate the default classes for the typography components', async ()
 
     .prose tbody tr {
       border-bottom-width: 1px;
-      border-bottom-color: #e4e4e7;
+      border-bottom-color: #e5e7eb;
     }
 
     .prose tbody tr:last-child {
@@ -1292,6 +1292,14 @@ it('should generate the default classes for the typography components', async ()
       color: #2563eb;
     }
 
+    .prose-indigo a {
+      color: #4f46e5;
+    }
+
+    .prose-indigo a code {
+      color: #4f46e5;
+    }
+
     .prose-purple a {
       color: #7c3aed;
     }
@@ -1310,12 +1318,12 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 640px) {
       .sm\\\\:prose {
-        color: #3f3f46;
+        color: #374151;
         max-width: 65ch;
       }
 
       .sm\\\\:prose [class~=\\"lead\\"] {
-        color: #52525b;
+        color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
         margin-top: 1.2em;
@@ -1323,13 +1331,13 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose a {
-        color: #18181b;
+        color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
       .sm\\\\:prose strong {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
       }
 
@@ -1349,7 +1357,7 @@ it('should generate the default classes for the typography components', async ()
         content: counter(list-counter) \\".\\";
         position: absolute;
         font-weight: 400;
-        color: #71717a;
+        color: #6b7280;
         left: 0;
       }
 
@@ -1361,7 +1369,7 @@ it('should generate the default classes for the typography components', async ()
       .sm\\\\:prose ul > li::before {
         content: \\"\\";
         position: absolute;
-        background-color: #d4d4d8;
+        background-color: #d1d5db;
         border-radius: 50%;
         width: 0.375em;
         height: 0.375em;
@@ -1370,7 +1378,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose hr {
-        border-color: #e4e4e7;
+        border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
@@ -1379,9 +1387,9 @@ it('should generate the default classes for the typography components', async ()
       .sm\\\\:prose blockquote {
         font-weight: 500;
         font-style: italic;
-        color: #18181b;
+        color: #111827;
         border-left-width: 0.25rem;
-        border-left-color: #e4e4e7;
+        border-left-color: #e5e7eb;
         quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
         margin-top: 1.6em;
         margin-bottom: 1.6em;
@@ -1397,7 +1405,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose h1 {
-        color: #18181b;
+        color: #111827;
         font-weight: 800;
         font-size: 2.25em;
         margin-top: 0;
@@ -1406,7 +1414,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose h2 {
-        color: #18181b;
+        color: #111827;
         font-weight: 700;
         font-size: 1.5em;
         margin-top: 2em;
@@ -1415,7 +1423,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose h3 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 1.25em;
         margin-top: 1.6em;
@@ -1424,7 +1432,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose h4 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
         margin-bottom: 0.5em;
@@ -1432,14 +1440,14 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose figure figcaption {
-        color: #71717a;
+        color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
       .sm\\\\:prose code {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
@@ -1453,12 +1461,12 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose a code {
-        color: #18181b;
+        color: #111827;
       }
 
       .sm\\\\:prose pre {
-        color: #e4e4e7;
-        background-color: #27272a;
+        color: #e5e7eb;
+        background-color: #1f2937;
         overflow-x: auto;
         font-size: 0.875em;
         line-height: 1.7142857;
@@ -1502,10 +1510,10 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose thead {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
-        border-bottom-color: #d4d4d8;
+        border-bottom-color: #d1d5db;
       }
 
       .sm\\\\:prose thead th {
@@ -1517,7 +1525,7 @@ it('should generate the default classes for the typography components', async ()
 
       .sm\\\\:prose tbody tr {
         border-bottom-width: 1px;
-        border-bottom-color: #e4e4e7;
+        border-bottom-color: #e5e7eb;
       }
 
       .sm\\\\:prose tbody tr:last-child {
@@ -2570,6 +2578,14 @@ it('should generate the default classes for the typography components', async ()
         color: #2563eb;
       }
 
+      .sm\\\\:prose-indigo a {
+        color: #4f46e5;
+      }
+
+      .sm\\\\:prose-indigo a code {
+        color: #4f46e5;
+      }
+
       .sm\\\\:prose-purple a {
         color: #7c3aed;
       }
@@ -2589,12 +2605,12 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 768px) {
       .md\\\\:prose {
-        color: #3f3f46;
+        color: #374151;
         max-width: 65ch;
       }
 
       .md\\\\:prose [class~=\\"lead\\"] {
-        color: #52525b;
+        color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
         margin-top: 1.2em;
@@ -2602,13 +2618,13 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose a {
-        color: #18181b;
+        color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
       .md\\\\:prose strong {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
       }
 
@@ -2628,7 +2644,7 @@ it('should generate the default classes for the typography components', async ()
         content: counter(list-counter) \\".\\";
         position: absolute;
         font-weight: 400;
-        color: #71717a;
+        color: #6b7280;
         left: 0;
       }
 
@@ -2640,7 +2656,7 @@ it('should generate the default classes for the typography components', async ()
       .md\\\\:prose ul > li::before {
         content: \\"\\";
         position: absolute;
-        background-color: #d4d4d8;
+        background-color: #d1d5db;
         border-radius: 50%;
         width: 0.375em;
         height: 0.375em;
@@ -2649,7 +2665,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose hr {
-        border-color: #e4e4e7;
+        border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
@@ -2658,9 +2674,9 @@ it('should generate the default classes for the typography components', async ()
       .md\\\\:prose blockquote {
         font-weight: 500;
         font-style: italic;
-        color: #18181b;
+        color: #111827;
         border-left-width: 0.25rem;
-        border-left-color: #e4e4e7;
+        border-left-color: #e5e7eb;
         quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
         margin-top: 1.6em;
         margin-bottom: 1.6em;
@@ -2676,7 +2692,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose h1 {
-        color: #18181b;
+        color: #111827;
         font-weight: 800;
         font-size: 2.25em;
         margin-top: 0;
@@ -2685,7 +2701,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose h2 {
-        color: #18181b;
+        color: #111827;
         font-weight: 700;
         font-size: 1.5em;
         margin-top: 2em;
@@ -2694,7 +2710,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose h3 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 1.25em;
         margin-top: 1.6em;
@@ -2703,7 +2719,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose h4 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
         margin-bottom: 0.5em;
@@ -2711,14 +2727,14 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose figure figcaption {
-        color: #71717a;
+        color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
       .md\\\\:prose code {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
@@ -2732,12 +2748,12 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose a code {
-        color: #18181b;
+        color: #111827;
       }
 
       .md\\\\:prose pre {
-        color: #e4e4e7;
-        background-color: #27272a;
+        color: #e5e7eb;
+        background-color: #1f2937;
         overflow-x: auto;
         font-size: 0.875em;
         line-height: 1.7142857;
@@ -2781,10 +2797,10 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose thead {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
-        border-bottom-color: #d4d4d8;
+        border-bottom-color: #d1d5db;
       }
 
       .md\\\\:prose thead th {
@@ -2796,7 +2812,7 @@ it('should generate the default classes for the typography components', async ()
 
       .md\\\\:prose tbody tr {
         border-bottom-width: 1px;
-        border-bottom-color: #e4e4e7;
+        border-bottom-color: #e5e7eb;
       }
 
       .md\\\\:prose tbody tr:last-child {
@@ -3849,6 +3865,14 @@ it('should generate the default classes for the typography components', async ()
         color: #2563eb;
       }
 
+      .md\\\\:prose-indigo a {
+        color: #4f46e5;
+      }
+
+      .md\\\\:prose-indigo a code {
+        color: #4f46e5;
+      }
+
       .md\\\\:prose-purple a {
         color: #7c3aed;
       }
@@ -3868,12 +3892,12 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1024px) {
       .lg\\\\:prose {
-        color: #3f3f46;
+        color: #374151;
         max-width: 65ch;
       }
 
       .lg\\\\:prose [class~=\\"lead\\"] {
-        color: #52525b;
+        color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
         margin-top: 1.2em;
@@ -3881,13 +3905,13 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose a {
-        color: #18181b;
+        color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
       .lg\\\\:prose strong {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
       }
 
@@ -3907,7 +3931,7 @@ it('should generate the default classes for the typography components', async ()
         content: counter(list-counter) \\".\\";
         position: absolute;
         font-weight: 400;
-        color: #71717a;
+        color: #6b7280;
         left: 0;
       }
 
@@ -3919,7 +3943,7 @@ it('should generate the default classes for the typography components', async ()
       .lg\\\\:prose ul > li::before {
         content: \\"\\";
         position: absolute;
-        background-color: #d4d4d8;
+        background-color: #d1d5db;
         border-radius: 50%;
         width: 0.375em;
         height: 0.375em;
@@ -3928,7 +3952,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose hr {
-        border-color: #e4e4e7;
+        border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
@@ -3937,9 +3961,9 @@ it('should generate the default classes for the typography components', async ()
       .lg\\\\:prose blockquote {
         font-weight: 500;
         font-style: italic;
-        color: #18181b;
+        color: #111827;
         border-left-width: 0.25rem;
-        border-left-color: #e4e4e7;
+        border-left-color: #e5e7eb;
         quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
         margin-top: 1.6em;
         margin-bottom: 1.6em;
@@ -3955,7 +3979,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose h1 {
-        color: #18181b;
+        color: #111827;
         font-weight: 800;
         font-size: 2.25em;
         margin-top: 0;
@@ -3964,7 +3988,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose h2 {
-        color: #18181b;
+        color: #111827;
         font-weight: 700;
         font-size: 1.5em;
         margin-top: 2em;
@@ -3973,7 +3997,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose h3 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 1.25em;
         margin-top: 1.6em;
@@ -3982,7 +4006,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose h4 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
         margin-bottom: 0.5em;
@@ -3990,14 +4014,14 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose figure figcaption {
-        color: #71717a;
+        color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
       .lg\\\\:prose code {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
@@ -4011,12 +4035,12 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose a code {
-        color: #18181b;
+        color: #111827;
       }
 
       .lg\\\\:prose pre {
-        color: #e4e4e7;
-        background-color: #27272a;
+        color: #e5e7eb;
+        background-color: #1f2937;
         overflow-x: auto;
         font-size: 0.875em;
         line-height: 1.7142857;
@@ -4060,10 +4084,10 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose thead {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
-        border-bottom-color: #d4d4d8;
+        border-bottom-color: #d1d5db;
       }
 
       .lg\\\\:prose thead th {
@@ -4075,7 +4099,7 @@ it('should generate the default classes for the typography components', async ()
 
       .lg\\\\:prose tbody tr {
         border-bottom-width: 1px;
-        border-bottom-color: #e4e4e7;
+        border-bottom-color: #e5e7eb;
       }
 
       .lg\\\\:prose tbody tr:last-child {
@@ -5128,6 +5152,14 @@ it('should generate the default classes for the typography components', async ()
         color: #2563eb;
       }
 
+      .lg\\\\:prose-indigo a {
+        color: #4f46e5;
+      }
+
+      .lg\\\\:prose-indigo a code {
+        color: #4f46e5;
+      }
+
       .lg\\\\:prose-purple a {
         color: #7c3aed;
       }
@@ -5147,12 +5179,12 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1280px) {
       .xl\\\\:prose {
-        color: #3f3f46;
+        color: #374151;
         max-width: 65ch;
       }
 
       .xl\\\\:prose [class~=\\"lead\\"] {
-        color: #52525b;
+        color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
         margin-top: 1.2em;
@@ -5160,13 +5192,13 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose a {
-        color: #18181b;
+        color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
       .xl\\\\:prose strong {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
       }
 
@@ -5186,7 +5218,7 @@ it('should generate the default classes for the typography components', async ()
         content: counter(list-counter) \\".\\";
         position: absolute;
         font-weight: 400;
-        color: #71717a;
+        color: #6b7280;
         left: 0;
       }
 
@@ -5198,7 +5230,7 @@ it('should generate the default classes for the typography components', async ()
       .xl\\\\:prose ul > li::before {
         content: \\"\\";
         position: absolute;
-        background-color: #d4d4d8;
+        background-color: #d1d5db;
         border-radius: 50%;
         width: 0.375em;
         height: 0.375em;
@@ -5207,7 +5239,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose hr {
-        border-color: #e4e4e7;
+        border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
@@ -5216,9 +5248,9 @@ it('should generate the default classes for the typography components', async ()
       .xl\\\\:prose blockquote {
         font-weight: 500;
         font-style: italic;
-        color: #18181b;
+        color: #111827;
         border-left-width: 0.25rem;
-        border-left-color: #e4e4e7;
+        border-left-color: #e5e7eb;
         quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
         margin-top: 1.6em;
         margin-bottom: 1.6em;
@@ -5234,7 +5266,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose h1 {
-        color: #18181b;
+        color: #111827;
         font-weight: 800;
         font-size: 2.25em;
         margin-top: 0;
@@ -5243,7 +5275,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose h2 {
-        color: #18181b;
+        color: #111827;
         font-weight: 700;
         font-size: 1.5em;
         margin-top: 2em;
@@ -5252,7 +5284,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose h3 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 1.25em;
         margin-top: 1.6em;
@@ -5261,7 +5293,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose h4 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
         margin-bottom: 0.5em;
@@ -5269,14 +5301,14 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose figure figcaption {
-        color: #71717a;
+        color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
       .xl\\\\:prose code {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
@@ -5290,12 +5322,12 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose a code {
-        color: #18181b;
+        color: #111827;
       }
 
       .xl\\\\:prose pre {
-        color: #e4e4e7;
-        background-color: #27272a;
+        color: #e5e7eb;
+        background-color: #1f2937;
         overflow-x: auto;
         font-size: 0.875em;
         line-height: 1.7142857;
@@ -5339,10 +5371,10 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose thead {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
-        border-bottom-color: #d4d4d8;
+        border-bottom-color: #d1d5db;
       }
 
       .xl\\\\:prose thead th {
@@ -5354,7 +5386,7 @@ it('should generate the default classes for the typography components', async ()
 
       .xl\\\\:prose tbody tr {
         border-bottom-width: 1px;
-        border-bottom-color: #e4e4e7;
+        border-bottom-color: #e5e7eb;
       }
 
       .xl\\\\:prose tbody tr:last-child {
@@ -6407,6 +6439,14 @@ it('should generate the default classes for the typography components', async ()
         color: #2563eb;
       }
 
+      .xl\\\\:prose-indigo a {
+        color: #4f46e5;
+      }
+
+      .xl\\\\:prose-indigo a code {
+        color: #4f46e5;
+      }
+
       .xl\\\\:prose-purple a {
         color: #7c3aed;
       }
@@ -6426,12 +6466,12 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1536px) {
       .\\\\32xl\\\\:prose {
-        color: #3f3f46;
+        color: #374151;
         max-width: 65ch;
       }
 
       .\\\\32xl\\\\:prose [class~=\\"lead\\"] {
-        color: #52525b;
+        color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
         margin-top: 1.2em;
@@ -6439,13 +6479,13 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose a {
-        color: #18181b;
+        color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
       .\\\\32xl\\\\:prose strong {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
       }
 
@@ -6465,7 +6505,7 @@ it('should generate the default classes for the typography components', async ()
         content: counter(list-counter) \\".\\";
         position: absolute;
         font-weight: 400;
-        color: #71717a;
+        color: #6b7280;
         left: 0;
       }
 
@@ -6477,7 +6517,7 @@ it('should generate the default classes for the typography components', async ()
       .\\\\32xl\\\\:prose ul > li::before {
         content: \\"\\";
         position: absolute;
-        background-color: #d4d4d8;
+        background-color: #d1d5db;
         border-radius: 50%;
         width: 0.375em;
         height: 0.375em;
@@ -6486,7 +6526,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose hr {
-        border-color: #e4e4e7;
+        border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
@@ -6495,9 +6535,9 @@ it('should generate the default classes for the typography components', async ()
       .\\\\32xl\\\\:prose blockquote {
         font-weight: 500;
         font-style: italic;
-        color: #18181b;
+        color: #111827;
         border-left-width: 0.25rem;
-        border-left-color: #e4e4e7;
+        border-left-color: #e5e7eb;
         quotes: \\"\\\\201C\\"\\"\\\\201D\\"\\"\\\\2018\\"\\"\\\\2019\\";
         margin-top: 1.6em;
         margin-bottom: 1.6em;
@@ -6513,7 +6553,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose h1 {
-        color: #18181b;
+        color: #111827;
         font-weight: 800;
         font-size: 2.25em;
         margin-top: 0;
@@ -6522,7 +6562,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose h2 {
-        color: #18181b;
+        color: #111827;
         font-weight: 700;
         font-size: 1.5em;
         margin-top: 2em;
@@ -6531,7 +6571,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose h3 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 1.25em;
         margin-top: 1.6em;
@@ -6540,7 +6580,7 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose h4 {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
         margin-bottom: 0.5em;
@@ -6548,14 +6588,14 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose figure figcaption {
-        color: #71717a;
+        color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
       .\\\\32xl\\\\:prose code {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
@@ -6569,12 +6609,12 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose a code {
-        color: #18181b;
+        color: #111827;
       }
 
       .\\\\32xl\\\\:prose pre {
-        color: #e4e4e7;
-        background-color: #27272a;
+        color: #e5e7eb;
+        background-color: #1f2937;
         overflow-x: auto;
         font-size: 0.875em;
         line-height: 1.7142857;
@@ -6618,10 +6658,10 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose thead {
-        color: #18181b;
+        color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
-        border-bottom-color: #d4d4d8;
+        border-bottom-color: #d1d5db;
       }
 
       .\\\\32xl\\\\:prose thead th {
@@ -6633,7 +6673,7 @@ it('should generate the default classes for the typography components', async ()
 
       .\\\\32xl\\\\:prose tbody tr {
         border-bottom-width: 1px;
-        border-bottom-color: #e4e4e7;
+        border-bottom-color: #e5e7eb;
       }
 
       .\\\\32xl\\\\:prose tbody tr:last-child {
@@ -7684,6 +7724,14 @@ it('should generate the default classes for the typography components', async ()
 
       .\\\\32xl\\\\:prose-blue a code {
         color: #2563eb;
+      }
+
+      .\\\\32xl\\\\:prose-indigo a {
+        color: #4f46e5;
+      }
+
+      .\\\\32xl\\\\:prose-indigo a code {
+        color: #4f46e5;
       }
 
       .\\\\32xl\\\\:prose-purple a {
@@ -8919,6 +8967,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
+      - .prose-indigo a {
+      + .markdown-indigo a {
+
+      ---
+
+      - .prose-indigo a code {
+      + .markdown-indigo a code {
+
+      ---
+
       - .prose-purple a {
       + .markdown-purple a {
 
@@ -10146,6 +10204,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       -   .sm\\\\:prose-blue a code {
       +   .sm\\\\:markdown-blue a code {
+
+      ---
+
+      -   .sm\\\\:prose-indigo a {
+      +   .sm\\\\:markdown-indigo a {
+
+      ---
+
+      -   .sm\\\\:prose-indigo a code {
+      +   .sm\\\\:markdown-indigo a code {
 
       ---
 
@@ -11379,6 +11447,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
+      -   .md\\\\:prose-indigo a {
+      +   .md\\\\:markdown-indigo a {
+
+      ---
+
+      -   .md\\\\:prose-indigo a code {
+      +   .md\\\\:markdown-indigo a code {
+
+      ---
+
       -   .md\\\\:prose-purple a {
       +   .md\\\\:markdown-purple a {
 
@@ -12606,6 +12684,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       -   .lg\\\\:prose-blue a code {
       +   .lg\\\\:markdown-blue a code {
+
+      ---
+
+      -   .lg\\\\:prose-indigo a {
+      +   .lg\\\\:markdown-indigo a {
+
+      ---
+
+      -   .lg\\\\:prose-indigo a code {
+      +   .lg\\\\:markdown-indigo a code {
 
       ---
 
@@ -13839,6 +13927,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
+      -   .xl\\\\:prose-indigo a {
+      +   .xl\\\\:markdown-indigo a {
+
+      ---
+
+      -   .xl\\\\:prose-indigo a code {
+      +   .xl\\\\:markdown-indigo a code {
+
+      ---
+
       -   .xl\\\\:prose-purple a {
       +   .xl\\\\:markdown-purple a {
 
@@ -15069,6 +15167,16 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
+      -   .\\\\32xl\\\\:prose-indigo a {
+      +   .\\\\32xl\\\\:markdown-indigo a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-indigo a code {
+      +   .\\\\32xl\\\\:markdown-indigo a code {
+
+      ---
+
       -   .\\\\32xl\\\\:prose-purple a {
       +   .\\\\32xl\\\\:markdown-purple a {
 
@@ -15350,6 +15458,14 @@ it('should be possible to change the default modifiers', async () => {
       -   color: #2563eb;
       - }
       -
+      - .prose-indigo a {
+      -   color: #4f46e5;
+      - }
+      -
+      - .prose-indigo a code {
+      -   color: #4f46e5;
+      - }
+      -
       - .prose-purple a {
       -   color: #7c3aed;
       - }
@@ -15482,9 +15598,7 @@ it('should be possible to change the default modifiers', async () => {
       -   .sm\\\\:prose-2xl ul {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
-
-      ---
-
+      -   }
       -
       -   .sm\\\\:prose-2xl li {
       -     margin-top: 0.5em;
@@ -15513,7 +15627,9 @@ it('should be possible to change the default modifiers', async () => {
       -   .sm\\\\:prose-2xl > ul > li p {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
-      -   }
+
+      ---
+
       -
       -   .sm\\\\:prose-2xl > ul > li > *:first-child {
       -     margin-top: 1.3333333em;
@@ -15629,6 +15745,14 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .sm\\\\:prose-blue a code {
       -     color: #2563eb;
+      -   }
+      -
+      -   .sm\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .sm\\\\:prose-indigo a code {
+      -     color: #4f46e5;
       -   }
       -
       -   .sm\\\\:prose-purple a {
@@ -15909,6 +16033,14 @@ it('should be possible to change the default modifiers', async () => {
       -     color: #2563eb;
       -   }
       -
+      -   .md\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .md\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
+      -
       -   .md\\\\:prose-purple a {
       -     color: #7c3aed;
       -   }
@@ -16184,9 +16316,15 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .lg\\\\:prose-blue a code {
       -     color: #2563eb;
-
-      ---
-
+      -   }
+      -
+      -   .lg\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .lg\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
       -
       -   .lg\\\\:prose-purple a {
       -     color: #7c3aed;
@@ -16194,7 +16332,9 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .lg\\\\:prose-purple a code {
       -     color: #7c3aed;
-      -   }
+
+      ---
+
       -
       -   .lg\\\\:prose-pink a {
       -     color: #db2777;
@@ -16448,9 +16588,7 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .xl\\\\:prose-yellow a code {
       -     color: #d97706;
-
-      ---
-
+      -   }
       -
       -   .xl\\\\:prose-green a {
       -     color: #059669;
@@ -16468,13 +16606,23 @@ it('should be possible to change the default modifiers', async () => {
       -     color: #2563eb;
       -   }
       -
+      -   .xl\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .xl\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
+      -
       -   .xl\\\\:prose-purple a {
       -     color: #7c3aed;
       -   }
       -
       -   .xl\\\\:prose-purple a code {
       -     color: #7c3aed;
-      -   }
+
+      ---
+
       -
       -   .xl\\\\:prose-pink a {
       -     color: #db2777;
@@ -16486,6 +16634,7 @@ it('should be possible to change the default modifiers', async () => {
 
       ---
 
+      -     margin-bottom: 0;
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl {
@@ -16555,7 +16704,9 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .\\\\32xl\\\\:prose-2xl figure > * {
       -     margin-top: 0;
-      -     margin-bottom: 0;
+
+      ---
+
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl figure figcaption {
@@ -16741,6 +16892,14 @@ it('should be possible to change the default modifiers', async () => {
       -
       -   .\\\\32xl\\\\:prose-blue a code {
       -     color: #2563eb;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-indigo a code {
+      -     color: #4f46e5;
       -   }
       -
       -   .\\\\32xl\\\\:prose-purple a {
@@ -17047,13 +17206,14 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
+      - }
+      -
       - .prose > :first-child {
-      + .markdown > :first-child {
-
-      ---
-
+      -   margin-top: 0;
+      - }
+      -
       - .prose > :last-child {
-      + .markdown > :last-child {
+      -   margin-bottom: 0;
 
       ---
 
@@ -17082,11 +17242,15 @@ it('should be possible to change the default modifiers and change the className'
       -
       - .prose-sm h1 {
       -   font-size: 2.1428571em;
-      -   margin-top: 0;
+      + .markdown > :first-child {
+
+      ---
+
       -   margin-bottom: 0.8em;
       -   line-height: 1.2;
-      - }
-      -
+
+      ---
+
       - .prose-sm h2 {
       -   font-size: 1.4285714em;
       -   margin-top: 1.6em;
@@ -17124,9 +17288,10 @@ it('should be possible to change the default modifiers and change the className'
       -
       - .prose-sm figure > * {
       -   margin-top: 0;
-      -   margin-bottom: 0;
-      - }
-      -
+      + .markdown > :last-child {
+
+      ---
+
       - .prose-sm figure figcaption {
       -   font-size: 0.8571429em;
       -   line-height: 1.3333333;
@@ -17944,9 +18109,8 @@ it('should be possible to change the default modifiers and change the className'
       -
       - .prose-red a {
       -   color: #dc2626;
-
-      ---
-
+      - }
+      -
       - .prose-red a code {
       -   color: #dc2626;
       - }
@@ -17957,8 +18121,9 @@ it('should be possible to change the default modifiers and change the className'
       -
       - .prose-yellow a code {
       -   color: #d97706;
-      - }
-      -
+
+      ---
+
       - .prose-green a {
       -   color: #059669;
       - }
@@ -17973,6 +18138,14 @@ it('should be possible to change the default modifiers and change the className'
       -
       - .prose-blue a code {
       -   color: #2563eb;
+      - }
+      -
+      - .prose-indigo a {
+      -   color: #4f46e5;
+      - }
+      -
+      - .prose-indigo a code {
+      -   color: #4f46e5;
       - }
       -
       - .prose-purple a {
@@ -18234,37 +18407,42 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .sm\\\\:prose hr + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown hr + * {
+
+      ---
+
       -   .sm\\\\:prose h2 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h2 + * {
+
+      ---
+
       -   .sm\\\\:prose h3 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h3 + * {
+
+      ---
+
       -   .sm\\\\:prose h4 + * {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .sm\\\\:markdown h4 + * {
+
+      ---
+
       -   .sm\\\\:prose thead th:first-child {
-      -     padding-left: 0;
+      +   .sm\\\\:markdown thead th:first-child {
+
+      ---
+
       -   }
       -
       -   .sm\\\\:prose thead th:last-child {
       -     padding-right: 0;
-      -   }
-      -
-      -   .sm\\\\:prose tbody td:first-child {
-      -     padding-left: 0;
 
       ---
 
+      -   .sm\\\\:prose tbody td:first-child {
+      -     padding-left: 0;
+      -   }
+      -
       -   .sm\\\\:prose tbody td:last-child {
       -     padding-right: 0;
       -   }
@@ -18443,25 +18621,21 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm hr + * {
-      +   .sm\\\\:markdown hr + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm h2 + * {
-      +   .sm\\\\:markdown h2 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm h3 + * {
-      +   .sm\\\\:markdown h3 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm h4 + * {
-      +   .sm\\\\:markdown h4 + * {
-
-      ---
-
+      -     margin-top: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
@@ -18474,10 +18648,9 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm thead th:first-child {
-      +   .sm\\\\:markdown thead th:first-child {
-
-      ---
-
+      -     padding-left: 0;
+      -   }
+      -
       -   .sm\\\\:prose-sm thead th:last-child {
       +   .sm\\\\:markdown thead th:last-child {
 
@@ -19198,12 +19371,20 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .sm\\\\:prose-blue a {
       -     color: #2563eb;
+      -   }
+      -
+      -   .sm\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .sm\\\\:prose-indigo a {
+      -     color: #4f46e5;
 
       ---
 
       -
-      -   .sm\\\\:prose-blue a code {
-      -     color: #2563eb;
+      -   .sm\\\\:prose-indigo a code {
+      -     color: #4f46e5;
       -   }
       -
       -   .sm\\\\:prose-purple a {
@@ -20431,6 +20612,14 @@ it('should be possible to change the default modifiers and change the className'
       -     color: #2563eb;
       -   }
       -
+      -   .md\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .md\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
+      -
       -   .md\\\\:prose-purple a {
       -     color: #7c3aed;
       -   }
@@ -20728,24 +20917,22 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose > :first-child {
-      +   .lg\\\\:markdown > :first-child {
-
-      ---
-
-      -   .lg\\\\:prose > :last-child {
-      +   .lg\\\\:markdown > :last-child {
-
-      ---
-
       -   }
       -
+      -   .lg\\\\:prose > :first-child {
+      -     margin-top: 0;
+      -   }
+      -
+      -   .lg\\\\:prose > :last-child {
+      -     margin-bottom: 0;
+
+      ---
+
       -   .lg\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
-
-      ---
-
+      -   }
+      -
       -   .lg\\\\:prose-sm p {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
@@ -20766,7 +20953,10 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .lg\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      -     margin-top: 0;
+      +   .lg\\\\:markdown > :first-child {
+
+      ---
+
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
@@ -20776,8 +20966,9 @@ it('should be possible to change the default modifiers and change the className'
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
-      -   }
-      -
+
+      ---
+
       -   .lg\\\\:prose-sm h3 {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
@@ -20808,9 +20999,10 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .lg\\\\:prose-sm figure > * {
       -     margin-top: 0;
-      -     margin-bottom: 0;
-      -   }
-      -
+      +   .lg\\\\:markdown > :last-child {
+
+      ---
+
       -   .lg\\\\:prose-sm figure figcaption {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
@@ -21632,9 +21824,7 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .lg\\\\:prose-red a code {
       -     color: #dc2626;
-
-      ---
-
+      -   }
       -
       -   .lg\\\\:prose-yellow a {
       -     color: #d97706;
@@ -21660,9 +21850,19 @@ it('should be possible to change the default modifiers and change the className'
       -     color: #2563eb;
       -   }
       -
+      -   .lg\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .lg\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
+      -
       -   .lg\\\\:prose-purple a {
       -     color: #7c3aed;
-      -   }
+
+      ---
+
       -
       -   .lg\\\\:prose-purple a code {
       -     color: #7c3aed;
@@ -21958,12 +22158,11 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .xl\\\\:prose > :first-child {
-      -     margin-top: 0;
-      -   }
-      -
+      +   .xl\\\\:markdown > :first-child {
+
+      ---
+
       -   .xl\\\\:prose > :last-child {
       -     margin-bottom: 0;
       -   }
@@ -21989,20 +22188,15 @@ it('should be possible to change the default modifiers and change the className'
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
-
-      ---
-
+      -   }
+      -
       -   .xl\\\\:prose-sm h1 {
       -     font-size: 2.1428571em;
-      +   .xl\\\\:markdown > :first-child {
-
-      ---
-
+      -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
-
-      ---
-
+      -   }
+      -
       -   .xl\\\\:prose-sm h2 {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
@@ -22044,8 +22238,6 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .xl\\\\:prose-sm figure figcaption {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
@@ -22062,9 +22254,8 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .xl\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
-
-      ---
-
+      -   }
+      -
       -   .xl\\\\:prose-sm pre {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
@@ -22888,12 +23079,20 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .xl\\\\:prose-blue a {
       -     color: #2563eb;
+      -   }
+      -
+      -   .xl\\\\:prose-blue a code {
+      -     color: #2563eb;
+      -   }
+      -
+      -   .xl\\\\:prose-indigo a {
+      -     color: #4f46e5;
 
       ---
 
       -
-      -   .xl\\\\:prose-blue a code {
-      -     color: #2563eb;
+      -   .xl\\\\:prose-indigo a code {
+      -     color: #4f46e5;
       -   }
       -
       -   .xl\\\\:prose-purple a {
@@ -23154,6 +23353,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
+      -   }
+      -
       -   .\\\\32xl\\\\:prose hr + * {
       -     margin-top: 0;
       -   }
@@ -23192,8 +23393,9 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose > :last-child {
       -     margin-bottom: 0;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm {
       -     font-size: 0.875rem;
       -     line-height: 1.7142857;
@@ -23260,7 +23462,10 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm figure > * {
-      -     margin-top: 0;
+      +   .\\\\32xl\\\\:markdown hr + * {
+
+      ---
+
       -     margin-bottom: 0;
       -   }
       -
@@ -23280,8 +23485,9 @@ it('should be possible to change the default modifiers and change the className'
       -
       -   .\\\\32xl\\\\:prose-sm h3 code {
       -     font-size: 0.8888889em;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm pre {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
@@ -23360,20 +23566,19 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm hr + * {
-      +   .\\\\32xl\\\\:markdown hr + * {
-
-      ---
-
-      -   .\\\\32xl\\\\:prose-sm h2 + * {
       +   .\\\\32xl\\\\:markdown h2 + * {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h3 + * {
+      -   .\\\\32xl\\\\:prose-sm h2 + * {
       +   .\\\\32xl\\\\:markdown h3 + * {
 
       ---
 
+      -   .\\\\32xl\\\\:prose-sm h3 + * {
+      -     margin-top: 0;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm h4 + * {
       +   .\\\\32xl\\\\:markdown h4 + * {
 
@@ -23384,15 +23589,15 @@ it('should be possible to change the default modifiers and change the className'
       -   .\\\\32xl\\\\:prose-sm table {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
-
-      ---
-
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm thead th {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
-      -   }
-      -
+
+      ---
+
       -   .\\\\32xl\\\\:prose-sm thead th:first-child {
       +   .\\\\32xl\\\\:markdown thead th:first-child {
 
@@ -23403,16 +23608,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   }
-      -
       -   .\\\\32xl\\\\:prose-sm tbody td {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
-
-      ---
-
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-sm tbody td:first-child {
       +   .\\\\32xl\\\\:markdown tbody td:first-child {
 
@@ -24127,6 +24329,14 @@ it('should be possible to change the default modifiers and change the className'
       -     color: #2563eb;
       -   }
       -
+      -   .\\\\32xl\\\\:prose-indigo a {
+      -     color: #4f46e5;
+      -   }
+      -
+      -   .\\\\32xl\\\\:prose-indigo a code {
+      -     color: #4f46e5;
+      -   }
+      -
       -   .\\\\32xl\\\\:prose-purple a {
       -     color: #7c3aed;
       -   }
@@ -24234,7 +24444,7 @@ it('should be possible to merge values', async () => {
   ).toMatchInlineSnapshot(`
     "
 
-      -   color: #18181b;
+      -   color: #111827;
       +   color: green;
 
       ---
@@ -24243,7 +24453,7 @@ it('should be possible to merge values', async () => {
 
       ---
 
-      -     color: #18181b;
+      -     color: #111827;
       +     color: green;
 
       ---
@@ -24252,7 +24462,7 @@ it('should be possible to merge values', async () => {
 
       ---
 
-      -     color: #18181b;
+      -     color: #111827;
       +     color: green;
 
       ---
@@ -24261,7 +24471,7 @@ it('should be possible to merge values', async () => {
 
       ---
 
-      -     color: #18181b;
+      -     color: #111827;
       +     color: green;
 
       ---
@@ -24270,7 +24480,7 @@ it('should be possible to merge values', async () => {
 
       ---
 
-      -     color: #18181b;
+      -     color: #111827;
       +     color: green;
 
       ---
@@ -24279,7 +24489,7 @@ it('should be possible to merge values', async () => {
 
       ---
 
-      -     color: #18181b;
+      -     color: #111827;
       +     color: green;
 
       ---

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,5 +1,5 @@
-const isPlainObject = require('lodash/isPlainObject')
 const defaultTheme = require('tailwindcss/defaultTheme')
+const { isUsableColor } = require('./utils')
 
 const round = (num) =>
   num
@@ -1074,7 +1074,7 @@ module.exports = (theme) => ({
 
   // Add color modifiers
   ...Object.entries(theme('colors')).reduce((reduced, [color, values]) => {
-    if (!isPlainObject(values) || color === 'gray' || !values[600]) {
+    if (!isUsableColor(color, values)) {
       return {}
     }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,3 +1,4 @@
+const isPlainObject = require('lodash/isPlainObject')
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 const round = (num) =>
@@ -8,7 +9,7 @@ const round = (num) =>
 const rem = (px) => `${round(px / 16)}rem`
 const em = (px, base) => `${round(px / base)}em`
 
-module.exports = {
+module.exports = (theme) => ({
   DEFAULT: {
     css: [
       {
@@ -20,6 +21,7 @@ module.exports = {
         a: {
           color: defaultTheme.colors.gray[900],
           textDecoration: 'underline',
+          fontWeight: '500',
         },
         strong: {
           color: defaultTheme.colors.gray[900],
@@ -93,6 +95,9 @@ module.exports = {
         },
         'code::after': {
           content: '"`"',
+        },
+        'a code': {
+          color: defaultTheme.colors.gray[900],
         },
         pre: {
           color: defaultTheme.colors.gray[200],
@@ -1066,4 +1071,23 @@ module.exports = {
       },
     ],
   },
-}
+
+  // Add color modifiers
+  ...Object.entries(theme('colors')).reduce((reduced, [color, values]) => {
+    if (!isPlainObject(values) || color === 'gray' || !values[600]) {
+      return {}
+    }
+
+    return {
+      ...reduced,
+      [color]: {
+        css: [
+          {
+            a: { color: values[600] },
+            'a code': { color: values[600] },
+          },
+        ],
+      },
+    }
+  }, {}),
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+const isPlainObject = require('lodash/isPlainObject')
+
+module.exports = {
+  isUsableColor(color, values) {
+    return isPlainObject(values) && color !== 'gray' && values[600]
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7929,10 +7929,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tailwindcss@^2.0.0-alpha.4:
-  version "2.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.0.0-alpha.4.tgz#d0f1a0bf152f25f36979f20efc312b877fc754a7"
-  integrity sha512-iq9en9dTdFntLLUOgR1yPLVYGUaGsHqm1QLseSxlZKoAsza78Kgv4wJZ2k9k1QG5daF4fAxyhXR1bgudsNvy/Q==
+tailwindcss@^2.0.0-alpha.16:
+  version "2.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.0.0-alpha.16.tgz#df7f2dd5a6a738116874dbde5d55d2ecf9c58088"
+  integrity sha512-o2c2J9IU7Gmza8qZdhSS8w94vgudkYPnjUYx7oodygcH3NCr5fz+TQ4hvn1DfInb8H1turDBCPU1EjGfPYs8Kw==
   dependencies:
     "@fullhuman/postcss-purgecss" "^3.0.0"
     autoprefixer "^9.8.6"


### PR DESCRIPTION
This PR adds new color modifiers by default like `prose-indigo`, `prose-blue`, `prose-pink`, etc. that update link colors to match the modifier color. Useful for adding a little bit of branding to your content sections.

It uses the `600` shade of each color in your `theme.colors` configuration by default, excluding `gray`. If a color doesn't have a `600` shade it is skipped.

This is implemented simply as a default config, and not as any special logic inside the plugin. You can control which ones are enabled just like the size modifiers:

```js
// tailwind.config.js
module.exports = {
  theme: {
    // ...
  },
  plugins: [
    require('@tailwindcss/typography')({
      modifiers: ['sm', 'lg', 'blue', 'pink'],
    }),
    // ...
  ],
}
```
