### PR TITLE
Fix Firefox showing extra line in `pre code`

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -112,10 +112,10 @@ module.exports = (theme) => ({
           lineHeight: 'inherit',
         },
         'pre code::before': {
-          content: '""',
+          content: 'none',
         },
         'pre code::after': {
-          content: '""',
+          content: 'none',
         },
         table: {
           width: '100%',


### PR DESCRIPTION
Also checked Chrome and setting to `none` seems to do the correct thing there, too. [Relevant MDN link](https://developer.mozilla.org/en-US/docs/Web/CSS/content)

Before:

![image](https://user-images.githubusercontent.com/1682194/102811016-b7a0ff80-4392-11eb-8aed-d94f6801da9d.png)
