### PR TITLE
Remove open/close quotes from blockquote

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8008,16 +8008,6 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose blockquote p:first-of-type::before {
-      + .markdown blockquote p:first-of-type::before {
-
-      ---
-
-      - .prose blockquote p:last-of-type::after {
-      + .markdown blockquote p:last-of-type::after {
-
-      ---
-
       - .prose h1 {
       + .markdown h1 {
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -139,14 +139,6 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1em;
     }
 
-    .prose blockquote p:first-of-type::before {
-      content: open-quote;
-    }
-
-    .prose blockquote p:last-of-type::after {
-      content: close-quote;
-    }
-
     .prose h1 {
       color: #111827;
       font-weight: 800;
@@ -1457,14 +1449,6 @@ it('should generate the default classes for the typography components', async ()
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1em;
-      }
-
-      .sm\\\\:prose blockquote p:first-of-type::before {
-        content: open-quote;
-      }
-
-      .sm\\\\:prose blockquote p:last-of-type::after {
-        content: close-quote;
       }
 
       .sm\\\\:prose h1 {
@@ -2780,14 +2764,6 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .md\\\\:prose blockquote p:first-of-type::before {
-        content: open-quote;
-      }
-
-      .md\\\\:prose blockquote p:last-of-type::after {
-        content: close-quote;
-      }
-
       .md\\\\:prose h1 {
         color: #111827;
         font-weight: 800;
@@ -4099,14 +4075,6 @@ it('should generate the default classes for the typography components', async ()
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1em;
-      }
-
-      .lg\\\\:prose blockquote p:first-of-type::before {
-        content: open-quote;
-      }
-
-      .lg\\\\:prose blockquote p:last-of-type::after {
-        content: close-quote;
       }
 
       .lg\\\\:prose h1 {
@@ -5422,14 +5390,6 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .xl\\\\:prose blockquote p:first-of-type::before {
-        content: open-quote;
-      }
-
-      .xl\\\\:prose blockquote p:last-of-type::after {
-        content: close-quote;
-      }
-
       .xl\\\\:prose h1 {
         color: #111827;
         font-weight: 800;
@@ -6741,14 +6701,6 @@ it('should generate the default classes for the typography components', async ()
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1em;
-      }
-
-      .\\\\32xl\\\\:prose blockquote p:first-of-type::before {
-        content: open-quote;
-      }
-
-      .\\\\32xl\\\\:prose blockquote p:last-of-type::after {
-        content: close-quote;
       }
 
       .\\\\32xl\\\\:prose h1 {

--- a/src/styles.js
+++ b/src/styles.js
@@ -84,12 +84,6 @@ module.exports = (theme) => ({
           borderLeftColor: theme('colors.gray.200', defaultTheme.colors.gray[200]),
           quotes: '"\\201C""\\201D""\\2018""\\2019"',
         },
-        'blockquote p:first-of-type::before': {
-          content: 'open-quote',
-        },
-        'blockquote p:last-of-type::after': {
-          content: 'close-quote',
-        },
         h1: {
           color: theme('colors.gray.900', defaultTheme.colors.gray[900]),
           fontWeight: '800',


### PR DESCRIPTION
Currently, for all blockquotes there are open and close quotes that are automatically added like so:
> "Quote from famous person
Famous person"

However, if we are trying to attribute the quote to someone (like above), it does not look work if there are automatic open/close quotes. It would be preferable to not have them and allow the user to add them as needed.

> "Quote from famous person"
Famous person