### PR TITLE
Added docs for changing the default class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,29 @@ module.exports = {
   },
 }
 ```
+
+
+### Changing the default class name
+
+If you'd like to customise the name of your tailwind typography class, you can do so by setting the `className` key to your preferred name in the options passed when you import the `@tailwindcss/typography` plugin in your `tailwind.config.js` file:
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    // ...
+  },
+  plugins: [
+    require('@tailwindcss/typography')({
+        className: 'typography',
+    }),
+  ]
+  ...
+}
+```
+
+```html
+<article class="typography sm:typography-sm lg:typography-lg xl:typography-xl">
+  {{ markdown }}
+</article>
+```

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ module.exports = {
 
 ### Changing the default class name
 
-If you'd like to customise the name of your tailwind typography class, you can do so by setting the `className` key to your preferred name in the options passed when you import the `@tailwindcss/typography` plugin in your `tailwind.config.js` file:
+If you need to use a class name other than `prose` for any reason, you can do so using the `className` option when registering the plugin:
 
 ```js
 // tailwind.config.js
@@ -361,7 +361,7 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography')({
-        className: 'typography',
+        className: 'markdown',
     }),
   ]
   ...
@@ -369,7 +369,7 @@ module.exports = {
 ```
 
 ```html
-<article class="typography sm:typography-sm lg:typography-lg xl:typography-xl">
+<article class="markdown md:markdown-lg">
   {{ markdown }}
 </article>
 ```


### PR DESCRIPTION
## Motivation

I was having trouble explaining the `prose` class to my students, so I decided to look through the documentation to see if I could change the name.

I came across [this issue](https://github.com/tailwindlabs/tailwindcss-typography/issues/16), where @adamwathan last commented 
> It should work in the latest release, just haven't written release notes yet sorry.

## Overview

I tried setting the class name to typography on a local nuxt build, and it worked perfectly, so I went ahead and created a PR to add this to the README documentation. 