### PR TITLE
Fix bug related to prose color helpers not working as expected

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -24693,3 +24693,97 @@ it('should be possible to override backticks for the inline `code` tag', async (
     "
   `)
 })
+
+it('should be possible to add colors without 600 and still get default and custom prose color helpers created', async () => {
+  expect(
+    await diffOnly(
+      {},
+      {
+        theme: {
+          extend: {
+            colors: {
+              'darkish-red': '#a85555',
+              'darkish-green': {
+                600: '#55a855',
+              },
+            },
+          },
+        },
+      }
+    )
+  ).toMatchInlineSnapshot(`
+    "
+
+      + .prose-darkish-green a {
+      +   color: #55a855;
+      + }
+      +
+      + .prose-darkish-green a code {
+      +   color: #55a855;
+      + }
+      +
+
+      ---
+
+      +   }
+      +
+      +   .sm\\\\:prose-darkish-green a {
+      +     color: #55a855;
+      +   }
+      +
+      +   .sm\\\\:prose-darkish-green a code {
+      +     color: #55a855;
+
+      ---
+
+      +   }
+      +
+      +   .md\\\\:prose-darkish-green a {
+      +     color: #55a855;
+      +   }
+      +
+      +   .md\\\\:prose-darkish-green a code {
+      +     color: #55a855;
+
+      ---
+
+      +   }
+      +
+      +   .lg\\\\:prose-darkish-green a {
+      +     color: #55a855;
+
+      ---
+
+      +
+      +   .lg\\\\:prose-darkish-green a code {
+      +     color: #55a855;
+      +   }
+
+      ---
+
+      +   }
+      +
+      +   .xl\\\\:prose-darkish-green a {
+      +     color: #55a855;
+
+      ---
+
+      +
+      +   .xl\\\\:prose-darkish-green a code {
+      +     color: #55a855;
+      +   }
+
+      ---
+
+      +   }
+      +
+      +   .\\\\32xl\\\\:prose-darkish-green a {
+      +     color: #55a855;
+      +   }
+      +
+      +   .\\\\32xl\\\\:prose-darkish-green a code {
+      +     color: #55a855;
+
+    "
+  `)
+})

--- a/src/styles.js
+++ b/src/styles.js
@@ -1075,7 +1075,7 @@ module.exports = (theme) => ({
   // Add color modifiers
   ...Object.entries(theme('colors')).reduce((reduced, [color, values]) => {
     if (!isUsableColor(color, values)) {
-      return {}
+      return reduced
     }
 
     return {


### PR DESCRIPTION
There is a bug in how the `prose-{color}` helpers are generated. Since this is `reduce` and not `map`, returning `{}` was effectively erasing any existing valid colors (usually the default colors) if someone created a custom color (by extending `colors`) that had no `600` value set.

Proof of concept here:

https://play.tailwindcss.com/IVTa5zHqPJ?file=config

Thanks to @RobinMalfait for helping me figure out the best way to move this issue forward. 