### PR TITLE
Remove empty line appended to code blocks

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -112,10 +112,10 @@ module.exports = (theme) => ({
           lineHeight: 'inherit',
         },
         'pre code::before': {
-          content: '""',
+          content: 'none',
         },
         'pre code::after': {
-          content: '""',
+          content: 'none',
         },
         table: {
           width: '100%',


### PR DESCRIPTION
As the `content` for inline `code::before, code::after` is [set to <code>&#96;</code>](https://github.com/tailwindlabs/tailwindcss-typography/blob/b36a20819f46fbf55479de9010b17154cd2bbd10/src/styles.js#L89-L94), it must be reset to the [initial value of `normal`](https://developer.mozilla.org/en-US/docs/Web/CSS/content#Syntax), or its matching `none` value for the targeted `pre code::before, pre code::after` pseudo-elements.