### PR TITLE
Add light modifier for dark mode

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -327,6 +327,65 @@ module.exports = (theme) => ({
       },
     ],
   },
+  light: {
+    css: {
+      color: theme('colors.gray.300', defaultTheme.colors.gray[300]),
+      '[class~="lead"]': {
+        color: theme('colors.gray.300', defaultTheme.colors.gray[300]),
+      },
+      a: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      strong: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      'ol > li::before': {
+        color: theme('colors.gray.400', defaultTheme.colors.gray[400]),
+      },
+      'ul > li::before': {
+        backgroundColor: theme('colors.gray.600', defaultTheme.colors.gray[600]),
+      },
+      hr: {
+        borderColor: theme('colors.gray.700', defaultTheme.colors.gray[700]),
+      },
+      blockquote: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+        borderLeftColor: theme('colors.gray.700', defaultTheme.colors.gray[700]),
+      },
+      h1: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      h2: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      h3: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      h4: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      'figure figcaption': {
+        color: theme('colors.gray.400', defaultTheme.colors.gray[400]),
+      },
+      code: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      'a code': {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+      },
+      pre: {
+        color: theme('colors.gray.700', defaultTheme.colors.gray[700]),
+        backgroundColor: theme('colors.gray.800', defaultTheme.colors.gray[800]),
+      },
+      thead: {
+        color: theme('colors.gray.200', defaultTheme.colors.gray[200]),
+        borderBottomColor: theme('colors.gray.600', defaultTheme.colors.gray[600]),
+      },
+      'tbody tr': {
+        borderBottomColor: theme('colors.gray.700', defaultTheme.colors.gray[700]),
+      },
+    },
+  },
   sm: {
     css: [
       {


### PR DESCRIPTION
After all the discussion in #69, I decided to create a light palette modifier class for this plugin.

Color replacements were made in the following order:

1. 700 → 300 (main text color)
2. 200 → 700
3. 300 → 600
4. 500 → 400
5. 900 → 200
6. 600 → 300

The light colors were selected with `bg-gray-900` and `bg-black` in mind.