### PR TITLE
Use :where to reduce specificity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,6 @@ module.exports = plugin.withOptions(
         ...Object.keys(config).filter((modifier) => !DEFAULT_MODIFIERS.includes(modifier)),
       ])
 
-      console.log(configToCss(config['DEFAULT']))
-
       addComponents(
         all.map((modifier) => ({
           [modifier === 'DEFAULT' ? `.${className}` : `.${className}-${modifier}`]: configToCss(

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,13 @@ function configToCss(config = {}) {
           .map((key) => computed[key](config[key])),
         ...castArray(config.css || {})
       )
-    ).map(([k, v]) => [inWhere(k), v])
+    ).map(([k, v]) => {
+      if (typeof v == 'object' && v.constructor == Object) {
+        return [inWhere(k), v]
+      }
+
+      return [k, v]
+    })
   )
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function inWhere(selector) {
   return `:where(${selector})`
 }
 
-function configToCss(config = {}) {
+function configToCss(config = {}, target) {
   return Object.fromEntries(
     Object.entries(
       merge(
@@ -33,6 +33,10 @@ function configToCss(config = {}) {
         ...castArray(config.css || {})
       )
     ).map(([k, v]) => {
+      if (target === 'legacy') {
+        return [k, v]
+      }
+
       if (typeof v == 'object' && v.constructor == Object) {
         return [inWhere(k), v]
       }
@@ -43,7 +47,7 @@ function configToCss(config = {}) {
 }
 
 module.exports = plugin.withOptions(
-  ({ modifiers, className = 'prose' } = {}) => {
+  ({ modifiers, className = 'prose', target = 'modern' } = {}) => {
     return function ({ addComponents, theme, variants }) {
       const DEFAULT_MODIFIERS = [
         'DEFAULT',
@@ -69,7 +73,8 @@ module.exports = plugin.withOptions(
       addComponents(
         all.map((modifier) => ({
           [modifier === 'DEFAULT' ? `.${className}` : `.${className}-${modifier}`]: configToCss(
-            config[modifier]
+            config[modifier],
+            target,
           ),
         })),
         variants('typography')

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,16 @@ const computed = {
 }
 
 function configToCss(config = {}) {
-  return merge(
-    {},
-    ...Object.keys(config)
-      .filter((key) => computed[key])
-      .map((key) => computed[key](config[key])),
-    ...castArray(config.css || {})
+  return Object.fromEntries(
+    Object.entries(
+      merge(
+        {},
+        ...Object.keys(config)
+          .filter((key) => computed[key])
+          .map((key) => computed[key](config[key])),
+        ...castArray(config.css || {})
+      )
+    ).map(([k, v]) => [`:where(${k})`, v])
   )
 }
 
@@ -43,6 +47,8 @@ module.exports = plugin.withOptions(
         ...modifiers,
         ...Object.keys(config).filter((modifier) => !DEFAULT_MODIFIERS.includes(modifier)),
       ])
+
+      console.log(configToCss(config['DEFAULT']))
 
       addComponents(
         all.map((modifier) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,18 @@ const computed = {
   // bulletColor: (color) => ({ 'ul > li::before': { backgroundColor: color } }),
 }
 
+function inWhere(selector) {
+  if (selector.endsWith('::before')) {
+    return `:where(${selector.slice(0, -8)})::before`
+  }
+
+  if (selector.endsWith('::after')) {
+    return `:where(${selector.slice(0, -7)})::after`
+  }
+
+  return `:where(${selector})`
+}
+
 function configToCss(config = {}) {
   return Object.fromEntries(
     Object.entries(
@@ -20,7 +32,7 @@ function configToCss(config = {}) {
           .map((key) => computed[key](config[key])),
         ...castArray(config.css || {})
       )
-    ).map(([k, v]) => [`:where(${k})`, v])
+    ).map(([k, v]) => [inWhere(k), v])
   )
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -32,11 +32,11 @@ async function diffOnly(options = {}, config = {}) {
 it('should generate the default classes for the typography components', async () => {
   expect(await run()).toMatchInlineSnapshot(`
     ".prose {
-      color: #374151;
-      max-width: 65ch;
+      :where(color): #374151;
+      :where(max-width): 65ch;
     }
 
-    .prose [class~=\\"lead\\"] {
+    .prose :where([class~=\\"lead\\"]) {
       color: #4b5563;
       font-size: 1.25em;
       line-height: 1.6;
@@ -44,59 +44,59 @@ it('should generate the default classes for the typography components', async ()
       margin-bottom: 1.2em;
     }
 
-    .prose a {
+    .prose :where(a) {
       color: #111827;
       text-decoration: underline;
       font-weight: 500;
     }
 
-    .prose strong {
+    .prose :where(strong) {
       color: #111827;
       font-weight: 600;
     }
 
-    .prose ol[type=\\"A\\"] {
+    .prose :where(ol[type=\\"A\\"]) {
       --list-counter-style: upper-alpha;
     }
 
-    .prose ol[type=\\"a\\"] {
+    .prose :where(ol[type=\\"a\\"]) {
       --list-counter-style: lower-alpha;
     }
 
-    .prose ol[type=\\"A\\" s] {
+    .prose :where(ol[type=\\"A\\" s]) {
       --list-counter-style: upper-alpha;
     }
 
-    .prose ol[type=\\"a\\" s] {
+    .prose :where(ol[type=\\"a\\" s]) {
       --list-counter-style: lower-alpha;
     }
 
-    .prose ol[type=\\"I\\"] {
+    .prose :where(ol[type=\\"I\\"]) {
       --list-counter-style: upper-roman;
     }
 
-    .prose ol[type=\\"i\\"] {
+    .prose :where(ol[type=\\"i\\"]) {
       --list-counter-style: lower-roman;
     }
 
-    .prose ol[type=\\"I\\" s] {
+    .prose :where(ol[type=\\"I\\" s]) {
       --list-counter-style: upper-roman;
     }
 
-    .prose ol[type=\\"i\\" s] {
+    .prose :where(ol[type=\\"i\\" s]) {
       --list-counter-style: lower-roman;
     }
 
-    .prose ol[type=\\"1\\"] {
+    .prose :where(ol[type=\\"1\\"]) {
       --list-counter-style: decimal;
     }
 
-    .prose ol > li {
+    .prose :where(ol > li) {
       position: relative;
       padding-left: 1.75em;
     }
 
-    .prose ol > li::before {
+    .prose :where(ol > li::before) {
       content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
       position: absolute;
       font-weight: 400;
@@ -104,12 +104,12 @@ it('should generate the default classes for the typography components', async ()
       left: 0;
     }
 
-    .prose ul > li {
+    .prose :where(ul > li) {
       position: relative;
       padding-left: 1.75em;
     }
 
-    .prose ul > li::before {
+    .prose :where(ul > li::before) {
       content: \\"\\";
       position: absolute;
       background-color: #d1d5db;
@@ -120,14 +120,14 @@ it('should generate the default classes for the typography components', async ()
       left: 0.25em;
     }
 
-    .prose hr {
+    .prose :where(hr) {
       border-color: #e5e7eb;
       border-top-width: 1px;
       margin-top: 3em;
       margin-bottom: 3em;
     }
 
-    .prose blockquote {
+    .prose :where(blockquote) {
       font-weight: 500;
       font-style: italic;
       color: #111827;
@@ -139,15 +139,15 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1em;
     }
 
-    .prose blockquote p:first-of-type::before {
+    .prose :where(blockquote p:first-of-type::before) {
       content: open-quote;
     }
 
-    .prose blockquote p:last-of-type::after {
+    .prose :where(blockquote p:last-of-type::after) {
       content: close-quote;
     }
 
-    .prose h1 {
+    .prose :where(h1) {
       color: #111827;
       font-weight: 800;
       font-size: 2.25em;
@@ -156,11 +156,11 @@ it('should generate the default classes for the typography components', async ()
       line-height: 1.1111111;
     }
 
-    .prose h1 strong {
+    .prose :where(h1 strong) {
       font-weight: 900;
     }
 
-    .prose h2 {
+    .prose :where(h2) {
       color: #111827;
       font-weight: 700;
       font-size: 1.5em;
@@ -169,11 +169,11 @@ it('should generate the default classes for the typography components', async ()
       line-height: 1.3333333;
     }
 
-    .prose h2 strong {
+    .prose :where(h2 strong) {
       font-weight: 800;
     }
 
-    .prose h3 {
+    .prose :where(h3) {
       color: #111827;
       font-weight: 600;
       font-size: 1.25em;
@@ -182,11 +182,11 @@ it('should generate the default classes for the typography components', async ()
       line-height: 1.6;
     }
 
-    .prose h3 strong {
+    .prose :where(h3 strong) {
       font-weight: 700;
     }
 
-    .prose h4 {
+    .prose :where(h4) {
       color: #111827;
       font-weight: 600;
       margin-top: 1.5em;
@@ -194,36 +194,36 @@ it('should generate the default classes for the typography components', async ()
       line-height: 1.5;
     }
 
-    .prose h4 strong {
+    .prose :where(h4 strong) {
       font-weight: 700;
     }
 
-    .prose figure figcaption {
+    .prose :where(figure figcaption) {
       color: #6b7280;
       font-size: 0.875em;
       line-height: 1.4285714;
       margin-top: 0.8571429em;
     }
 
-    .prose code {
+    .prose :where(code) {
       color: #111827;
       font-weight: 600;
       font-size: 0.875em;
     }
 
-    .prose code::before {
+    .prose :where(code::before) {
       content: \\"\`\\";
     }
 
-    .prose code::after {
+    .prose :where(code::after) {
       content: \\"\`\\";
     }
 
-    .prose a code {
+    .prose :where(a code) {
       color: #111827;
     }
 
-    .prose pre {
+    .prose :where(pre) {
       color: #e5e7eb;
       background-color: #1f2937;
       overflow-x: auto;
@@ -238,7 +238,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.1428571em;
     }
 
-    .prose pre code {
+    .prose :where(pre code) {
       background-color: transparent;
       border-width: 0;
       border-radius: 0;
@@ -250,15 +250,15 @@ it('should generate the default classes for the typography components', async ()
       line-height: inherit;
     }
 
-    .prose pre code::before {
+    .prose :where(pre code::before) {
       content: none;
     }
 
-    .prose pre code::after {
+    .prose :where(pre code::after) {
       content: none;
     }
 
-    .prose table {
+    .prose :where(table) {
       width: 100%;
       table-layout: auto;
       text-align: left;
@@ -268,30 +268,30 @@ it('should generate the default classes for the typography components', async ()
       line-height: 1.7142857;
     }
 
-    .prose thead {
+    .prose :where(thead) {
       color: #111827;
       font-weight: 600;
       border-bottom-width: 1px;
       border-bottom-color: #d1d5db;
     }
 
-    .prose thead th {
+    .prose :where(thead th) {
       vertical-align: bottom;
       padding-right: 0.5714286em;
       padding-bottom: 0.5714286em;
       padding-left: 0.5714286em;
     }
 
-    .prose tbody tr {
+    .prose :where(tbody tr) {
       border-bottom-width: 1px;
       border-bottom-color: #e5e7eb;
     }
 
-    .prose tbody tr:last-child {
+    .prose :where(tbody tr:last-child) {
       border-bottom-width: 0;
     }
 
-    .prose tbody td {
+    .prose :where(tbody td) {
       vertical-align: top;
       padding-top: 0.5714286em;
       padding-right: 0.5714286em;
@@ -300,213 +300,213 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose {
-      font-size: 1rem;
-      line-height: 1.75;
+      :where(font-size): 1rem;
+      :where(line-height): 1.75;
     }
 
-    .prose p {
+    .prose :where(p) {
       margin-top: 1.25em;
       margin-bottom: 1.25em;
     }
 
-    .prose img {
+    .prose :where(img) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose video {
+    .prose :where(video) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose figure {
+    .prose :where(figure) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose figure > * {
+    .prose :where(figure > *) {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .prose h2 code {
+    .prose :where(h2 code) {
       font-size: 0.875em;
     }
 
-    .prose h3 code {
+    .prose :where(h3 code) {
       font-size: 0.9em;
     }
 
-    .prose ol {
+    .prose :where(ol) {
       margin-top: 1.25em;
       margin-bottom: 1.25em;
     }
 
-    .prose ul {
+    .prose :where(ul) {
       margin-top: 1.25em;
       margin-bottom: 1.25em;
     }
 
-    .prose li {
+    .prose :where(li) {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
     }
 
-    .prose > ul > li p {
+    .prose :where(> ul > li p) {
       margin-top: 0.75em;
       margin-bottom: 0.75em;
     }
 
-    .prose > ul > li > *:first-child {
+    .prose :where(> ul > li > *:first-child) {
       margin-top: 1.25em;
     }
 
-    .prose > ul > li > *:last-child {
+    .prose :where(> ul > li > *:last-child) {
       margin-bottom: 1.25em;
     }
 
-    .prose > ol > li > *:first-child {
+    .prose :where(> ol > li > *:first-child) {
       margin-top: 1.25em;
     }
 
-    .prose > ol > li > *:last-child {
+    .prose :where(> ol > li > *:last-child) {
       margin-bottom: 1.25em;
     }
 
-    .prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
+    .prose :where(ul ul, ul ol, ol ul, ol ol) {
       margin-top: 0.75em;
       margin-bottom: 0.75em;
     }
 
-    .prose hr + * {
+    .prose :where(hr + *) {
       margin-top: 0;
     }
 
-    .prose h2 + * {
+    .prose :where(h2 + *) {
       margin-top: 0;
     }
 
-    .prose h3 + * {
+    .prose :where(h3 + *) {
       margin-top: 0;
     }
 
-    .prose h4 + * {
+    .prose :where(h4 + *) {
       margin-top: 0;
     }
 
-    .prose thead th:first-child {
+    .prose :where(thead th:first-child) {
       padding-left: 0;
     }
 
-    .prose thead th:last-child {
+    .prose :where(thead th:last-child) {
       padding-right: 0;
     }
 
-    .prose tbody td:first-child {
+    .prose :where(tbody td:first-child) {
       padding-left: 0;
     }
 
-    .prose tbody td:last-child {
+    .prose :where(tbody td:last-child) {
       padding-right: 0;
     }
 
-    .prose > :first-child {
+    .prose :where(> :first-child) {
       margin-top: 0;
     }
 
-    .prose > :last-child {
+    .prose :where(> :last-child) {
       margin-bottom: 0;
     }
 
     .prose-sm {
-      font-size: 0.875rem;
-      line-height: 1.7142857;
+      :where(font-size): 0.875rem;
+      :where(line-height): 1.7142857;
     }
 
-    .prose-sm p {
+    .prose-sm :where(p) {
       margin-top: 1.1428571em;
       margin-bottom: 1.1428571em;
     }
 
-    .prose-sm [class~=\\"lead\\"] {
+    .prose-sm :where([class~=\\"lead\\"]) {
       font-size: 1.2857143em;
       line-height: 1.5555556;
       margin-top: 0.8888889em;
       margin-bottom: 0.8888889em;
     }
 
-    .prose-sm blockquote {
+    .prose-sm :where(blockquote) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
       padding-left: 1.1111111em;
     }
 
-    .prose-sm h1 {
+    .prose-sm :where(h1) {
       font-size: 2.1428571em;
       margin-top: 0;
       margin-bottom: 0.8em;
       line-height: 1.2;
     }
 
-    .prose-sm h2 {
+    .prose-sm :where(h2) {
       font-size: 1.4285714em;
       margin-top: 1.6em;
       margin-bottom: 0.8em;
       line-height: 1.4;
     }
 
-    .prose-sm h3 {
+    .prose-sm :where(h3) {
       font-size: 1.2857143em;
       margin-top: 1.5555556em;
       margin-bottom: 0.4444444em;
       line-height: 1.5555556;
     }
 
-    .prose-sm h4 {
+    .prose-sm :where(h4) {
       margin-top: 1.4285714em;
       margin-bottom: 0.5714286em;
       line-height: 1.4285714;
     }
 
-    .prose-sm img {
+    .prose-sm :where(img) {
       margin-top: 1.7142857em;
       margin-bottom: 1.7142857em;
     }
 
-    .prose-sm video {
+    .prose-sm :where(video) {
       margin-top: 1.7142857em;
       margin-bottom: 1.7142857em;
     }
 
-    .prose-sm figure {
+    .prose-sm :where(figure) {
       margin-top: 1.7142857em;
       margin-bottom: 1.7142857em;
     }
 
-    .prose-sm figure > * {
+    .prose-sm :where(figure > *) {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .prose-sm figure figcaption {
+    .prose-sm :where(figure figcaption) {
       font-size: 0.8571429em;
       line-height: 1.3333333;
       margin-top: 0.6666667em;
     }
 
-    .prose-sm code {
+    .prose-sm :where(code) {
       font-size: 0.8571429em;
     }
 
-    .prose-sm h2 code {
+    .prose-sm :where(h2 code) {
       font-size: 0.9em;
     }
 
-    .prose-sm h3 code {
+    .prose-sm :where(h3 code) {
       font-size: 0.8888889em;
     }
 
-    .prose-sm pre {
+    .prose-sm :where(pre) {
       font-size: 0.8571429em;
       line-height: 1.6666667;
       margin-top: 1.6666667em;
@@ -518,218 +518,218 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1em;
     }
 
-    .prose-sm ol {
+    .prose-sm :where(ol) {
       margin-top: 1.1428571em;
       margin-bottom: 1.1428571em;
     }
 
-    .prose-sm ul {
+    .prose-sm :where(ul) {
       margin-top: 1.1428571em;
       margin-bottom: 1.1428571em;
     }
 
-    .prose-sm li {
+    .prose-sm :where(li) {
       margin-top: 0.2857143em;
       margin-bottom: 0.2857143em;
     }
 
-    .prose-sm ol > li {
+    .prose-sm :where(ol > li) {
       padding-left: 1.5714286em;
     }
 
-    .prose-sm ol > li::before {
+    .prose-sm :where(ol > li::before) {
       left: 0;
     }
 
-    .prose-sm ul > li {
+    .prose-sm :where(ul > li) {
       padding-left: 1.5714286em;
     }
 
-    .prose-sm ul > li::before {
+    .prose-sm :where(ul > li::before) {
       height: 0.3571429em;
       width: 0.3571429em;
       top: calc(0.8571429em - 0.1785714em);
       left: 0.2142857em;
     }
 
-    .prose-sm > ul > li p {
+    .prose-sm :where(> ul > li p) {
       margin-top: 0.5714286em;
       margin-bottom: 0.5714286em;
     }
 
-    .prose-sm > ul > li > *:first-child {
+    .prose-sm :where(> ul > li > *:first-child) {
       margin-top: 1.1428571em;
     }
 
-    .prose-sm > ul > li > *:last-child {
+    .prose-sm :where(> ul > li > *:last-child) {
       margin-bottom: 1.1428571em;
     }
 
-    .prose-sm > ol > li > *:first-child {
+    .prose-sm :where(> ol > li > *:first-child) {
       margin-top: 1.1428571em;
     }
 
-    .prose-sm > ol > li > *:last-child {
+    .prose-sm :where(> ol > li > *:last-child) {
       margin-bottom: 1.1428571em;
     }
 
-    .prose-sm ul ul, .prose-sm ul ol, .prose-sm ol ul, .prose-sm ol ol {
+    .prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       margin-top: 0.5714286em;
       margin-bottom: 0.5714286em;
     }
 
-    .prose-sm hr {
+    .prose-sm :where(hr) {
       margin-top: 2.8571429em;
       margin-bottom: 2.8571429em;
     }
 
-    .prose-sm hr + * {
+    .prose-sm :where(hr + *) {
       margin-top: 0;
     }
 
-    .prose-sm h2 + * {
+    .prose-sm :where(h2 + *) {
       margin-top: 0;
     }
 
-    .prose-sm h3 + * {
+    .prose-sm :where(h3 + *) {
       margin-top: 0;
     }
 
-    .prose-sm h4 + * {
+    .prose-sm :where(h4 + *) {
       margin-top: 0;
     }
 
-    .prose-sm table {
+    .prose-sm :where(table) {
       font-size: 0.8571429em;
       line-height: 1.5;
     }
 
-    .prose-sm thead th {
+    .prose-sm :where(thead th) {
       padding-right: 1em;
       padding-bottom: 0.6666667em;
       padding-left: 1em;
     }
 
-    .prose-sm thead th:first-child {
+    .prose-sm :where(thead th:first-child) {
       padding-left: 0;
     }
 
-    .prose-sm thead th:last-child {
+    .prose-sm :where(thead th:last-child) {
       padding-right: 0;
     }
 
-    .prose-sm tbody td {
+    .prose-sm :where(tbody td) {
       padding-top: 0.6666667em;
       padding-right: 1em;
       padding-bottom: 0.6666667em;
       padding-left: 1em;
     }
 
-    .prose-sm tbody td:first-child {
+    .prose-sm :where(tbody td:first-child) {
       padding-left: 0;
     }
 
-    .prose-sm tbody td:last-child {
+    .prose-sm :where(tbody td:last-child) {
       padding-right: 0;
     }
 
-    .prose-sm > :first-child {
+    .prose-sm :where(> :first-child) {
       margin-top: 0;
     }
 
-    .prose-sm > :last-child {
+    .prose-sm :where(> :last-child) {
       margin-bottom: 0;
     }
 
     .prose-lg {
-      font-size: 1.125rem;
-      line-height: 1.7777778;
+      :where(font-size): 1.125rem;
+      :where(line-height): 1.7777778;
     }
 
-    .prose-lg p {
+    .prose-lg :where(p) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-lg [class~=\\"lead\\"] {
+    .prose-lg :where([class~=\\"lead\\"]) {
       font-size: 1.2222222em;
       line-height: 1.4545455;
       margin-top: 1.0909091em;
       margin-bottom: 1.0909091em;
     }
 
-    .prose-lg blockquote {
+    .prose-lg :where(blockquote) {
       margin-top: 1.6666667em;
       margin-bottom: 1.6666667em;
       padding-left: 1em;
     }
 
-    .prose-lg h1 {
+    .prose-lg :where(h1) {
       font-size: 2.6666667em;
       margin-top: 0;
       margin-bottom: 0.8333333em;
       line-height: 1;
     }
 
-    .prose-lg h2 {
+    .prose-lg :where(h2) {
       font-size: 1.6666667em;
       margin-top: 1.8666667em;
       margin-bottom: 1.0666667em;
       line-height: 1.3333333;
     }
 
-    .prose-lg h3 {
+    .prose-lg :where(h3) {
       font-size: 1.3333333em;
       margin-top: 1.6666667em;
       margin-bottom: 0.6666667em;
       line-height: 1.5;
     }
 
-    .prose-lg h4 {
+    .prose-lg :where(h4) {
       margin-top: 1.7777778em;
       margin-bottom: 0.4444444em;
       line-height: 1.5555556;
     }
 
-    .prose-lg img {
+    .prose-lg :where(img) {
       margin-top: 1.7777778em;
       margin-bottom: 1.7777778em;
     }
 
-    .prose-lg video {
+    .prose-lg :where(video) {
       margin-top: 1.7777778em;
       margin-bottom: 1.7777778em;
     }
 
-    .prose-lg figure {
+    .prose-lg :where(figure) {
       margin-top: 1.7777778em;
       margin-bottom: 1.7777778em;
     }
 
-    .prose-lg figure > * {
+    .prose-lg :where(figure > *) {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .prose-lg figure figcaption {
+    .prose-lg :where(figure figcaption) {
       font-size: 0.8888889em;
       line-height: 1.5;
       margin-top: 1em;
     }
 
-    .prose-lg code {
+    .prose-lg :where(code) {
       font-size: 0.8888889em;
     }
 
-    .prose-lg h2 code {
+    .prose-lg :where(h2 code) {
       font-size: 0.8666667em;
     }
 
-    .prose-lg h3 code {
+    .prose-lg :where(h3 code) {
       font-size: 0.875em;
     }
 
-    .prose-lg pre {
+    .prose-lg :where(pre) {
       font-size: 0.8888889em;
       line-height: 1.75;
       margin-top: 2em;
@@ -741,218 +741,218 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.5em;
     }
 
-    .prose-lg ol {
+    .prose-lg :where(ol) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-lg ul {
+    .prose-lg :where(ul) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-lg li {
+    .prose-lg :where(li) {
       margin-top: 0.6666667em;
       margin-bottom: 0.6666667em;
     }
 
-    .prose-lg ol > li {
+    .prose-lg :where(ol > li) {
       padding-left: 1.6666667em;
     }
 
-    .prose-lg ol > li::before {
+    .prose-lg :where(ol > li::before) {
       left: 0;
     }
 
-    .prose-lg ul > li {
+    .prose-lg :where(ul > li) {
       padding-left: 1.6666667em;
     }
 
-    .prose-lg ul > li::before {
+    .prose-lg :where(ul > li::before) {
       width: 0.3333333em;
       height: 0.3333333em;
       top: calc(0.8888889em - 0.1666667em);
       left: 0.2222222em;
     }
 
-    .prose-lg > ul > li p {
+    .prose-lg :where(> ul > li p) {
       margin-top: 0.8888889em;
       margin-bottom: 0.8888889em;
     }
 
-    .prose-lg > ul > li > *:first-child {
+    .prose-lg :where(> ul > li > *:first-child) {
       margin-top: 1.3333333em;
     }
 
-    .prose-lg > ul > li > *:last-child {
+    .prose-lg :where(> ul > li > *:last-child) {
       margin-bottom: 1.3333333em;
     }
 
-    .prose-lg > ol > li > *:first-child {
+    .prose-lg :where(> ol > li > *:first-child) {
       margin-top: 1.3333333em;
     }
 
-    .prose-lg > ol > li > *:last-child {
+    .prose-lg :where(> ol > li > *:last-child) {
       margin-bottom: 1.3333333em;
     }
 
-    .prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
+    .prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
       margin-top: 0.8888889em;
       margin-bottom: 0.8888889em;
     }
 
-    .prose-lg hr {
+    .prose-lg :where(hr) {
       margin-top: 3.1111111em;
       margin-bottom: 3.1111111em;
     }
 
-    .prose-lg hr + * {
+    .prose-lg :where(hr + *) {
       margin-top: 0;
     }
 
-    .prose-lg h2 + * {
+    .prose-lg :where(h2 + *) {
       margin-top: 0;
     }
 
-    .prose-lg h3 + * {
+    .prose-lg :where(h3 + *) {
       margin-top: 0;
     }
 
-    .prose-lg h4 + * {
+    .prose-lg :where(h4 + *) {
       margin-top: 0;
     }
 
-    .prose-lg table {
+    .prose-lg :where(table) {
       font-size: 0.8888889em;
       line-height: 1.5;
     }
 
-    .prose-lg thead th {
+    .prose-lg :where(thead th) {
       padding-right: 0.75em;
       padding-bottom: 0.75em;
       padding-left: 0.75em;
     }
 
-    .prose-lg thead th:first-child {
+    .prose-lg :where(thead th:first-child) {
       padding-left: 0;
     }
 
-    .prose-lg thead th:last-child {
+    .prose-lg :where(thead th:last-child) {
       padding-right: 0;
     }
 
-    .prose-lg tbody td {
+    .prose-lg :where(tbody td) {
       padding-top: 0.75em;
       padding-right: 0.75em;
       padding-bottom: 0.75em;
       padding-left: 0.75em;
     }
 
-    .prose-lg tbody td:first-child {
+    .prose-lg :where(tbody td:first-child) {
       padding-left: 0;
     }
 
-    .prose-lg tbody td:last-child {
+    .prose-lg :where(tbody td:last-child) {
       padding-right: 0;
     }
 
-    .prose-lg > :first-child {
+    .prose-lg :where(> :first-child) {
       margin-top: 0;
     }
 
-    .prose-lg > :last-child {
+    .prose-lg :where(> :last-child) {
       margin-bottom: 0;
     }
 
     .prose-xl {
-      font-size: 1.25rem;
-      line-height: 1.8;
+      :where(font-size): 1.25rem;
+      :where(line-height): 1.8;
     }
 
-    .prose-xl p {
+    .prose-xl :where(p) {
       margin-top: 1.2em;
       margin-bottom: 1.2em;
     }
 
-    .prose-xl [class~=\\"lead\\"] {
+    .prose-xl :where([class~=\\"lead\\"]) {
       font-size: 1.2em;
       line-height: 1.5;
       margin-top: 1em;
       margin-bottom: 1em;
     }
 
-    .prose-xl blockquote {
+    .prose-xl :where(blockquote) {
       margin-top: 1.6em;
       margin-bottom: 1.6em;
       padding-left: 1.0666667em;
     }
 
-    .prose-xl h1 {
+    .prose-xl :where(h1) {
       font-size: 2.8em;
       margin-top: 0;
       margin-bottom: 0.8571429em;
       line-height: 1;
     }
 
-    .prose-xl h2 {
+    .prose-xl :where(h2) {
       font-size: 1.8em;
       margin-top: 1.5555556em;
       margin-bottom: 0.8888889em;
       line-height: 1.1111111;
     }
 
-    .prose-xl h3 {
+    .prose-xl :where(h3) {
       font-size: 1.5em;
       margin-top: 1.6em;
       margin-bottom: 0.6666667em;
       line-height: 1.3333333;
     }
 
-    .prose-xl h4 {
+    .prose-xl :where(h4) {
       margin-top: 1.8em;
       margin-bottom: 0.6em;
       line-height: 1.6;
     }
 
-    .prose-xl img {
+    .prose-xl :where(img) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-xl video {
+    .prose-xl :where(video) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-xl figure {
+    .prose-xl :where(figure) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-xl figure > * {
+    .prose-xl :where(figure > *) {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .prose-xl figure figcaption {
+    .prose-xl :where(figure figcaption) {
       font-size: 0.9em;
       line-height: 1.5555556;
       margin-top: 1em;
     }
 
-    .prose-xl code {
+    .prose-xl :where(code) {
       font-size: 0.9em;
     }
 
-    .prose-xl h2 code {
+    .prose-xl :where(h2 code) {
       font-size: 0.8611111em;
     }
 
-    .prose-xl h3 code {
+    .prose-xl :where(h3 code) {
       font-size: 0.9em;
     }
 
-    .prose-xl pre {
+    .prose-xl :where(pre) {
       font-size: 0.9em;
       line-height: 1.7777778;
       margin-top: 2em;
@@ -964,218 +964,218 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.3333333em;
     }
 
-    .prose-xl ol {
+    .prose-xl :where(ol) {
       margin-top: 1.2em;
       margin-bottom: 1.2em;
     }
 
-    .prose-xl ul {
+    .prose-xl :where(ul) {
       margin-top: 1.2em;
       margin-bottom: 1.2em;
     }
 
-    .prose-xl li {
+    .prose-xl :where(li) {
       margin-top: 0.6em;
       margin-bottom: 0.6em;
     }
 
-    .prose-xl ol > li {
+    .prose-xl :where(ol > li) {
       padding-left: 1.8em;
     }
 
-    .prose-xl ol > li::before {
+    .prose-xl :where(ol > li::before) {
       left: 0;
     }
 
-    .prose-xl ul > li {
+    .prose-xl :where(ul > li) {
       padding-left: 1.8em;
     }
 
-    .prose-xl ul > li::before {
+    .prose-xl :where(ul > li::before) {
       width: 0.35em;
       height: 0.35em;
       top: calc(0.9em - 0.175em);
       left: 0.25em;
     }
 
-    .prose-xl > ul > li p {
+    .prose-xl :where(> ul > li p) {
       margin-top: 0.8em;
       margin-bottom: 0.8em;
     }
 
-    .prose-xl > ul > li > *:first-child {
+    .prose-xl :where(> ul > li > *:first-child) {
       margin-top: 1.2em;
     }
 
-    .prose-xl > ul > li > *:last-child {
+    .prose-xl :where(> ul > li > *:last-child) {
       margin-bottom: 1.2em;
     }
 
-    .prose-xl > ol > li > *:first-child {
+    .prose-xl :where(> ol > li > *:first-child) {
       margin-top: 1.2em;
     }
 
-    .prose-xl > ol > li > *:last-child {
+    .prose-xl :where(> ol > li > *:last-child) {
       margin-bottom: 1.2em;
     }
 
-    .prose-xl ul ul, .prose-xl ul ol, .prose-xl ol ul, .prose-xl ol ol {
+    .prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
       margin-top: 0.8em;
       margin-bottom: 0.8em;
     }
 
-    .prose-xl hr {
+    .prose-xl :where(hr) {
       margin-top: 2.8em;
       margin-bottom: 2.8em;
     }
 
-    .prose-xl hr + * {
+    .prose-xl :where(hr + *) {
       margin-top: 0;
     }
 
-    .prose-xl h2 + * {
+    .prose-xl :where(h2 + *) {
       margin-top: 0;
     }
 
-    .prose-xl h3 + * {
+    .prose-xl :where(h3 + *) {
       margin-top: 0;
     }
 
-    .prose-xl h4 + * {
+    .prose-xl :where(h4 + *) {
       margin-top: 0;
     }
 
-    .prose-xl table {
+    .prose-xl :where(table) {
       font-size: 0.9em;
       line-height: 1.5555556;
     }
 
-    .prose-xl thead th {
+    .prose-xl :where(thead th) {
       padding-right: 0.6666667em;
       padding-bottom: 0.8888889em;
       padding-left: 0.6666667em;
     }
 
-    .prose-xl thead th:first-child {
+    .prose-xl :where(thead th:first-child) {
       padding-left: 0;
     }
 
-    .prose-xl thead th:last-child {
+    .prose-xl :where(thead th:last-child) {
       padding-right: 0;
     }
 
-    .prose-xl tbody td {
+    .prose-xl :where(tbody td) {
       padding-top: 0.8888889em;
       padding-right: 0.6666667em;
       padding-bottom: 0.8888889em;
       padding-left: 0.6666667em;
     }
 
-    .prose-xl tbody td:first-child {
+    .prose-xl :where(tbody td:first-child) {
       padding-left: 0;
     }
 
-    .prose-xl tbody td:last-child {
+    .prose-xl :where(tbody td:last-child) {
       padding-right: 0;
     }
 
-    .prose-xl > :first-child {
+    .prose-xl :where(> :first-child) {
       margin-top: 0;
     }
 
-    .prose-xl > :last-child {
+    .prose-xl :where(> :last-child) {
       margin-bottom: 0;
     }
 
     .prose-2xl {
-      font-size: 1.5rem;
-      line-height: 1.6666667;
+      :where(font-size): 1.5rem;
+      :where(line-height): 1.6666667;
     }
 
-    .prose-2xl p {
+    .prose-2xl :where(p) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-2xl [class~=\\"lead\\"] {
+    .prose-2xl :where([class~=\\"lead\\"]) {
       font-size: 1.25em;
       line-height: 1.4666667;
       margin-top: 1.0666667em;
       margin-bottom: 1.0666667em;
     }
 
-    .prose-2xl blockquote {
+    .prose-2xl :where(blockquote) {
       margin-top: 1.7777778em;
       margin-bottom: 1.7777778em;
       padding-left: 1.1111111em;
     }
 
-    .prose-2xl h1 {
+    .prose-2xl :where(h1) {
       font-size: 2.6666667em;
       margin-top: 0;
       margin-bottom: 0.875em;
       line-height: 1;
     }
 
-    .prose-2xl h2 {
+    .prose-2xl :where(h2) {
       font-size: 2em;
       margin-top: 1.5em;
       margin-bottom: 0.8333333em;
       line-height: 1.0833333;
     }
 
-    .prose-2xl h3 {
+    .prose-2xl :where(h3) {
       font-size: 1.5em;
       margin-top: 1.5555556em;
       margin-bottom: 0.6666667em;
       line-height: 1.2222222;
     }
 
-    .prose-2xl h4 {
+    .prose-2xl :where(h4) {
       margin-top: 1.6666667em;
       margin-bottom: 0.6666667em;
       line-height: 1.5;
     }
 
-    .prose-2xl img {
+    .prose-2xl :where(img) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-2xl video {
+    .prose-2xl :where(video) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-2xl figure {
+    .prose-2xl :where(figure) {
       margin-top: 2em;
       margin-bottom: 2em;
     }
 
-    .prose-2xl figure > * {
+    .prose-2xl :where(figure > *) {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .prose-2xl figure figcaption {
+    .prose-2xl :where(figure figcaption) {
       font-size: 0.8333333em;
       line-height: 1.6;
       margin-top: 1em;
     }
 
-    .prose-2xl code {
+    .prose-2xl :where(code) {
       font-size: 0.8333333em;
     }
 
-    .prose-2xl h2 code {
+    .prose-2xl :where(h2 code) {
       font-size: 0.875em;
     }
 
-    .prose-2xl h3 code {
+    .prose-2xl :where(h3 code) {
       font-size: 0.8888889em;
     }
 
-    .prose-2xl pre {
+    .prose-2xl :where(pre) {
       font-size: 0.8333333em;
       line-height: 1.8;
       margin-top: 2em;
@@ -1187,192 +1187,192 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.6em;
     }
 
-    .prose-2xl ol {
+    .prose-2xl :where(ol) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-2xl ul {
+    .prose-2xl :where(ul) {
       margin-top: 1.3333333em;
       margin-bottom: 1.3333333em;
     }
 
-    .prose-2xl li {
+    .prose-2xl :where(li) {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
     }
 
-    .prose-2xl ol > li {
+    .prose-2xl :where(ol > li) {
       padding-left: 1.6666667em;
     }
 
-    .prose-2xl ol > li::before {
+    .prose-2xl :where(ol > li::before) {
       left: 0;
     }
 
-    .prose-2xl ul > li {
+    .prose-2xl :where(ul > li) {
       padding-left: 1.6666667em;
     }
 
-    .prose-2xl ul > li::before {
+    .prose-2xl :where(ul > li::before) {
       width: 0.3333333em;
       height: 0.3333333em;
       top: calc(0.8333333em - 0.1666667em);
       left: 0.25em;
     }
 
-    .prose-2xl > ul > li p {
+    .prose-2xl :where(> ul > li p) {
       margin-top: 0.8333333em;
       margin-bottom: 0.8333333em;
     }
 
-    .prose-2xl > ul > li > *:first-child {
+    .prose-2xl :where(> ul > li > *:first-child) {
       margin-top: 1.3333333em;
     }
 
-    .prose-2xl > ul > li > *:last-child {
+    .prose-2xl :where(> ul > li > *:last-child) {
       margin-bottom: 1.3333333em;
     }
 
-    .prose-2xl > ol > li > *:first-child {
+    .prose-2xl :where(> ol > li > *:first-child) {
       margin-top: 1.3333333em;
     }
 
-    .prose-2xl > ol > li > *:last-child {
+    .prose-2xl :where(> ol > li > *:last-child) {
       margin-bottom: 1.3333333em;
     }
 
-    .prose-2xl ul ul, .prose-2xl ul ol, .prose-2xl ol ul, .prose-2xl ol ol {
+    .prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       margin-top: 0.6666667em;
       margin-bottom: 0.6666667em;
     }
 
-    .prose-2xl hr {
+    .prose-2xl :where(hr) {
       margin-top: 3em;
       margin-bottom: 3em;
     }
 
-    .prose-2xl hr + * {
+    .prose-2xl :where(hr + *) {
       margin-top: 0;
     }
 
-    .prose-2xl h2 + * {
+    .prose-2xl :where(h2 + *) {
       margin-top: 0;
     }
 
-    .prose-2xl h3 + * {
+    .prose-2xl :where(h3 + *) {
       margin-top: 0;
     }
 
-    .prose-2xl h4 + * {
+    .prose-2xl :where(h4 + *) {
       margin-top: 0;
     }
 
-    .prose-2xl table {
+    .prose-2xl :where(table) {
       font-size: 0.8333333em;
       line-height: 1.4;
     }
 
-    .prose-2xl thead th {
+    .prose-2xl :where(thead th) {
       padding-right: 0.6em;
       padding-bottom: 0.8em;
       padding-left: 0.6em;
     }
 
-    .prose-2xl thead th:first-child {
+    .prose-2xl :where(thead th:first-child) {
       padding-left: 0;
     }
 
-    .prose-2xl thead th:last-child {
+    .prose-2xl :where(thead th:last-child) {
       padding-right: 0;
     }
 
-    .prose-2xl tbody td {
+    .prose-2xl :where(tbody td) {
       padding-top: 0.8em;
       padding-right: 0.6em;
       padding-bottom: 0.8em;
       padding-left: 0.6em;
     }
 
-    .prose-2xl tbody td:first-child {
+    .prose-2xl :where(tbody td:first-child) {
       padding-left: 0;
     }
 
-    .prose-2xl tbody td:last-child {
+    .prose-2xl :where(tbody td:last-child) {
       padding-right: 0;
     }
 
-    .prose-2xl > :first-child {
+    .prose-2xl :where(> :first-child) {
       margin-top: 0;
     }
 
-    .prose-2xl > :last-child {
+    .prose-2xl :where(> :last-child) {
       margin-bottom: 0;
     }
 
-    .prose-red a {
+    .prose-red :where(a) {
       color: #dc2626;
     }
 
-    .prose-red a code {
+    .prose-red :where(a code) {
       color: #dc2626;
     }
 
-    .prose-yellow a {
+    .prose-yellow :where(a) {
       color: #d97706;
     }
 
-    .prose-yellow a code {
+    .prose-yellow :where(a code) {
       color: #d97706;
     }
 
-    .prose-green a {
+    .prose-green :where(a) {
       color: #059669;
     }
 
-    .prose-green a code {
+    .prose-green :where(a code) {
       color: #059669;
     }
 
-    .prose-blue a {
+    .prose-blue :where(a) {
       color: #2563eb;
     }
 
-    .prose-blue a code {
+    .prose-blue :where(a code) {
       color: #2563eb;
     }
 
-    .prose-indigo a {
+    .prose-indigo :where(a) {
       color: #4f46e5;
     }
 
-    .prose-indigo a code {
+    .prose-indigo :where(a code) {
       color: #4f46e5;
     }
 
-    .prose-purple a {
+    .prose-purple :where(a) {
       color: #7c3aed;
     }
 
-    .prose-purple a code {
+    .prose-purple :where(a code) {
       color: #7c3aed;
     }
 
-    .prose-pink a {
+    .prose-pink :where(a) {
       color: #db2777;
     }
 
-    .prose-pink a code {
+    .prose-pink :where(a code) {
       color: #db2777;
     }
 
     @media (min-width: 640px) {
       .sm\\\\:prose {
-        color: #374151;
-        max-width: 65ch;
+        :where(color): #374151;
+        :where(max-width): 65ch;
       }
 
-      .sm\\\\:prose [class~=\\"lead\\"] {
+      .sm\\\\:prose :where([class~=\\"lead\\"]) {
         color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
@@ -1380,59 +1380,59 @@ it('should generate the default classes for the typography components', async ()
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose a {
+      .sm\\\\:prose :where(a) {
         color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
-      .sm\\\\:prose strong {
+      .sm\\\\:prose :where(strong) {
         color: #111827;
         font-weight: 600;
       }
 
-      .sm\\\\:prose ol[type=\\"A\\"] {
+      .sm\\\\:prose :where(ol[type=\\"A\\"]) {
         --list-counter-style: upper-alpha;
       }
 
-      .sm\\\\:prose ol[type=\\"a\\"] {
+      .sm\\\\:prose :where(ol[type=\\"a\\"]) {
         --list-counter-style: lower-alpha;
       }
 
-      .sm\\\\:prose ol[type=\\"A\\" s] {
+      .sm\\\\:prose :where(ol[type=\\"A\\" s]) {
         --list-counter-style: upper-alpha;
       }
 
-      .sm\\\\:prose ol[type=\\"a\\" s] {
+      .sm\\\\:prose :where(ol[type=\\"a\\" s]) {
         --list-counter-style: lower-alpha;
       }
 
-      .sm\\\\:prose ol[type=\\"I\\"] {
+      .sm\\\\:prose :where(ol[type=\\"I\\"]) {
         --list-counter-style: upper-roman;
       }
 
-      .sm\\\\:prose ol[type=\\"i\\"] {
+      .sm\\\\:prose :where(ol[type=\\"i\\"]) {
         --list-counter-style: lower-roman;
       }
 
-      .sm\\\\:prose ol[type=\\"I\\" s] {
+      .sm\\\\:prose :where(ol[type=\\"I\\" s]) {
         --list-counter-style: upper-roman;
       }
 
-      .sm\\\\:prose ol[type=\\"i\\" s] {
+      .sm\\\\:prose :where(ol[type=\\"i\\" s]) {
         --list-counter-style: lower-roman;
       }
 
-      .sm\\\\:prose ol[type=\\"1\\"] {
+      .sm\\\\:prose :where(ol[type=\\"1\\"]) {
         --list-counter-style: decimal;
       }
 
-      .sm\\\\:prose ol > li {
+      .sm\\\\:prose :where(ol > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .sm\\\\:prose ol > li::before {
+      .sm\\\\:prose :where(ol > li::before) {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -1440,12 +1440,12 @@ it('should generate the default classes for the typography components', async ()
         left: 0;
       }
 
-      .sm\\\\:prose ul > li {
+      .sm\\\\:prose :where(ul > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .sm\\\\:prose ul > li::before {
+      .sm\\\\:prose :where(ul > li::before) {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -1456,14 +1456,14 @@ it('should generate the default classes for the typography components', async ()
         left: 0.25em;
       }
 
-      .sm\\\\:prose hr {
+      .sm\\\\:prose :where(hr) {
         border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .sm\\\\:prose blockquote {
+      .sm\\\\:prose :where(blockquote) {
         font-weight: 500;
         font-style: italic;
         color: #111827;
@@ -1475,15 +1475,15 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .sm\\\\:prose blockquote p:first-of-type::before {
+      .sm\\\\:prose :where(blockquote p:first-of-type::before) {
         content: open-quote;
       }
 
-      .sm\\\\:prose blockquote p:last-of-type::after {
+      .sm\\\\:prose :where(blockquote p:last-of-type::after) {
         content: close-quote;
       }
 
-      .sm\\\\:prose h1 {
+      .sm\\\\:prose :where(h1) {
         color: #111827;
         font-weight: 800;
         font-size: 2.25em;
@@ -1492,11 +1492,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.1111111;
       }
 
-      .sm\\\\:prose h1 strong {
+      .sm\\\\:prose :where(h1 strong) {
         font-weight: 900;
       }
 
-      .sm\\\\:prose h2 {
+      .sm\\\\:prose :where(h2) {
         color: #111827;
         font-weight: 700;
         font-size: 1.5em;
@@ -1505,11 +1505,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.3333333;
       }
 
-      .sm\\\\:prose h2 strong {
+      .sm\\\\:prose :where(h2 strong) {
         font-weight: 800;
       }
 
-      .sm\\\\:prose h3 {
+      .sm\\\\:prose :where(h3) {
         color: #111827;
         font-weight: 600;
         font-size: 1.25em;
@@ -1518,11 +1518,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.6;
       }
 
-      .sm\\\\:prose h3 strong {
+      .sm\\\\:prose :where(h3 strong) {
         font-weight: 700;
       }
 
-      .sm\\\\:prose h4 {
+      .sm\\\\:prose :where(h4) {
         color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
@@ -1530,36 +1530,36 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.5;
       }
 
-      .sm\\\\:prose h4 strong {
+      .sm\\\\:prose :where(h4 strong) {
         font-weight: 700;
       }
 
-      .sm\\\\:prose figure figcaption {
+      .sm\\\\:prose :where(figure figcaption) {
         color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
-      .sm\\\\:prose code {
+      .sm\\\\:prose :where(code) {
         color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
 
-      .sm\\\\:prose code::before {
+      .sm\\\\:prose :where(code::before) {
         content: \\"\`\\";
       }
 
-      .sm\\\\:prose code::after {
+      .sm\\\\:prose :where(code::after) {
         content: \\"\`\\";
       }
 
-      .sm\\\\:prose a code {
+      .sm\\\\:prose :where(a code) {
         color: #111827;
       }
 
-      .sm\\\\:prose pre {
+      .sm\\\\:prose :where(pre) {
         color: #e5e7eb;
         background-color: #1f2937;
         overflow-x: auto;
@@ -1574,7 +1574,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.1428571em;
       }
 
-      .sm\\\\:prose pre code {
+      .sm\\\\:prose :where(pre code) {
         background-color: transparent;
         border-width: 0;
         border-radius: 0;
@@ -1586,15 +1586,15 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .sm\\\\:prose pre code::before {
+      .sm\\\\:prose :where(pre code::before) {
         content: none;
       }
 
-      .sm\\\\:prose pre code::after {
+      .sm\\\\:prose :where(pre code::after) {
         content: none;
       }
 
-      .sm\\\\:prose table {
+      .sm\\\\:prose :where(table) {
         width: 100%;
         table-layout: auto;
         text-align: left;
@@ -1604,30 +1604,30 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.7142857;
       }
 
-      .sm\\\\:prose thead {
+      .sm\\\\:prose :where(thead) {
         color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
         border-bottom-color: #d1d5db;
       }
 
-      .sm\\\\:prose thead th {
+      .sm\\\\:prose :where(thead th) {
         vertical-align: bottom;
         padding-right: 0.5714286em;
         padding-bottom: 0.5714286em;
         padding-left: 0.5714286em;
       }
 
-      .sm\\\\:prose tbody tr {
+      .sm\\\\:prose :where(tbody tr) {
         border-bottom-width: 1px;
         border-bottom-color: #e5e7eb;
       }
 
-      .sm\\\\:prose tbody tr:last-child {
+      .sm\\\\:prose :where(tbody tr:last-child) {
         border-bottom-width: 0;
       }
 
-      .sm\\\\:prose tbody td {
+      .sm\\\\:prose :where(tbody td) {
         vertical-align: top;
         padding-top: 0.5714286em;
         padding-right: 0.5714286em;
@@ -1636,213 +1636,213 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose {
-        font-size: 1rem;
-        line-height: 1.75;
+        :where(font-size): 1rem;
+        :where(line-height): 1.75;
       }
 
-      .sm\\\\:prose p {
+      .sm\\\\:prose :where(p) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .sm\\\\:prose img {
+      .sm\\\\:prose :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose video {
+      .sm\\\\:prose :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose figure {
+      .sm\\\\:prose :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose figure > * {
+      .sm\\\\:prose :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose h2 code {
+      .sm\\\\:prose :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .sm\\\\:prose h3 code {
+      .sm\\\\:prose :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .sm\\\\:prose ol {
+      .sm\\\\:prose :where(ol) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .sm\\\\:prose ul {
+      .sm\\\\:prose :where(ul) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .sm\\\\:prose li {
+      .sm\\\\:prose :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .sm\\\\:prose > ul > li p {
+      .sm\\\\:prose :where(> ul > li p) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .sm\\\\:prose > ul > li > *:first-child {
+      .sm\\\\:prose :where(> ul > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .sm\\\\:prose > ul > li > *:last-child {
+      .sm\\\\:prose :where(> ul > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .sm\\\\:prose > ol > li > *:first-child {
+      .sm\\\\:prose :where(> ol > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .sm\\\\:prose > ol > li > *:last-child {
+      .sm\\\\:prose :where(> ol > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .sm\\\\:prose ul ul, .sm\\\\:prose ul ol, .sm\\\\:prose ol ul, .sm\\\\:prose ol ol {
+      .sm\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .sm\\\\:prose hr + * {
+      .sm\\\\:prose :where(hr + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose h2 + * {
+      .sm\\\\:prose :where(h2 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose h3 + * {
+      .sm\\\\:prose :where(h3 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose h4 + * {
+      .sm\\\\:prose :where(h4 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose thead th:first-child {
+      .sm\\\\:prose :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose thead th:last-child {
+      .sm\\\\:prose :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose tbody td:first-child {
+      .sm\\\\:prose :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose tbody td:last-child {
+      .sm\\\\:prose :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose > :first-child {
+      .sm\\\\:prose :where(> :first-child) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose > :last-child {
+      .sm\\\\:prose :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .sm\\\\:prose-sm {
-        font-size: 0.875rem;
-        line-height: 1.7142857;
+        :where(font-size): 0.875rem;
+        :where(line-height): 1.7142857;
       }
 
-      .sm\\\\:prose-sm p {
+      .sm\\\\:prose-sm :where(p) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm [class~=\\"lead\\"] {
+      .sm\\\\:prose-sm :where([class~=\\"lead\\"]) {
         font-size: 1.2857143em;
         line-height: 1.5555556;
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .sm\\\\:prose-sm blockquote {
+      .sm\\\\:prose-sm :where(blockquote) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
         padding-left: 1.1111111em;
       }
 
-      .sm\\\\:prose-sm h1 {
+      .sm\\\\:prose-sm :where(h1) {
         font-size: 2.1428571em;
         margin-top: 0;
         margin-bottom: 0.8em;
         line-height: 1.2;
       }
 
-      .sm\\\\:prose-sm h2 {
+      .sm\\\\:prose-sm :where(h2) {
         font-size: 1.4285714em;
         margin-top: 1.6em;
         margin-bottom: 0.8em;
         line-height: 1.4;
       }
 
-      .sm\\\\:prose-sm h3 {
+      .sm\\\\:prose-sm :where(h3) {
         font-size: 1.2857143em;
         margin-top: 1.5555556em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .sm\\\\:prose-sm h4 {
+      .sm\\\\:prose-sm :where(h4) {
         margin-top: 1.4285714em;
         margin-bottom: 0.5714286em;
         line-height: 1.4285714;
       }
 
-      .sm\\\\:prose-sm img {
+      .sm\\\\:prose-sm :where(img) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .sm\\\\:prose-sm video {
+      .sm\\\\:prose-sm :where(video) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .sm\\\\:prose-sm figure {
+      .sm\\\\:prose-sm :where(figure) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .sm\\\\:prose-sm figure > * {
+      .sm\\\\:prose-sm :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose-sm figure figcaption {
+      .sm\\\\:prose-sm :where(figure figcaption) {
         font-size: 0.8571429em;
         line-height: 1.3333333;
         margin-top: 0.6666667em;
       }
 
-      .sm\\\\:prose-sm code {
+      .sm\\\\:prose-sm :where(code) {
         font-size: 0.8571429em;
       }
 
-      .sm\\\\:prose-sm h2 code {
+      .sm\\\\:prose-sm :where(h2 code) {
         font-size: 0.9em;
       }
 
-      .sm\\\\:prose-sm h3 code {
+      .sm\\\\:prose-sm :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .sm\\\\:prose-sm pre {
+      .sm\\\\:prose-sm :where(pre) {
         font-size: 0.8571429em;
         line-height: 1.6666667;
         margin-top: 1.6666667em;
@@ -1854,218 +1854,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .sm\\\\:prose-sm ol {
+      .sm\\\\:prose-sm :where(ol) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm ul {
+      .sm\\\\:prose-sm :where(ul) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm li {
+      .sm\\\\:prose-sm :where(li) {
         margin-top: 0.2857143em;
         margin-bottom: 0.2857143em;
       }
 
-      .sm\\\\:prose-sm ol > li {
+      .sm\\\\:prose-sm :where(ol > li) {
         padding-left: 1.5714286em;
       }
 
-      .sm\\\\:prose-sm ol > li::before {
+      .sm\\\\:prose-sm :where(ol > li::before) {
         left: 0;
       }
 
-      .sm\\\\:prose-sm ul > li {
+      .sm\\\\:prose-sm :where(ul > li) {
         padding-left: 1.5714286em;
       }
 
-      .sm\\\\:prose-sm ul > li::before {
+      .sm\\\\:prose-sm :where(ul > li::before) {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
         left: 0.2142857em;
       }
 
-      .sm\\\\:prose-sm > ul > li p {
+      .sm\\\\:prose-sm :where(> ul > li p) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .sm\\\\:prose-sm > ul > li > *:first-child {
+      .sm\\\\:prose-sm :where(> ul > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm > ul > li > *:last-child {
+      .sm\\\\:prose-sm :where(> ul > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm > ol > li > *:first-child {
+      .sm\\\\:prose-sm :where(> ol > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm > ol > li > *:last-child {
+      .sm\\\\:prose-sm :where(> ol > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .sm\\\\:prose-sm ul ul, .sm\\\\:prose-sm ul ol, .sm\\\\:prose-sm ol ul, .sm\\\\:prose-sm ol ol {
+      .sm\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .sm\\\\:prose-sm hr {
+      .sm\\\\:prose-sm :where(hr) {
         margin-top: 2.8571429em;
         margin-bottom: 2.8571429em;
       }
 
-      .sm\\\\:prose-sm hr + * {
+      .sm\\\\:prose-sm :where(hr + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-sm h2 + * {
+      .sm\\\\:prose-sm :where(h2 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-sm h3 + * {
+      .sm\\\\:prose-sm :where(h3 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-sm h4 + * {
+      .sm\\\\:prose-sm :where(h4 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-sm table {
+      .sm\\\\:prose-sm :where(table) {
         font-size: 0.8571429em;
         line-height: 1.5;
       }
 
-      .sm\\\\:prose-sm thead th {
+      .sm\\\\:prose-sm :where(thead th) {
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .sm\\\\:prose-sm thead th:first-child {
+      .sm\\\\:prose-sm :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-sm thead th:last-child {
+      .sm\\\\:prose-sm :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-sm tbody td {
+      .sm\\\\:prose-sm :where(tbody td) {
         padding-top: 0.6666667em;
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .sm\\\\:prose-sm tbody td:first-child {
+      .sm\\\\:prose-sm :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-sm tbody td:last-child {
+      .sm\\\\:prose-sm :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-sm > :first-child {
+      .sm\\\\:prose-sm :where(> :first-child) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-sm > :last-child {
+      .sm\\\\:prose-sm :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .sm\\\\:prose-lg {
-        font-size: 1.125rem;
-        line-height: 1.7777778;
+        :where(font-size): 1.125rem;
+        :where(line-height): 1.7777778;
       }
 
-      .sm\\\\:prose-lg p {
+      .sm\\\\:prose-lg :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg [class~=\\"lead\\"] {
+      .sm\\\\:prose-lg :where([class~=\\"lead\\"]) {
         font-size: 1.2222222em;
         line-height: 1.4545455;
         margin-top: 1.0909091em;
         margin-bottom: 1.0909091em;
       }
 
-      .sm\\\\:prose-lg blockquote {
+      .sm\\\\:prose-lg :where(blockquote) {
         margin-top: 1.6666667em;
         margin-bottom: 1.6666667em;
         padding-left: 1em;
       }
 
-      .sm\\\\:prose-lg h1 {
+      .sm\\\\:prose-lg :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.8333333em;
         line-height: 1;
       }
 
-      .sm\\\\:prose-lg h2 {
+      .sm\\\\:prose-lg :where(h2) {
         font-size: 1.6666667em;
         margin-top: 1.8666667em;
         margin-bottom: 1.0666667em;
         line-height: 1.3333333;
       }
 
-      .sm\\\\:prose-lg h3 {
+      .sm\\\\:prose-lg :where(h3) {
         font-size: 1.3333333em;
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .sm\\\\:prose-lg h4 {
+      .sm\\\\:prose-lg :where(h4) {
         margin-top: 1.7777778em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .sm\\\\:prose-lg img {
+      .sm\\\\:prose-lg :where(img) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .sm\\\\:prose-lg video {
+      .sm\\\\:prose-lg :where(video) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .sm\\\\:prose-lg figure {
+      .sm\\\\:prose-lg :where(figure) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .sm\\\\:prose-lg figure > * {
+      .sm\\\\:prose-lg :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose-lg figure figcaption {
+      .sm\\\\:prose-lg :where(figure figcaption) {
         font-size: 0.8888889em;
         line-height: 1.5;
         margin-top: 1em;
       }
 
-      .sm\\\\:prose-lg code {
+      .sm\\\\:prose-lg :where(code) {
         font-size: 0.8888889em;
       }
 
-      .sm\\\\:prose-lg h2 code {
+      .sm\\\\:prose-lg :where(h2 code) {
         font-size: 0.8666667em;
       }
 
-      .sm\\\\:prose-lg h3 code {
+      .sm\\\\:prose-lg :where(h3 code) {
         font-size: 0.875em;
       }
 
-      .sm\\\\:prose-lg pre {
+      .sm\\\\:prose-lg :where(pre) {
         font-size: 0.8888889em;
         line-height: 1.75;
         margin-top: 2em;
@@ -2077,218 +2077,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5em;
       }
 
-      .sm\\\\:prose-lg ol {
+      .sm\\\\:prose-lg :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg ul {
+      .sm\\\\:prose-lg :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg li {
+      .sm\\\\:prose-lg :where(li) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .sm\\\\:prose-lg ol > li {
+      .sm\\\\:prose-lg :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-lg ol > li::before {
+      .sm\\\\:prose-lg :where(ol > li::before) {
         left: 0;
       }
 
-      .sm\\\\:prose-lg ul > li {
+      .sm\\\\:prose-lg :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-lg ul > li::before {
+      .sm\\\\:prose-lg :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
         left: 0.2222222em;
       }
 
-      .sm\\\\:prose-lg > ul > li p {
+      .sm\\\\:prose-lg :where(> ul > li p) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .sm\\\\:prose-lg > ul > li > *:first-child {
+      .sm\\\\:prose-lg :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg > ul > li > *:last-child {
+      .sm\\\\:prose-lg :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg > ol > li > *:first-child {
+      .sm\\\\:prose-lg :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg > ol > li > *:last-child {
+      .sm\\\\:prose-lg :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-lg ul ul, .sm\\\\:prose-lg ul ol, .sm\\\\:prose-lg ol ul, .sm\\\\:prose-lg ol ol {
+      .sm\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .sm\\\\:prose-lg hr {
+      .sm\\\\:prose-lg :where(hr) {
         margin-top: 3.1111111em;
         margin-bottom: 3.1111111em;
       }
 
-      .sm\\\\:prose-lg hr + * {
+      .sm\\\\:prose-lg :where(hr + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-lg h2 + * {
+      .sm\\\\:prose-lg :where(h2 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-lg h3 + * {
+      .sm\\\\:prose-lg :where(h3 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-lg h4 + * {
+      .sm\\\\:prose-lg :where(h4 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-lg table {
+      .sm\\\\:prose-lg :where(table) {
         font-size: 0.8888889em;
         line-height: 1.5;
       }
 
-      .sm\\\\:prose-lg thead th {
+      .sm\\\\:prose-lg :where(thead th) {
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .sm\\\\:prose-lg thead th:first-child {
+      .sm\\\\:prose-lg :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-lg thead th:last-child {
+      .sm\\\\:prose-lg :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-lg tbody td {
+      .sm\\\\:prose-lg :where(tbody td) {
         padding-top: 0.75em;
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .sm\\\\:prose-lg tbody td:first-child {
+      .sm\\\\:prose-lg :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-lg tbody td:last-child {
+      .sm\\\\:prose-lg :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-lg > :first-child {
+      .sm\\\\:prose-lg :where(> :first-child) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-lg > :last-child {
+      .sm\\\\:prose-lg :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .sm\\\\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
+        :where(font-size): 1.25rem;
+        :where(line-height): 1.8;
       }
 
-      .sm\\\\:prose-xl p {
+      .sm\\\\:prose-xl :where(p) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose-xl [class~=\\"lead\\"] {
+      .sm\\\\:prose-xl :where([class~=\\"lead\\"]) {
         font-size: 1.2em;
         line-height: 1.5;
         margin-top: 1em;
         margin-bottom: 1em;
       }
 
-      .sm\\\\:prose-xl blockquote {
+      .sm\\\\:prose-xl :where(blockquote) {
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1.0666667em;
       }
 
-      .sm\\\\:prose-xl h1 {
+      .sm\\\\:prose-xl :where(h1) {
         font-size: 2.8em;
         margin-top: 0;
         margin-bottom: 0.8571429em;
         line-height: 1;
       }
 
-      .sm\\\\:prose-xl h2 {
+      .sm\\\\:prose-xl :where(h2) {
         font-size: 1.8em;
         margin-top: 1.5555556em;
         margin-bottom: 0.8888889em;
         line-height: 1.1111111;
       }
 
-      .sm\\\\:prose-xl h3 {
+      .sm\\\\:prose-xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.6em;
         margin-bottom: 0.6666667em;
         line-height: 1.3333333;
       }
 
-      .sm\\\\:prose-xl h4 {
+      .sm\\\\:prose-xl :where(h4) {
         margin-top: 1.8em;
         margin-bottom: 0.6em;
         line-height: 1.6;
       }
 
-      .sm\\\\:prose-xl img {
+      .sm\\\\:prose-xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-xl video {
+      .sm\\\\:prose-xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-xl figure {
+      .sm\\\\:prose-xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-xl figure > * {
+      .sm\\\\:prose-xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose-xl figure figcaption {
+      .sm\\\\:prose-xl :where(figure figcaption) {
         font-size: 0.9em;
         line-height: 1.5555556;
         margin-top: 1em;
       }
 
-      .sm\\\\:prose-xl code {
+      .sm\\\\:prose-xl :where(code) {
         font-size: 0.9em;
       }
 
-      .sm\\\\:prose-xl h2 code {
+      .sm\\\\:prose-xl :where(h2 code) {
         font-size: 0.8611111em;
       }
 
-      .sm\\\\:prose-xl h3 code {
+      .sm\\\\:prose-xl :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .sm\\\\:prose-xl pre {
+      .sm\\\\:prose-xl :where(pre) {
         font-size: 0.9em;
         line-height: 1.7777778;
         margin-top: 2em;
@@ -2300,218 +2300,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.3333333em;
       }
 
-      .sm\\\\:prose-xl ol {
+      .sm\\\\:prose-xl :where(ol) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose-xl ul {
+      .sm\\\\:prose-xl :where(ul) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose-xl li {
+      .sm\\\\:prose-xl :where(li) {
         margin-top: 0.6em;
         margin-bottom: 0.6em;
       }
 
-      .sm\\\\:prose-xl ol > li {
+      .sm\\\\:prose-xl :where(ol > li) {
         padding-left: 1.8em;
       }
 
-      .sm\\\\:prose-xl ol > li::before {
+      .sm\\\\:prose-xl :where(ol > li::before) {
         left: 0;
       }
 
-      .sm\\\\:prose-xl ul > li {
+      .sm\\\\:prose-xl :where(ul > li) {
         padding-left: 1.8em;
       }
 
-      .sm\\\\:prose-xl ul > li::before {
+      .sm\\\\:prose-xl :where(ul > li::before) {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
         left: 0.25em;
       }
 
-      .sm\\\\:prose-xl > ul > li p {
+      .sm\\\\:prose-xl :where(> ul > li p) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .sm\\\\:prose-xl > ul > li > *:first-child {
+      .sm\\\\:prose-xl :where(> ul > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .sm\\\\:prose-xl > ul > li > *:last-child {
+      .sm\\\\:prose-xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose-xl > ol > li > *:first-child {
+      .sm\\\\:prose-xl :where(> ol > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .sm\\\\:prose-xl > ol > li > *:last-child {
+      .sm\\\\:prose-xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .sm\\\\:prose-xl ul ul, .sm\\\\:prose-xl ul ol, .sm\\\\:prose-xl ol ul, .sm\\\\:prose-xl ol ol {
+      .sm\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .sm\\\\:prose-xl hr {
+      .sm\\\\:prose-xl :where(hr) {
         margin-top: 2.8em;
         margin-bottom: 2.8em;
       }
 
-      .sm\\\\:prose-xl hr + * {
+      .sm\\\\:prose-xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-xl h2 + * {
+      .sm\\\\:prose-xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-xl h3 + * {
+      .sm\\\\:prose-xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-xl h4 + * {
+      .sm\\\\:prose-xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-xl table {
+      .sm\\\\:prose-xl :where(table) {
         font-size: 0.9em;
         line-height: 1.5555556;
       }
 
-      .sm\\\\:prose-xl thead th {
+      .sm\\\\:prose-xl :where(thead th) {
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .sm\\\\:prose-xl thead th:first-child {
+      .sm\\\\:prose-xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-xl thead th:last-child {
+      .sm\\\\:prose-xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-xl tbody td {
+      .sm\\\\:prose-xl :where(tbody td) {
         padding-top: 0.8888889em;
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .sm\\\\:prose-xl tbody td:first-child {
+      .sm\\\\:prose-xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-xl tbody td:last-child {
+      .sm\\\\:prose-xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-xl > :first-child {
+      .sm\\\\:prose-xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-xl > :last-child {
+      .sm\\\\:prose-xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .sm\\\\:prose-2xl {
-        font-size: 1.5rem;
-        line-height: 1.6666667;
+        :where(font-size): 1.5rem;
+        :where(line-height): 1.6666667;
       }
 
-      .sm\\\\:prose-2xl p {
+      .sm\\\\:prose-2xl :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl [class~=\\"lead\\"] {
+      .sm\\\\:prose-2xl :where([class~=\\"lead\\"]) {
         font-size: 1.25em;
         line-height: 1.4666667;
         margin-top: 1.0666667em;
         margin-bottom: 1.0666667em;
       }
 
-      .sm\\\\:prose-2xl blockquote {
+      .sm\\\\:prose-2xl :where(blockquote) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
         padding-left: 1.1111111em;
       }
 
-      .sm\\\\:prose-2xl h1 {
+      .sm\\\\:prose-2xl :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.875em;
         line-height: 1;
       }
 
-      .sm\\\\:prose-2xl h2 {
+      .sm\\\\:prose-2xl :where(h2) {
         font-size: 2em;
         margin-top: 1.5em;
         margin-bottom: 0.8333333em;
         line-height: 1.0833333;
       }
 
-      .sm\\\\:prose-2xl h3 {
+      .sm\\\\:prose-2xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.5555556em;
         margin-bottom: 0.6666667em;
         line-height: 1.2222222;
       }
 
-      .sm\\\\:prose-2xl h4 {
+      .sm\\\\:prose-2xl :where(h4) {
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .sm\\\\:prose-2xl img {
+      .sm\\\\:prose-2xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-2xl video {
+      .sm\\\\:prose-2xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-2xl figure {
+      .sm\\\\:prose-2xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .sm\\\\:prose-2xl figure > * {
+      .sm\\\\:prose-2xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose-2xl figure figcaption {
+      .sm\\\\:prose-2xl :where(figure figcaption) {
         font-size: 0.8333333em;
         line-height: 1.6;
         margin-top: 1em;
       }
 
-      .sm\\\\:prose-2xl code {
+      .sm\\\\:prose-2xl :where(code) {
         font-size: 0.8333333em;
       }
 
-      .sm\\\\:prose-2xl h2 code {
+      .sm\\\\:prose-2xl :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .sm\\\\:prose-2xl h3 code {
+      .sm\\\\:prose-2xl :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .sm\\\\:prose-2xl pre {
+      .sm\\\\:prose-2xl :where(pre) {
         font-size: 0.8333333em;
         line-height: 1.8;
         margin-top: 2em;
@@ -2523,193 +2523,193 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6em;
       }
 
-      .sm\\\\:prose-2xl ol {
+      .sm\\\\:prose-2xl :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl ul {
+      .sm\\\\:prose-2xl :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl li {
+      .sm\\\\:prose-2xl :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .sm\\\\:prose-2xl ol > li {
+      .sm\\\\:prose-2xl :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-2xl ol > li::before {
+      .sm\\\\:prose-2xl :where(ol > li::before) {
         left: 0;
       }
 
-      .sm\\\\:prose-2xl ul > li {
+      .sm\\\\:prose-2xl :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-2xl ul > li::before {
+      .sm\\\\:prose-2xl :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
         left: 0.25em;
       }
 
-      .sm\\\\:prose-2xl > ul > li p {
+      .sm\\\\:prose-2xl :where(> ul > li p) {
         margin-top: 0.8333333em;
         margin-bottom: 0.8333333em;
       }
 
-      .sm\\\\:prose-2xl > ul > li > *:first-child {
+      .sm\\\\:prose-2xl :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl > ul > li > *:last-child {
+      .sm\\\\:prose-2xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl > ol > li > *:first-child {
+      .sm\\\\:prose-2xl :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl > ol > li > *:last-child {
+      .sm\\\\:prose-2xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .sm\\\\:prose-2xl ul ul, .sm\\\\:prose-2xl ul ol, .sm\\\\:prose-2xl ol ul, .sm\\\\:prose-2xl ol ol {
+      .sm\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .sm\\\\:prose-2xl hr {
+      .sm\\\\:prose-2xl :where(hr) {
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .sm\\\\:prose-2xl hr + * {
+      .sm\\\\:prose-2xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-2xl h2 + * {
+      .sm\\\\:prose-2xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-2xl h3 + * {
+      .sm\\\\:prose-2xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-2xl h4 + * {
+      .sm\\\\:prose-2xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-2xl table {
+      .sm\\\\:prose-2xl :where(table) {
         font-size: 0.8333333em;
         line-height: 1.4;
       }
 
-      .sm\\\\:prose-2xl thead th {
+      .sm\\\\:prose-2xl :where(thead th) {
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .sm\\\\:prose-2xl thead th:first-child {
+      .sm\\\\:prose-2xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-2xl thead th:last-child {
+      .sm\\\\:prose-2xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-2xl tbody td {
+      .sm\\\\:prose-2xl :where(tbody td) {
         padding-top: 0.8em;
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .sm\\\\:prose-2xl tbody td:first-child {
+      .sm\\\\:prose-2xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .sm\\\\:prose-2xl tbody td:last-child {
+      .sm\\\\:prose-2xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .sm\\\\:prose-2xl > :first-child {
+      .sm\\\\:prose-2xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .sm\\\\:prose-2xl > :last-child {
+      .sm\\\\:prose-2xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
-      .sm\\\\:prose-red a {
+      .sm\\\\:prose-red :where(a) {
         color: #dc2626;
       }
 
-      .sm\\\\:prose-red a code {
+      .sm\\\\:prose-red :where(a code) {
         color: #dc2626;
       }
 
-      .sm\\\\:prose-yellow a {
+      .sm\\\\:prose-yellow :where(a) {
         color: #d97706;
       }
 
-      .sm\\\\:prose-yellow a code {
+      .sm\\\\:prose-yellow :where(a code) {
         color: #d97706;
       }
 
-      .sm\\\\:prose-green a {
+      .sm\\\\:prose-green :where(a) {
         color: #059669;
       }
 
-      .sm\\\\:prose-green a code {
+      .sm\\\\:prose-green :where(a code) {
         color: #059669;
       }
 
-      .sm\\\\:prose-blue a {
+      .sm\\\\:prose-blue :where(a) {
         color: #2563eb;
       }
 
-      .sm\\\\:prose-blue a code {
+      .sm\\\\:prose-blue :where(a code) {
         color: #2563eb;
       }
 
-      .sm\\\\:prose-indigo a {
+      .sm\\\\:prose-indigo :where(a) {
         color: #4f46e5;
       }
 
-      .sm\\\\:prose-indigo a code {
+      .sm\\\\:prose-indigo :where(a code) {
         color: #4f46e5;
       }
 
-      .sm\\\\:prose-purple a {
+      .sm\\\\:prose-purple :where(a) {
         color: #7c3aed;
       }
 
-      .sm\\\\:prose-purple a code {
+      .sm\\\\:prose-purple :where(a code) {
         color: #7c3aed;
       }
 
-      .sm\\\\:prose-pink a {
+      .sm\\\\:prose-pink :where(a) {
         color: #db2777;
       }
 
-      .sm\\\\:prose-pink a code {
+      .sm\\\\:prose-pink :where(a code) {
         color: #db2777;
       }
     }
 
     @media (min-width: 768px) {
       .md\\\\:prose {
-        color: #374151;
-        max-width: 65ch;
+        :where(color): #374151;
+        :where(max-width): 65ch;
       }
 
-      .md\\\\:prose [class~=\\"lead\\"] {
+      .md\\\\:prose :where([class~=\\"lead\\"]) {
         color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
@@ -2717,59 +2717,59 @@ it('should generate the default classes for the typography components', async ()
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose a {
+      .md\\\\:prose :where(a) {
         color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
-      .md\\\\:prose strong {
+      .md\\\\:prose :where(strong) {
         color: #111827;
         font-weight: 600;
       }
 
-      .md\\\\:prose ol[type=\\"A\\"] {
+      .md\\\\:prose :where(ol[type=\\"A\\"]) {
         --list-counter-style: upper-alpha;
       }
 
-      .md\\\\:prose ol[type=\\"a\\"] {
+      .md\\\\:prose :where(ol[type=\\"a\\"]) {
         --list-counter-style: lower-alpha;
       }
 
-      .md\\\\:prose ol[type=\\"A\\" s] {
+      .md\\\\:prose :where(ol[type=\\"A\\" s]) {
         --list-counter-style: upper-alpha;
       }
 
-      .md\\\\:prose ol[type=\\"a\\" s] {
+      .md\\\\:prose :where(ol[type=\\"a\\" s]) {
         --list-counter-style: lower-alpha;
       }
 
-      .md\\\\:prose ol[type=\\"I\\"] {
+      .md\\\\:prose :where(ol[type=\\"I\\"]) {
         --list-counter-style: upper-roman;
       }
 
-      .md\\\\:prose ol[type=\\"i\\"] {
+      .md\\\\:prose :where(ol[type=\\"i\\"]) {
         --list-counter-style: lower-roman;
       }
 
-      .md\\\\:prose ol[type=\\"I\\" s] {
+      .md\\\\:prose :where(ol[type=\\"I\\" s]) {
         --list-counter-style: upper-roman;
       }
 
-      .md\\\\:prose ol[type=\\"i\\" s] {
+      .md\\\\:prose :where(ol[type=\\"i\\" s]) {
         --list-counter-style: lower-roman;
       }
 
-      .md\\\\:prose ol[type=\\"1\\"] {
+      .md\\\\:prose :where(ol[type=\\"1\\"]) {
         --list-counter-style: decimal;
       }
 
-      .md\\\\:prose ol > li {
+      .md\\\\:prose :where(ol > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .md\\\\:prose ol > li::before {
+      .md\\\\:prose :where(ol > li::before) {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -2777,12 +2777,12 @@ it('should generate the default classes for the typography components', async ()
         left: 0;
       }
 
-      .md\\\\:prose ul > li {
+      .md\\\\:prose :where(ul > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .md\\\\:prose ul > li::before {
+      .md\\\\:prose :where(ul > li::before) {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -2793,14 +2793,14 @@ it('should generate the default classes for the typography components', async ()
         left: 0.25em;
       }
 
-      .md\\\\:prose hr {
+      .md\\\\:prose :where(hr) {
         border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .md\\\\:prose blockquote {
+      .md\\\\:prose :where(blockquote) {
         font-weight: 500;
         font-style: italic;
         color: #111827;
@@ -2812,15 +2812,15 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .md\\\\:prose blockquote p:first-of-type::before {
+      .md\\\\:prose :where(blockquote p:first-of-type::before) {
         content: open-quote;
       }
 
-      .md\\\\:prose blockquote p:last-of-type::after {
+      .md\\\\:prose :where(blockquote p:last-of-type::after) {
         content: close-quote;
       }
 
-      .md\\\\:prose h1 {
+      .md\\\\:prose :where(h1) {
         color: #111827;
         font-weight: 800;
         font-size: 2.25em;
@@ -2829,11 +2829,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.1111111;
       }
 
-      .md\\\\:prose h1 strong {
+      .md\\\\:prose :where(h1 strong) {
         font-weight: 900;
       }
 
-      .md\\\\:prose h2 {
+      .md\\\\:prose :where(h2) {
         color: #111827;
         font-weight: 700;
         font-size: 1.5em;
@@ -2842,11 +2842,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.3333333;
       }
 
-      .md\\\\:prose h2 strong {
+      .md\\\\:prose :where(h2 strong) {
         font-weight: 800;
       }
 
-      .md\\\\:prose h3 {
+      .md\\\\:prose :where(h3) {
         color: #111827;
         font-weight: 600;
         font-size: 1.25em;
@@ -2855,11 +2855,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.6;
       }
 
-      .md\\\\:prose h3 strong {
+      .md\\\\:prose :where(h3 strong) {
         font-weight: 700;
       }
 
-      .md\\\\:prose h4 {
+      .md\\\\:prose :where(h4) {
         color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
@@ -2867,36 +2867,36 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.5;
       }
 
-      .md\\\\:prose h4 strong {
+      .md\\\\:prose :where(h4 strong) {
         font-weight: 700;
       }
 
-      .md\\\\:prose figure figcaption {
+      .md\\\\:prose :where(figure figcaption) {
         color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
-      .md\\\\:prose code {
+      .md\\\\:prose :where(code) {
         color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
 
-      .md\\\\:prose code::before {
+      .md\\\\:prose :where(code::before) {
         content: \\"\`\\";
       }
 
-      .md\\\\:prose code::after {
+      .md\\\\:prose :where(code::after) {
         content: \\"\`\\";
       }
 
-      .md\\\\:prose a code {
+      .md\\\\:prose :where(a code) {
         color: #111827;
       }
 
-      .md\\\\:prose pre {
+      .md\\\\:prose :where(pre) {
         color: #e5e7eb;
         background-color: #1f2937;
         overflow-x: auto;
@@ -2911,7 +2911,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.1428571em;
       }
 
-      .md\\\\:prose pre code {
+      .md\\\\:prose :where(pre code) {
         background-color: transparent;
         border-width: 0;
         border-radius: 0;
@@ -2923,15 +2923,15 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .md\\\\:prose pre code::before {
+      .md\\\\:prose :where(pre code::before) {
         content: none;
       }
 
-      .md\\\\:prose pre code::after {
+      .md\\\\:prose :where(pre code::after) {
         content: none;
       }
 
-      .md\\\\:prose table {
+      .md\\\\:prose :where(table) {
         width: 100%;
         table-layout: auto;
         text-align: left;
@@ -2941,30 +2941,30 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.7142857;
       }
 
-      .md\\\\:prose thead {
+      .md\\\\:prose :where(thead) {
         color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
         border-bottom-color: #d1d5db;
       }
 
-      .md\\\\:prose thead th {
+      .md\\\\:prose :where(thead th) {
         vertical-align: bottom;
         padding-right: 0.5714286em;
         padding-bottom: 0.5714286em;
         padding-left: 0.5714286em;
       }
 
-      .md\\\\:prose tbody tr {
+      .md\\\\:prose :where(tbody tr) {
         border-bottom-width: 1px;
         border-bottom-color: #e5e7eb;
       }
 
-      .md\\\\:prose tbody tr:last-child {
+      .md\\\\:prose :where(tbody tr:last-child) {
         border-bottom-width: 0;
       }
 
-      .md\\\\:prose tbody td {
+      .md\\\\:prose :where(tbody td) {
         vertical-align: top;
         padding-top: 0.5714286em;
         padding-right: 0.5714286em;
@@ -2973,213 +2973,213 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose {
-        font-size: 1rem;
-        line-height: 1.75;
+        :where(font-size): 1rem;
+        :where(line-height): 1.75;
       }
 
-      .md\\\\:prose p {
+      .md\\\\:prose :where(p) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .md\\\\:prose img {
+      .md\\\\:prose :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose video {
+      .md\\\\:prose :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose figure {
+      .md\\\\:prose :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose figure > * {
+      .md\\\\:prose :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .md\\\\:prose h2 code {
+      .md\\\\:prose :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .md\\\\:prose h3 code {
+      .md\\\\:prose :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .md\\\\:prose ol {
+      .md\\\\:prose :where(ol) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .md\\\\:prose ul {
+      .md\\\\:prose :where(ul) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .md\\\\:prose li {
+      .md\\\\:prose :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .md\\\\:prose > ul > li p {
+      .md\\\\:prose :where(> ul > li p) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .md\\\\:prose > ul > li > *:first-child {
+      .md\\\\:prose :where(> ul > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .md\\\\:prose > ul > li > *:last-child {
+      .md\\\\:prose :where(> ul > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .md\\\\:prose > ol > li > *:first-child {
+      .md\\\\:prose :where(> ol > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .md\\\\:prose > ol > li > *:last-child {
+      .md\\\\:prose :where(> ol > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .md\\\\:prose ul ul, .md\\\\:prose ul ol, .md\\\\:prose ol ul, .md\\\\:prose ol ol {
+      .md\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .md\\\\:prose hr + * {
+      .md\\\\:prose :where(hr + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose h2 + * {
+      .md\\\\:prose :where(h2 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose h3 + * {
+      .md\\\\:prose :where(h3 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose h4 + * {
+      .md\\\\:prose :where(h4 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose thead th:first-child {
+      .md\\\\:prose :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose thead th:last-child {
+      .md\\\\:prose :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose tbody td:first-child {
+      .md\\\\:prose :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose tbody td:last-child {
+      .md\\\\:prose :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose > :first-child {
+      .md\\\\:prose :where(> :first-child) {
         margin-top: 0;
       }
 
-      .md\\\\:prose > :last-child {
+      .md\\\\:prose :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .md\\\\:prose-sm {
-        font-size: 0.875rem;
-        line-height: 1.7142857;
+        :where(font-size): 0.875rem;
+        :where(line-height): 1.7142857;
       }
 
-      .md\\\\:prose-sm p {
+      .md\\\\:prose-sm :where(p) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .md\\\\:prose-sm [class~=\\"lead\\"] {
+      .md\\\\:prose-sm :where([class~=\\"lead\\"]) {
         font-size: 1.2857143em;
         line-height: 1.5555556;
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .md\\\\:prose-sm blockquote {
+      .md\\\\:prose-sm :where(blockquote) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
         padding-left: 1.1111111em;
       }
 
-      .md\\\\:prose-sm h1 {
+      .md\\\\:prose-sm :where(h1) {
         font-size: 2.1428571em;
         margin-top: 0;
         margin-bottom: 0.8em;
         line-height: 1.2;
       }
 
-      .md\\\\:prose-sm h2 {
+      .md\\\\:prose-sm :where(h2) {
         font-size: 1.4285714em;
         margin-top: 1.6em;
         margin-bottom: 0.8em;
         line-height: 1.4;
       }
 
-      .md\\\\:prose-sm h3 {
+      .md\\\\:prose-sm :where(h3) {
         font-size: 1.2857143em;
         margin-top: 1.5555556em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .md\\\\:prose-sm h4 {
+      .md\\\\:prose-sm :where(h4) {
         margin-top: 1.4285714em;
         margin-bottom: 0.5714286em;
         line-height: 1.4285714;
       }
 
-      .md\\\\:prose-sm img {
+      .md\\\\:prose-sm :where(img) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .md\\\\:prose-sm video {
+      .md\\\\:prose-sm :where(video) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .md\\\\:prose-sm figure {
+      .md\\\\:prose-sm :where(figure) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .md\\\\:prose-sm figure > * {
+      .md\\\\:prose-sm :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .md\\\\:prose-sm figure figcaption {
+      .md\\\\:prose-sm :where(figure figcaption) {
         font-size: 0.8571429em;
         line-height: 1.3333333;
         margin-top: 0.6666667em;
       }
 
-      .md\\\\:prose-sm code {
+      .md\\\\:prose-sm :where(code) {
         font-size: 0.8571429em;
       }
 
-      .md\\\\:prose-sm h2 code {
+      .md\\\\:prose-sm :where(h2 code) {
         font-size: 0.9em;
       }
 
-      .md\\\\:prose-sm h3 code {
+      .md\\\\:prose-sm :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .md\\\\:prose-sm pre {
+      .md\\\\:prose-sm :where(pre) {
         font-size: 0.8571429em;
         line-height: 1.6666667;
         margin-top: 1.6666667em;
@@ -3191,218 +3191,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .md\\\\:prose-sm ol {
+      .md\\\\:prose-sm :where(ol) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .md\\\\:prose-sm ul {
+      .md\\\\:prose-sm :where(ul) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .md\\\\:prose-sm li {
+      .md\\\\:prose-sm :where(li) {
         margin-top: 0.2857143em;
         margin-bottom: 0.2857143em;
       }
 
-      .md\\\\:prose-sm ol > li {
+      .md\\\\:prose-sm :where(ol > li) {
         padding-left: 1.5714286em;
       }
 
-      .md\\\\:prose-sm ol > li::before {
+      .md\\\\:prose-sm :where(ol > li::before) {
         left: 0;
       }
 
-      .md\\\\:prose-sm ul > li {
+      .md\\\\:prose-sm :where(ul > li) {
         padding-left: 1.5714286em;
       }
 
-      .md\\\\:prose-sm ul > li::before {
+      .md\\\\:prose-sm :where(ul > li::before) {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
         left: 0.2142857em;
       }
 
-      .md\\\\:prose-sm > ul > li p {
+      .md\\\\:prose-sm :where(> ul > li p) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .md\\\\:prose-sm > ul > li > *:first-child {
+      .md\\\\:prose-sm :where(> ul > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .md\\\\:prose-sm > ul > li > *:last-child {
+      .md\\\\:prose-sm :where(> ul > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .md\\\\:prose-sm > ol > li > *:first-child {
+      .md\\\\:prose-sm :where(> ol > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .md\\\\:prose-sm > ol > li > *:last-child {
+      .md\\\\:prose-sm :where(> ol > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .md\\\\:prose-sm ul ul, .md\\\\:prose-sm ul ol, .md\\\\:prose-sm ol ul, .md\\\\:prose-sm ol ol {
+      .md\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .md\\\\:prose-sm hr {
+      .md\\\\:prose-sm :where(hr) {
         margin-top: 2.8571429em;
         margin-bottom: 2.8571429em;
       }
 
-      .md\\\\:prose-sm hr + * {
+      .md\\\\:prose-sm :where(hr + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-sm h2 + * {
+      .md\\\\:prose-sm :where(h2 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-sm h3 + * {
+      .md\\\\:prose-sm :where(h3 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-sm h4 + * {
+      .md\\\\:prose-sm :where(h4 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-sm table {
+      .md\\\\:prose-sm :where(table) {
         font-size: 0.8571429em;
         line-height: 1.5;
       }
 
-      .md\\\\:prose-sm thead th {
+      .md\\\\:prose-sm :where(thead th) {
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .md\\\\:prose-sm thead th:first-child {
+      .md\\\\:prose-sm :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-sm thead th:last-child {
+      .md\\\\:prose-sm :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-sm tbody td {
+      .md\\\\:prose-sm :where(tbody td) {
         padding-top: 0.6666667em;
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .md\\\\:prose-sm tbody td:first-child {
+      .md\\\\:prose-sm :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-sm tbody td:last-child {
+      .md\\\\:prose-sm :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-sm > :first-child {
+      .md\\\\:prose-sm :where(> :first-child) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-sm > :last-child {
+      .md\\\\:prose-sm :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .md\\\\:prose-lg {
-        font-size: 1.125rem;
-        line-height: 1.7777778;
+        :where(font-size): 1.125rem;
+        :where(line-height): 1.7777778;
       }
 
-      .md\\\\:prose-lg p {
+      .md\\\\:prose-lg :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-lg [class~=\\"lead\\"] {
+      .md\\\\:prose-lg :where([class~=\\"lead\\"]) {
         font-size: 1.2222222em;
         line-height: 1.4545455;
         margin-top: 1.0909091em;
         margin-bottom: 1.0909091em;
       }
 
-      .md\\\\:prose-lg blockquote {
+      .md\\\\:prose-lg :where(blockquote) {
         margin-top: 1.6666667em;
         margin-bottom: 1.6666667em;
         padding-left: 1em;
       }
 
-      .md\\\\:prose-lg h1 {
+      .md\\\\:prose-lg :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.8333333em;
         line-height: 1;
       }
 
-      .md\\\\:prose-lg h2 {
+      .md\\\\:prose-lg :where(h2) {
         font-size: 1.6666667em;
         margin-top: 1.8666667em;
         margin-bottom: 1.0666667em;
         line-height: 1.3333333;
       }
 
-      .md\\\\:prose-lg h3 {
+      .md\\\\:prose-lg :where(h3) {
         font-size: 1.3333333em;
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .md\\\\:prose-lg h4 {
+      .md\\\\:prose-lg :where(h4) {
         margin-top: 1.7777778em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .md\\\\:prose-lg img {
+      .md\\\\:prose-lg :where(img) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .md\\\\:prose-lg video {
+      .md\\\\:prose-lg :where(video) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .md\\\\:prose-lg figure {
+      .md\\\\:prose-lg :where(figure) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .md\\\\:prose-lg figure > * {
+      .md\\\\:prose-lg :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .md\\\\:prose-lg figure figcaption {
+      .md\\\\:prose-lg :where(figure figcaption) {
         font-size: 0.8888889em;
         line-height: 1.5;
         margin-top: 1em;
       }
 
-      .md\\\\:prose-lg code {
+      .md\\\\:prose-lg :where(code) {
         font-size: 0.8888889em;
       }
 
-      .md\\\\:prose-lg h2 code {
+      .md\\\\:prose-lg :where(h2 code) {
         font-size: 0.8666667em;
       }
 
-      .md\\\\:prose-lg h3 code {
+      .md\\\\:prose-lg :where(h3 code) {
         font-size: 0.875em;
       }
 
-      .md\\\\:prose-lg pre {
+      .md\\\\:prose-lg :where(pre) {
         font-size: 0.8888889em;
         line-height: 1.75;
         margin-top: 2em;
@@ -3414,218 +3414,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5em;
       }
 
-      .md\\\\:prose-lg ol {
+      .md\\\\:prose-lg :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-lg ul {
+      .md\\\\:prose-lg :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-lg li {
+      .md\\\\:prose-lg :where(li) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .md\\\\:prose-lg ol > li {
+      .md\\\\:prose-lg :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-lg ol > li::before {
+      .md\\\\:prose-lg :where(ol > li::before) {
         left: 0;
       }
 
-      .md\\\\:prose-lg ul > li {
+      .md\\\\:prose-lg :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-lg ul > li::before {
+      .md\\\\:prose-lg :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
         left: 0.2222222em;
       }
 
-      .md\\\\:prose-lg > ul > li p {
+      .md\\\\:prose-lg :where(> ul > li p) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .md\\\\:prose-lg > ul > li > *:first-child {
+      .md\\\\:prose-lg :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .md\\\\:prose-lg > ul > li > *:last-child {
+      .md\\\\:prose-lg :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-lg > ol > li > *:first-child {
+      .md\\\\:prose-lg :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .md\\\\:prose-lg > ol > li > *:last-child {
+      .md\\\\:prose-lg :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-lg ul ul, .md\\\\:prose-lg ul ol, .md\\\\:prose-lg ol ul, .md\\\\:prose-lg ol ol {
+      .md\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .md\\\\:prose-lg hr {
+      .md\\\\:prose-lg :where(hr) {
         margin-top: 3.1111111em;
         margin-bottom: 3.1111111em;
       }
 
-      .md\\\\:prose-lg hr + * {
+      .md\\\\:prose-lg :where(hr + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-lg h2 + * {
+      .md\\\\:prose-lg :where(h2 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-lg h3 + * {
+      .md\\\\:prose-lg :where(h3 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-lg h4 + * {
+      .md\\\\:prose-lg :where(h4 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-lg table {
+      .md\\\\:prose-lg :where(table) {
         font-size: 0.8888889em;
         line-height: 1.5;
       }
 
-      .md\\\\:prose-lg thead th {
+      .md\\\\:prose-lg :where(thead th) {
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .md\\\\:prose-lg thead th:first-child {
+      .md\\\\:prose-lg :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-lg thead th:last-child {
+      .md\\\\:prose-lg :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-lg tbody td {
+      .md\\\\:prose-lg :where(tbody td) {
         padding-top: 0.75em;
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .md\\\\:prose-lg tbody td:first-child {
+      .md\\\\:prose-lg :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-lg tbody td:last-child {
+      .md\\\\:prose-lg :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-lg > :first-child {
+      .md\\\\:prose-lg :where(> :first-child) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-lg > :last-child {
+      .md\\\\:prose-lg :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .md\\\\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
+        :where(font-size): 1.25rem;
+        :where(line-height): 1.8;
       }
 
-      .md\\\\:prose-xl p {
+      .md\\\\:prose-xl :where(p) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose-xl [class~=\\"lead\\"] {
+      .md\\\\:prose-xl :where([class~=\\"lead\\"]) {
         font-size: 1.2em;
         line-height: 1.5;
         margin-top: 1em;
         margin-bottom: 1em;
       }
 
-      .md\\\\:prose-xl blockquote {
+      .md\\\\:prose-xl :where(blockquote) {
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1.0666667em;
       }
 
-      .md\\\\:prose-xl h1 {
+      .md\\\\:prose-xl :where(h1) {
         font-size: 2.8em;
         margin-top: 0;
         margin-bottom: 0.8571429em;
         line-height: 1;
       }
 
-      .md\\\\:prose-xl h2 {
+      .md\\\\:prose-xl :where(h2) {
         font-size: 1.8em;
         margin-top: 1.5555556em;
         margin-bottom: 0.8888889em;
         line-height: 1.1111111;
       }
 
-      .md\\\\:prose-xl h3 {
+      .md\\\\:prose-xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.6em;
         margin-bottom: 0.6666667em;
         line-height: 1.3333333;
       }
 
-      .md\\\\:prose-xl h4 {
+      .md\\\\:prose-xl :where(h4) {
         margin-top: 1.8em;
         margin-bottom: 0.6em;
         line-height: 1.6;
       }
 
-      .md\\\\:prose-xl img {
+      .md\\\\:prose-xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-xl video {
+      .md\\\\:prose-xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-xl figure {
+      .md\\\\:prose-xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-xl figure > * {
+      .md\\\\:prose-xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .md\\\\:prose-xl figure figcaption {
+      .md\\\\:prose-xl :where(figure figcaption) {
         font-size: 0.9em;
         line-height: 1.5555556;
         margin-top: 1em;
       }
 
-      .md\\\\:prose-xl code {
+      .md\\\\:prose-xl :where(code) {
         font-size: 0.9em;
       }
 
-      .md\\\\:prose-xl h2 code {
+      .md\\\\:prose-xl :where(h2 code) {
         font-size: 0.8611111em;
       }
 
-      .md\\\\:prose-xl h3 code {
+      .md\\\\:prose-xl :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .md\\\\:prose-xl pre {
+      .md\\\\:prose-xl :where(pre) {
         font-size: 0.9em;
         line-height: 1.7777778;
         margin-top: 2em;
@@ -3637,218 +3637,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.3333333em;
       }
 
-      .md\\\\:prose-xl ol {
+      .md\\\\:prose-xl :where(ol) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose-xl ul {
+      .md\\\\:prose-xl :where(ul) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose-xl li {
+      .md\\\\:prose-xl :where(li) {
         margin-top: 0.6em;
         margin-bottom: 0.6em;
       }
 
-      .md\\\\:prose-xl ol > li {
+      .md\\\\:prose-xl :where(ol > li) {
         padding-left: 1.8em;
       }
 
-      .md\\\\:prose-xl ol > li::before {
+      .md\\\\:prose-xl :where(ol > li::before) {
         left: 0;
       }
 
-      .md\\\\:prose-xl ul > li {
+      .md\\\\:prose-xl :where(ul > li) {
         padding-left: 1.8em;
       }
 
-      .md\\\\:prose-xl ul > li::before {
+      .md\\\\:prose-xl :where(ul > li::before) {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
         left: 0.25em;
       }
 
-      .md\\\\:prose-xl > ul > li p {
+      .md\\\\:prose-xl :where(> ul > li p) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .md\\\\:prose-xl > ul > li > *:first-child {
+      .md\\\\:prose-xl :where(> ul > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .md\\\\:prose-xl > ul > li > *:last-child {
+      .md\\\\:prose-xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose-xl > ol > li > *:first-child {
+      .md\\\\:prose-xl :where(> ol > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .md\\\\:prose-xl > ol > li > *:last-child {
+      .md\\\\:prose-xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .md\\\\:prose-xl ul ul, .md\\\\:prose-xl ul ol, .md\\\\:prose-xl ol ul, .md\\\\:prose-xl ol ol {
+      .md\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .md\\\\:prose-xl hr {
+      .md\\\\:prose-xl :where(hr) {
         margin-top: 2.8em;
         margin-bottom: 2.8em;
       }
 
-      .md\\\\:prose-xl hr + * {
+      .md\\\\:prose-xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-xl h2 + * {
+      .md\\\\:prose-xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-xl h3 + * {
+      .md\\\\:prose-xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-xl h4 + * {
+      .md\\\\:prose-xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-xl table {
+      .md\\\\:prose-xl :where(table) {
         font-size: 0.9em;
         line-height: 1.5555556;
       }
 
-      .md\\\\:prose-xl thead th {
+      .md\\\\:prose-xl :where(thead th) {
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .md\\\\:prose-xl thead th:first-child {
+      .md\\\\:prose-xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-xl thead th:last-child {
+      .md\\\\:prose-xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-xl tbody td {
+      .md\\\\:prose-xl :where(tbody td) {
         padding-top: 0.8888889em;
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .md\\\\:prose-xl tbody td:first-child {
+      .md\\\\:prose-xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-xl tbody td:last-child {
+      .md\\\\:prose-xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-xl > :first-child {
+      .md\\\\:prose-xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-xl > :last-child {
+      .md\\\\:prose-xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .md\\\\:prose-2xl {
-        font-size: 1.5rem;
-        line-height: 1.6666667;
+        :where(font-size): 1.5rem;
+        :where(line-height): 1.6666667;
       }
 
-      .md\\\\:prose-2xl p {
+      .md\\\\:prose-2xl :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl [class~=\\"lead\\"] {
+      .md\\\\:prose-2xl :where([class~=\\"lead\\"]) {
         font-size: 1.25em;
         line-height: 1.4666667;
         margin-top: 1.0666667em;
         margin-bottom: 1.0666667em;
       }
 
-      .md\\\\:prose-2xl blockquote {
+      .md\\\\:prose-2xl :where(blockquote) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
         padding-left: 1.1111111em;
       }
 
-      .md\\\\:prose-2xl h1 {
+      .md\\\\:prose-2xl :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.875em;
         line-height: 1;
       }
 
-      .md\\\\:prose-2xl h2 {
+      .md\\\\:prose-2xl :where(h2) {
         font-size: 2em;
         margin-top: 1.5em;
         margin-bottom: 0.8333333em;
         line-height: 1.0833333;
       }
 
-      .md\\\\:prose-2xl h3 {
+      .md\\\\:prose-2xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.5555556em;
         margin-bottom: 0.6666667em;
         line-height: 1.2222222;
       }
 
-      .md\\\\:prose-2xl h4 {
+      .md\\\\:prose-2xl :where(h4) {
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .md\\\\:prose-2xl img {
+      .md\\\\:prose-2xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-2xl video {
+      .md\\\\:prose-2xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-2xl figure {
+      .md\\\\:prose-2xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .md\\\\:prose-2xl figure > * {
+      .md\\\\:prose-2xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .md\\\\:prose-2xl figure figcaption {
+      .md\\\\:prose-2xl :where(figure figcaption) {
         font-size: 0.8333333em;
         line-height: 1.6;
         margin-top: 1em;
       }
 
-      .md\\\\:prose-2xl code {
+      .md\\\\:prose-2xl :where(code) {
         font-size: 0.8333333em;
       }
 
-      .md\\\\:prose-2xl h2 code {
+      .md\\\\:prose-2xl :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .md\\\\:prose-2xl h3 code {
+      .md\\\\:prose-2xl :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .md\\\\:prose-2xl pre {
+      .md\\\\:prose-2xl :where(pre) {
         font-size: 0.8333333em;
         line-height: 1.8;
         margin-top: 2em;
@@ -3860,193 +3860,193 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6em;
       }
 
-      .md\\\\:prose-2xl ol {
+      .md\\\\:prose-2xl :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl ul {
+      .md\\\\:prose-2xl :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl li {
+      .md\\\\:prose-2xl :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .md\\\\:prose-2xl ol > li {
+      .md\\\\:prose-2xl :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-2xl ol > li::before {
+      .md\\\\:prose-2xl :where(ol > li::before) {
         left: 0;
       }
 
-      .md\\\\:prose-2xl ul > li {
+      .md\\\\:prose-2xl :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-2xl ul > li::before {
+      .md\\\\:prose-2xl :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
         left: 0.25em;
       }
 
-      .md\\\\:prose-2xl > ul > li p {
+      .md\\\\:prose-2xl :where(> ul > li p) {
         margin-top: 0.8333333em;
         margin-bottom: 0.8333333em;
       }
 
-      .md\\\\:prose-2xl > ul > li > *:first-child {
+      .md\\\\:prose-2xl :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl > ul > li > *:last-child {
+      .md\\\\:prose-2xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl > ol > li > *:first-child {
+      .md\\\\:prose-2xl :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl > ol > li > *:last-child {
+      .md\\\\:prose-2xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .md\\\\:prose-2xl ul ul, .md\\\\:prose-2xl ul ol, .md\\\\:prose-2xl ol ul, .md\\\\:prose-2xl ol ol {
+      .md\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .md\\\\:prose-2xl hr {
+      .md\\\\:prose-2xl :where(hr) {
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .md\\\\:prose-2xl hr + * {
+      .md\\\\:prose-2xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-2xl h2 + * {
+      .md\\\\:prose-2xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-2xl h3 + * {
+      .md\\\\:prose-2xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-2xl h4 + * {
+      .md\\\\:prose-2xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-2xl table {
+      .md\\\\:prose-2xl :where(table) {
         font-size: 0.8333333em;
         line-height: 1.4;
       }
 
-      .md\\\\:prose-2xl thead th {
+      .md\\\\:prose-2xl :where(thead th) {
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .md\\\\:prose-2xl thead th:first-child {
+      .md\\\\:prose-2xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-2xl thead th:last-child {
+      .md\\\\:prose-2xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-2xl tbody td {
+      .md\\\\:prose-2xl :where(tbody td) {
         padding-top: 0.8em;
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .md\\\\:prose-2xl tbody td:first-child {
+      .md\\\\:prose-2xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .md\\\\:prose-2xl tbody td:last-child {
+      .md\\\\:prose-2xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .md\\\\:prose-2xl > :first-child {
+      .md\\\\:prose-2xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .md\\\\:prose-2xl > :last-child {
+      .md\\\\:prose-2xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
-      .md\\\\:prose-red a {
+      .md\\\\:prose-red :where(a) {
         color: #dc2626;
       }
 
-      .md\\\\:prose-red a code {
+      .md\\\\:prose-red :where(a code) {
         color: #dc2626;
       }
 
-      .md\\\\:prose-yellow a {
+      .md\\\\:prose-yellow :where(a) {
         color: #d97706;
       }
 
-      .md\\\\:prose-yellow a code {
+      .md\\\\:prose-yellow :where(a code) {
         color: #d97706;
       }
 
-      .md\\\\:prose-green a {
+      .md\\\\:prose-green :where(a) {
         color: #059669;
       }
 
-      .md\\\\:prose-green a code {
+      .md\\\\:prose-green :where(a code) {
         color: #059669;
       }
 
-      .md\\\\:prose-blue a {
+      .md\\\\:prose-blue :where(a) {
         color: #2563eb;
       }
 
-      .md\\\\:prose-blue a code {
+      .md\\\\:prose-blue :where(a code) {
         color: #2563eb;
       }
 
-      .md\\\\:prose-indigo a {
+      .md\\\\:prose-indigo :where(a) {
         color: #4f46e5;
       }
 
-      .md\\\\:prose-indigo a code {
+      .md\\\\:prose-indigo :where(a code) {
         color: #4f46e5;
       }
 
-      .md\\\\:prose-purple a {
+      .md\\\\:prose-purple :where(a) {
         color: #7c3aed;
       }
 
-      .md\\\\:prose-purple a code {
+      .md\\\\:prose-purple :where(a code) {
         color: #7c3aed;
       }
 
-      .md\\\\:prose-pink a {
+      .md\\\\:prose-pink :where(a) {
         color: #db2777;
       }
 
-      .md\\\\:prose-pink a code {
+      .md\\\\:prose-pink :where(a code) {
         color: #db2777;
       }
     }
 
     @media (min-width: 1024px) {
       .lg\\\\:prose {
-        color: #374151;
-        max-width: 65ch;
+        :where(color): #374151;
+        :where(max-width): 65ch;
       }
 
-      .lg\\\\:prose [class~=\\"lead\\"] {
+      .lg\\\\:prose :where([class~=\\"lead\\"]) {
         color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
@@ -4054,59 +4054,59 @@ it('should generate the default classes for the typography components', async ()
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose a {
+      .lg\\\\:prose :where(a) {
         color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
-      .lg\\\\:prose strong {
+      .lg\\\\:prose :where(strong) {
         color: #111827;
         font-weight: 600;
       }
 
-      .lg\\\\:prose ol[type=\\"A\\"] {
+      .lg\\\\:prose :where(ol[type=\\"A\\"]) {
         --list-counter-style: upper-alpha;
       }
 
-      .lg\\\\:prose ol[type=\\"a\\"] {
+      .lg\\\\:prose :where(ol[type=\\"a\\"]) {
         --list-counter-style: lower-alpha;
       }
 
-      .lg\\\\:prose ol[type=\\"A\\" s] {
+      .lg\\\\:prose :where(ol[type=\\"A\\" s]) {
         --list-counter-style: upper-alpha;
       }
 
-      .lg\\\\:prose ol[type=\\"a\\" s] {
+      .lg\\\\:prose :where(ol[type=\\"a\\" s]) {
         --list-counter-style: lower-alpha;
       }
 
-      .lg\\\\:prose ol[type=\\"I\\"] {
+      .lg\\\\:prose :where(ol[type=\\"I\\"]) {
         --list-counter-style: upper-roman;
       }
 
-      .lg\\\\:prose ol[type=\\"i\\"] {
+      .lg\\\\:prose :where(ol[type=\\"i\\"]) {
         --list-counter-style: lower-roman;
       }
 
-      .lg\\\\:prose ol[type=\\"I\\" s] {
+      .lg\\\\:prose :where(ol[type=\\"I\\" s]) {
         --list-counter-style: upper-roman;
       }
 
-      .lg\\\\:prose ol[type=\\"i\\" s] {
+      .lg\\\\:prose :where(ol[type=\\"i\\" s]) {
         --list-counter-style: lower-roman;
       }
 
-      .lg\\\\:prose ol[type=\\"1\\"] {
+      .lg\\\\:prose :where(ol[type=\\"1\\"]) {
         --list-counter-style: decimal;
       }
 
-      .lg\\\\:prose ol > li {
+      .lg\\\\:prose :where(ol > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .lg\\\\:prose ol > li::before {
+      .lg\\\\:prose :where(ol > li::before) {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -4114,12 +4114,12 @@ it('should generate the default classes for the typography components', async ()
         left: 0;
       }
 
-      .lg\\\\:prose ul > li {
+      .lg\\\\:prose :where(ul > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .lg\\\\:prose ul > li::before {
+      .lg\\\\:prose :where(ul > li::before) {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -4130,14 +4130,14 @@ it('should generate the default classes for the typography components', async ()
         left: 0.25em;
       }
 
-      .lg\\\\:prose hr {
+      .lg\\\\:prose :where(hr) {
         border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .lg\\\\:prose blockquote {
+      .lg\\\\:prose :where(blockquote) {
         font-weight: 500;
         font-style: italic;
         color: #111827;
@@ -4149,15 +4149,15 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .lg\\\\:prose blockquote p:first-of-type::before {
+      .lg\\\\:prose :where(blockquote p:first-of-type::before) {
         content: open-quote;
       }
 
-      .lg\\\\:prose blockquote p:last-of-type::after {
+      .lg\\\\:prose :where(blockquote p:last-of-type::after) {
         content: close-quote;
       }
 
-      .lg\\\\:prose h1 {
+      .lg\\\\:prose :where(h1) {
         color: #111827;
         font-weight: 800;
         font-size: 2.25em;
@@ -4166,11 +4166,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.1111111;
       }
 
-      .lg\\\\:prose h1 strong {
+      .lg\\\\:prose :where(h1 strong) {
         font-weight: 900;
       }
 
-      .lg\\\\:prose h2 {
+      .lg\\\\:prose :where(h2) {
         color: #111827;
         font-weight: 700;
         font-size: 1.5em;
@@ -4179,11 +4179,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.3333333;
       }
 
-      .lg\\\\:prose h2 strong {
+      .lg\\\\:prose :where(h2 strong) {
         font-weight: 800;
       }
 
-      .lg\\\\:prose h3 {
+      .lg\\\\:prose :where(h3) {
         color: #111827;
         font-weight: 600;
         font-size: 1.25em;
@@ -4192,11 +4192,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.6;
       }
 
-      .lg\\\\:prose h3 strong {
+      .lg\\\\:prose :where(h3 strong) {
         font-weight: 700;
       }
 
-      .lg\\\\:prose h4 {
+      .lg\\\\:prose :where(h4) {
         color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
@@ -4204,36 +4204,36 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.5;
       }
 
-      .lg\\\\:prose h4 strong {
+      .lg\\\\:prose :where(h4 strong) {
         font-weight: 700;
       }
 
-      .lg\\\\:prose figure figcaption {
+      .lg\\\\:prose :where(figure figcaption) {
         color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
-      .lg\\\\:prose code {
+      .lg\\\\:prose :where(code) {
         color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
 
-      .lg\\\\:prose code::before {
+      .lg\\\\:prose :where(code::before) {
         content: \\"\`\\";
       }
 
-      .lg\\\\:prose code::after {
+      .lg\\\\:prose :where(code::after) {
         content: \\"\`\\";
       }
 
-      .lg\\\\:prose a code {
+      .lg\\\\:prose :where(a code) {
         color: #111827;
       }
 
-      .lg\\\\:prose pre {
+      .lg\\\\:prose :where(pre) {
         color: #e5e7eb;
         background-color: #1f2937;
         overflow-x: auto;
@@ -4248,7 +4248,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.1428571em;
       }
 
-      .lg\\\\:prose pre code {
+      .lg\\\\:prose :where(pre code) {
         background-color: transparent;
         border-width: 0;
         border-radius: 0;
@@ -4260,15 +4260,15 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .lg\\\\:prose pre code::before {
+      .lg\\\\:prose :where(pre code::before) {
         content: none;
       }
 
-      .lg\\\\:prose pre code::after {
+      .lg\\\\:prose :where(pre code::after) {
         content: none;
       }
 
-      .lg\\\\:prose table {
+      .lg\\\\:prose :where(table) {
         width: 100%;
         table-layout: auto;
         text-align: left;
@@ -4278,30 +4278,30 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.7142857;
       }
 
-      .lg\\\\:prose thead {
+      .lg\\\\:prose :where(thead) {
         color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
         border-bottom-color: #d1d5db;
       }
 
-      .lg\\\\:prose thead th {
+      .lg\\\\:prose :where(thead th) {
         vertical-align: bottom;
         padding-right: 0.5714286em;
         padding-bottom: 0.5714286em;
         padding-left: 0.5714286em;
       }
 
-      .lg\\\\:prose tbody tr {
+      .lg\\\\:prose :where(tbody tr) {
         border-bottom-width: 1px;
         border-bottom-color: #e5e7eb;
       }
 
-      .lg\\\\:prose tbody tr:last-child {
+      .lg\\\\:prose :where(tbody tr:last-child) {
         border-bottom-width: 0;
       }
 
-      .lg\\\\:prose tbody td {
+      .lg\\\\:prose :where(tbody td) {
         vertical-align: top;
         padding-top: 0.5714286em;
         padding-right: 0.5714286em;
@@ -4310,213 +4310,213 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose {
-        font-size: 1rem;
-        line-height: 1.75;
+        :where(font-size): 1rem;
+        :where(line-height): 1.75;
       }
 
-      .lg\\\\:prose p {
+      .lg\\\\:prose :where(p) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .lg\\\\:prose img {
+      .lg\\\\:prose :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose video {
+      .lg\\\\:prose :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose figure {
+      .lg\\\\:prose :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose figure > * {
+      .lg\\\\:prose :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose h2 code {
+      .lg\\\\:prose :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .lg\\\\:prose h3 code {
+      .lg\\\\:prose :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .lg\\\\:prose ol {
+      .lg\\\\:prose :where(ol) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .lg\\\\:prose ul {
+      .lg\\\\:prose :where(ul) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .lg\\\\:prose li {
+      .lg\\\\:prose :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .lg\\\\:prose > ul > li p {
+      .lg\\\\:prose :where(> ul > li p) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .lg\\\\:prose > ul > li > *:first-child {
+      .lg\\\\:prose :where(> ul > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .lg\\\\:prose > ul > li > *:last-child {
+      .lg\\\\:prose :where(> ul > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .lg\\\\:prose > ol > li > *:first-child {
+      .lg\\\\:prose :where(> ol > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .lg\\\\:prose > ol > li > *:last-child {
+      .lg\\\\:prose :where(> ol > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .lg\\\\:prose ul ul, .lg\\\\:prose ul ol, .lg\\\\:prose ol ul, .lg\\\\:prose ol ol {
+      .lg\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .lg\\\\:prose hr + * {
+      .lg\\\\:prose :where(hr + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose h2 + * {
+      .lg\\\\:prose :where(h2 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose h3 + * {
+      .lg\\\\:prose :where(h3 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose h4 + * {
+      .lg\\\\:prose :where(h4 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose thead th:first-child {
+      .lg\\\\:prose :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose thead th:last-child {
+      .lg\\\\:prose :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose tbody td:first-child {
+      .lg\\\\:prose :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose tbody td:last-child {
+      .lg\\\\:prose :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose > :first-child {
+      .lg\\\\:prose :where(> :first-child) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose > :last-child {
+      .lg\\\\:prose :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .lg\\\\:prose-sm {
-        font-size: 0.875rem;
-        line-height: 1.7142857;
+        :where(font-size): 0.875rem;
+        :where(line-height): 1.7142857;
       }
 
-      .lg\\\\:prose-sm p {
+      .lg\\\\:prose-sm :where(p) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm [class~=\\"lead\\"] {
+      .lg\\\\:prose-sm :where([class~=\\"lead\\"]) {
         font-size: 1.2857143em;
         line-height: 1.5555556;
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .lg\\\\:prose-sm blockquote {
+      .lg\\\\:prose-sm :where(blockquote) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
         padding-left: 1.1111111em;
       }
 
-      .lg\\\\:prose-sm h1 {
+      .lg\\\\:prose-sm :where(h1) {
         font-size: 2.1428571em;
         margin-top: 0;
         margin-bottom: 0.8em;
         line-height: 1.2;
       }
 
-      .lg\\\\:prose-sm h2 {
+      .lg\\\\:prose-sm :where(h2) {
         font-size: 1.4285714em;
         margin-top: 1.6em;
         margin-bottom: 0.8em;
         line-height: 1.4;
       }
 
-      .lg\\\\:prose-sm h3 {
+      .lg\\\\:prose-sm :where(h3) {
         font-size: 1.2857143em;
         margin-top: 1.5555556em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .lg\\\\:prose-sm h4 {
+      .lg\\\\:prose-sm :where(h4) {
         margin-top: 1.4285714em;
         margin-bottom: 0.5714286em;
         line-height: 1.4285714;
       }
 
-      .lg\\\\:prose-sm img {
+      .lg\\\\:prose-sm :where(img) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .lg\\\\:prose-sm video {
+      .lg\\\\:prose-sm :where(video) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .lg\\\\:prose-sm figure {
+      .lg\\\\:prose-sm :where(figure) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .lg\\\\:prose-sm figure > * {
+      .lg\\\\:prose-sm :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose-sm figure figcaption {
+      .lg\\\\:prose-sm :where(figure figcaption) {
         font-size: 0.8571429em;
         line-height: 1.3333333;
         margin-top: 0.6666667em;
       }
 
-      .lg\\\\:prose-sm code {
+      .lg\\\\:prose-sm :where(code) {
         font-size: 0.8571429em;
       }
 
-      .lg\\\\:prose-sm h2 code {
+      .lg\\\\:prose-sm :where(h2 code) {
         font-size: 0.9em;
       }
 
-      .lg\\\\:prose-sm h3 code {
+      .lg\\\\:prose-sm :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .lg\\\\:prose-sm pre {
+      .lg\\\\:prose-sm :where(pre) {
         font-size: 0.8571429em;
         line-height: 1.6666667;
         margin-top: 1.6666667em;
@@ -4528,218 +4528,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .lg\\\\:prose-sm ol {
+      .lg\\\\:prose-sm :where(ol) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm ul {
+      .lg\\\\:prose-sm :where(ul) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm li {
+      .lg\\\\:prose-sm :where(li) {
         margin-top: 0.2857143em;
         margin-bottom: 0.2857143em;
       }
 
-      .lg\\\\:prose-sm ol > li {
+      .lg\\\\:prose-sm :where(ol > li) {
         padding-left: 1.5714286em;
       }
 
-      .lg\\\\:prose-sm ol > li::before {
+      .lg\\\\:prose-sm :where(ol > li::before) {
         left: 0;
       }
 
-      .lg\\\\:prose-sm ul > li {
+      .lg\\\\:prose-sm :where(ul > li) {
         padding-left: 1.5714286em;
       }
 
-      .lg\\\\:prose-sm ul > li::before {
+      .lg\\\\:prose-sm :where(ul > li::before) {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
         left: 0.2142857em;
       }
 
-      .lg\\\\:prose-sm > ul > li p {
+      .lg\\\\:prose-sm :where(> ul > li p) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .lg\\\\:prose-sm > ul > li > *:first-child {
+      .lg\\\\:prose-sm :where(> ul > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm > ul > li > *:last-child {
+      .lg\\\\:prose-sm :where(> ul > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm > ol > li > *:first-child {
+      .lg\\\\:prose-sm :where(> ol > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm > ol > li > *:last-child {
+      .lg\\\\:prose-sm :where(> ol > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .lg\\\\:prose-sm ul ul, .lg\\\\:prose-sm ul ol, .lg\\\\:prose-sm ol ul, .lg\\\\:prose-sm ol ol {
+      .lg\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .lg\\\\:prose-sm hr {
+      .lg\\\\:prose-sm :where(hr) {
         margin-top: 2.8571429em;
         margin-bottom: 2.8571429em;
       }
 
-      .lg\\\\:prose-sm hr + * {
+      .lg\\\\:prose-sm :where(hr + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-sm h2 + * {
+      .lg\\\\:prose-sm :where(h2 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-sm h3 + * {
+      .lg\\\\:prose-sm :where(h3 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-sm h4 + * {
+      .lg\\\\:prose-sm :where(h4 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-sm table {
+      .lg\\\\:prose-sm :where(table) {
         font-size: 0.8571429em;
         line-height: 1.5;
       }
 
-      .lg\\\\:prose-sm thead th {
+      .lg\\\\:prose-sm :where(thead th) {
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .lg\\\\:prose-sm thead th:first-child {
+      .lg\\\\:prose-sm :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-sm thead th:last-child {
+      .lg\\\\:prose-sm :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-sm tbody td {
+      .lg\\\\:prose-sm :where(tbody td) {
         padding-top: 0.6666667em;
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .lg\\\\:prose-sm tbody td:first-child {
+      .lg\\\\:prose-sm :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-sm tbody td:last-child {
+      .lg\\\\:prose-sm :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-sm > :first-child {
+      .lg\\\\:prose-sm :where(> :first-child) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-sm > :last-child {
+      .lg\\\\:prose-sm :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .lg\\\\:prose-lg {
-        font-size: 1.125rem;
-        line-height: 1.7777778;
+        :where(font-size): 1.125rem;
+        :where(line-height): 1.7777778;
       }
 
-      .lg\\\\:prose-lg p {
+      .lg\\\\:prose-lg :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg [class~=\\"lead\\"] {
+      .lg\\\\:prose-lg :where([class~=\\"lead\\"]) {
         font-size: 1.2222222em;
         line-height: 1.4545455;
         margin-top: 1.0909091em;
         margin-bottom: 1.0909091em;
       }
 
-      .lg\\\\:prose-lg blockquote {
+      .lg\\\\:prose-lg :where(blockquote) {
         margin-top: 1.6666667em;
         margin-bottom: 1.6666667em;
         padding-left: 1em;
       }
 
-      .lg\\\\:prose-lg h1 {
+      .lg\\\\:prose-lg :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.8333333em;
         line-height: 1;
       }
 
-      .lg\\\\:prose-lg h2 {
+      .lg\\\\:prose-lg :where(h2) {
         font-size: 1.6666667em;
         margin-top: 1.8666667em;
         margin-bottom: 1.0666667em;
         line-height: 1.3333333;
       }
 
-      .lg\\\\:prose-lg h3 {
+      .lg\\\\:prose-lg :where(h3) {
         font-size: 1.3333333em;
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .lg\\\\:prose-lg h4 {
+      .lg\\\\:prose-lg :where(h4) {
         margin-top: 1.7777778em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .lg\\\\:prose-lg img {
+      .lg\\\\:prose-lg :where(img) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .lg\\\\:prose-lg video {
+      .lg\\\\:prose-lg :where(video) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .lg\\\\:prose-lg figure {
+      .lg\\\\:prose-lg :where(figure) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .lg\\\\:prose-lg figure > * {
+      .lg\\\\:prose-lg :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose-lg figure figcaption {
+      .lg\\\\:prose-lg :where(figure figcaption) {
         font-size: 0.8888889em;
         line-height: 1.5;
         margin-top: 1em;
       }
 
-      .lg\\\\:prose-lg code {
+      .lg\\\\:prose-lg :where(code) {
         font-size: 0.8888889em;
       }
 
-      .lg\\\\:prose-lg h2 code {
+      .lg\\\\:prose-lg :where(h2 code) {
         font-size: 0.8666667em;
       }
 
-      .lg\\\\:prose-lg h3 code {
+      .lg\\\\:prose-lg :where(h3 code) {
         font-size: 0.875em;
       }
 
-      .lg\\\\:prose-lg pre {
+      .lg\\\\:prose-lg :where(pre) {
         font-size: 0.8888889em;
         line-height: 1.75;
         margin-top: 2em;
@@ -4751,218 +4751,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5em;
       }
 
-      .lg\\\\:prose-lg ol {
+      .lg\\\\:prose-lg :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg ul {
+      .lg\\\\:prose-lg :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg li {
+      .lg\\\\:prose-lg :where(li) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .lg\\\\:prose-lg ol > li {
+      .lg\\\\:prose-lg :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-lg ol > li::before {
+      .lg\\\\:prose-lg :where(ol > li::before) {
         left: 0;
       }
 
-      .lg\\\\:prose-lg ul > li {
+      .lg\\\\:prose-lg :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-lg ul > li::before {
+      .lg\\\\:prose-lg :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
         left: 0.2222222em;
       }
 
-      .lg\\\\:prose-lg > ul > li p {
+      .lg\\\\:prose-lg :where(> ul > li p) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .lg\\\\:prose-lg > ul > li > *:first-child {
+      .lg\\\\:prose-lg :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg > ul > li > *:last-child {
+      .lg\\\\:prose-lg :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg > ol > li > *:first-child {
+      .lg\\\\:prose-lg :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg > ol > li > *:last-child {
+      .lg\\\\:prose-lg :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-lg ul ul, .lg\\\\:prose-lg ul ol, .lg\\\\:prose-lg ol ul, .lg\\\\:prose-lg ol ol {
+      .lg\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .lg\\\\:prose-lg hr {
+      .lg\\\\:prose-lg :where(hr) {
         margin-top: 3.1111111em;
         margin-bottom: 3.1111111em;
       }
 
-      .lg\\\\:prose-lg hr + * {
+      .lg\\\\:prose-lg :where(hr + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-lg h2 + * {
+      .lg\\\\:prose-lg :where(h2 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-lg h3 + * {
+      .lg\\\\:prose-lg :where(h3 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-lg h4 + * {
+      .lg\\\\:prose-lg :where(h4 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-lg table {
+      .lg\\\\:prose-lg :where(table) {
         font-size: 0.8888889em;
         line-height: 1.5;
       }
 
-      .lg\\\\:prose-lg thead th {
+      .lg\\\\:prose-lg :where(thead th) {
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .lg\\\\:prose-lg thead th:first-child {
+      .lg\\\\:prose-lg :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-lg thead th:last-child {
+      .lg\\\\:prose-lg :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-lg tbody td {
+      .lg\\\\:prose-lg :where(tbody td) {
         padding-top: 0.75em;
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .lg\\\\:prose-lg tbody td:first-child {
+      .lg\\\\:prose-lg :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-lg tbody td:last-child {
+      .lg\\\\:prose-lg :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-lg > :first-child {
+      .lg\\\\:prose-lg :where(> :first-child) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-lg > :last-child {
+      .lg\\\\:prose-lg :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .lg\\\\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
+        :where(font-size): 1.25rem;
+        :where(line-height): 1.8;
       }
 
-      .lg\\\\:prose-xl p {
+      .lg\\\\:prose-xl :where(p) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose-xl [class~=\\"lead\\"] {
+      .lg\\\\:prose-xl :where([class~=\\"lead\\"]) {
         font-size: 1.2em;
         line-height: 1.5;
         margin-top: 1em;
         margin-bottom: 1em;
       }
 
-      .lg\\\\:prose-xl blockquote {
+      .lg\\\\:prose-xl :where(blockquote) {
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1.0666667em;
       }
 
-      .lg\\\\:prose-xl h1 {
+      .lg\\\\:prose-xl :where(h1) {
         font-size: 2.8em;
         margin-top: 0;
         margin-bottom: 0.8571429em;
         line-height: 1;
       }
 
-      .lg\\\\:prose-xl h2 {
+      .lg\\\\:prose-xl :where(h2) {
         font-size: 1.8em;
         margin-top: 1.5555556em;
         margin-bottom: 0.8888889em;
         line-height: 1.1111111;
       }
 
-      .lg\\\\:prose-xl h3 {
+      .lg\\\\:prose-xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.6em;
         margin-bottom: 0.6666667em;
         line-height: 1.3333333;
       }
 
-      .lg\\\\:prose-xl h4 {
+      .lg\\\\:prose-xl :where(h4) {
         margin-top: 1.8em;
         margin-bottom: 0.6em;
         line-height: 1.6;
       }
 
-      .lg\\\\:prose-xl img {
+      .lg\\\\:prose-xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-xl video {
+      .lg\\\\:prose-xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-xl figure {
+      .lg\\\\:prose-xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-xl figure > * {
+      .lg\\\\:prose-xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose-xl figure figcaption {
+      .lg\\\\:prose-xl :where(figure figcaption) {
         font-size: 0.9em;
         line-height: 1.5555556;
         margin-top: 1em;
       }
 
-      .lg\\\\:prose-xl code {
+      .lg\\\\:prose-xl :where(code) {
         font-size: 0.9em;
       }
 
-      .lg\\\\:prose-xl h2 code {
+      .lg\\\\:prose-xl :where(h2 code) {
         font-size: 0.8611111em;
       }
 
-      .lg\\\\:prose-xl h3 code {
+      .lg\\\\:prose-xl :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .lg\\\\:prose-xl pre {
+      .lg\\\\:prose-xl :where(pre) {
         font-size: 0.9em;
         line-height: 1.7777778;
         margin-top: 2em;
@@ -4974,218 +4974,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.3333333em;
       }
 
-      .lg\\\\:prose-xl ol {
+      .lg\\\\:prose-xl :where(ol) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose-xl ul {
+      .lg\\\\:prose-xl :where(ul) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose-xl li {
+      .lg\\\\:prose-xl :where(li) {
         margin-top: 0.6em;
         margin-bottom: 0.6em;
       }
 
-      .lg\\\\:prose-xl ol > li {
+      .lg\\\\:prose-xl :where(ol > li) {
         padding-left: 1.8em;
       }
 
-      .lg\\\\:prose-xl ol > li::before {
+      .lg\\\\:prose-xl :where(ol > li::before) {
         left: 0;
       }
 
-      .lg\\\\:prose-xl ul > li {
+      .lg\\\\:prose-xl :where(ul > li) {
         padding-left: 1.8em;
       }
 
-      .lg\\\\:prose-xl ul > li::before {
+      .lg\\\\:prose-xl :where(ul > li::before) {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
         left: 0.25em;
       }
 
-      .lg\\\\:prose-xl > ul > li p {
+      .lg\\\\:prose-xl :where(> ul > li p) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .lg\\\\:prose-xl > ul > li > *:first-child {
+      .lg\\\\:prose-xl :where(> ul > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .lg\\\\:prose-xl > ul > li > *:last-child {
+      .lg\\\\:prose-xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose-xl > ol > li > *:first-child {
+      .lg\\\\:prose-xl :where(> ol > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .lg\\\\:prose-xl > ol > li > *:last-child {
+      .lg\\\\:prose-xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .lg\\\\:prose-xl ul ul, .lg\\\\:prose-xl ul ol, .lg\\\\:prose-xl ol ul, .lg\\\\:prose-xl ol ol {
+      .lg\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .lg\\\\:prose-xl hr {
+      .lg\\\\:prose-xl :where(hr) {
         margin-top: 2.8em;
         margin-bottom: 2.8em;
       }
 
-      .lg\\\\:prose-xl hr + * {
+      .lg\\\\:prose-xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-xl h2 + * {
+      .lg\\\\:prose-xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-xl h3 + * {
+      .lg\\\\:prose-xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-xl h4 + * {
+      .lg\\\\:prose-xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-xl table {
+      .lg\\\\:prose-xl :where(table) {
         font-size: 0.9em;
         line-height: 1.5555556;
       }
 
-      .lg\\\\:prose-xl thead th {
+      .lg\\\\:prose-xl :where(thead th) {
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .lg\\\\:prose-xl thead th:first-child {
+      .lg\\\\:prose-xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-xl thead th:last-child {
+      .lg\\\\:prose-xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-xl tbody td {
+      .lg\\\\:prose-xl :where(tbody td) {
         padding-top: 0.8888889em;
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .lg\\\\:prose-xl tbody td:first-child {
+      .lg\\\\:prose-xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-xl tbody td:last-child {
+      .lg\\\\:prose-xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-xl > :first-child {
+      .lg\\\\:prose-xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-xl > :last-child {
+      .lg\\\\:prose-xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .lg\\\\:prose-2xl {
-        font-size: 1.5rem;
-        line-height: 1.6666667;
+        :where(font-size): 1.5rem;
+        :where(line-height): 1.6666667;
       }
 
-      .lg\\\\:prose-2xl p {
+      .lg\\\\:prose-2xl :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl [class~=\\"lead\\"] {
+      .lg\\\\:prose-2xl :where([class~=\\"lead\\"]) {
         font-size: 1.25em;
         line-height: 1.4666667;
         margin-top: 1.0666667em;
         margin-bottom: 1.0666667em;
       }
 
-      .lg\\\\:prose-2xl blockquote {
+      .lg\\\\:prose-2xl :where(blockquote) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
         padding-left: 1.1111111em;
       }
 
-      .lg\\\\:prose-2xl h1 {
+      .lg\\\\:prose-2xl :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.875em;
         line-height: 1;
       }
 
-      .lg\\\\:prose-2xl h2 {
+      .lg\\\\:prose-2xl :where(h2) {
         font-size: 2em;
         margin-top: 1.5em;
         margin-bottom: 0.8333333em;
         line-height: 1.0833333;
       }
 
-      .lg\\\\:prose-2xl h3 {
+      .lg\\\\:prose-2xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.5555556em;
         margin-bottom: 0.6666667em;
         line-height: 1.2222222;
       }
 
-      .lg\\\\:prose-2xl h4 {
+      .lg\\\\:prose-2xl :where(h4) {
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .lg\\\\:prose-2xl img {
+      .lg\\\\:prose-2xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-2xl video {
+      .lg\\\\:prose-2xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-2xl figure {
+      .lg\\\\:prose-2xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .lg\\\\:prose-2xl figure > * {
+      .lg\\\\:prose-2xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose-2xl figure figcaption {
+      .lg\\\\:prose-2xl :where(figure figcaption) {
         font-size: 0.8333333em;
         line-height: 1.6;
         margin-top: 1em;
       }
 
-      .lg\\\\:prose-2xl code {
+      .lg\\\\:prose-2xl :where(code) {
         font-size: 0.8333333em;
       }
 
-      .lg\\\\:prose-2xl h2 code {
+      .lg\\\\:prose-2xl :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .lg\\\\:prose-2xl h3 code {
+      .lg\\\\:prose-2xl :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .lg\\\\:prose-2xl pre {
+      .lg\\\\:prose-2xl :where(pre) {
         font-size: 0.8333333em;
         line-height: 1.8;
         margin-top: 2em;
@@ -5197,193 +5197,193 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6em;
       }
 
-      .lg\\\\:prose-2xl ol {
+      .lg\\\\:prose-2xl :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl ul {
+      .lg\\\\:prose-2xl :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl li {
+      .lg\\\\:prose-2xl :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .lg\\\\:prose-2xl ol > li {
+      .lg\\\\:prose-2xl :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-2xl ol > li::before {
+      .lg\\\\:prose-2xl :where(ol > li::before) {
         left: 0;
       }
 
-      .lg\\\\:prose-2xl ul > li {
+      .lg\\\\:prose-2xl :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-2xl ul > li::before {
+      .lg\\\\:prose-2xl :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
         left: 0.25em;
       }
 
-      .lg\\\\:prose-2xl > ul > li p {
+      .lg\\\\:prose-2xl :where(> ul > li p) {
         margin-top: 0.8333333em;
         margin-bottom: 0.8333333em;
       }
 
-      .lg\\\\:prose-2xl > ul > li > *:first-child {
+      .lg\\\\:prose-2xl :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl > ul > li > *:last-child {
+      .lg\\\\:prose-2xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl > ol > li > *:first-child {
+      .lg\\\\:prose-2xl :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl > ol > li > *:last-child {
+      .lg\\\\:prose-2xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .lg\\\\:prose-2xl ul ul, .lg\\\\:prose-2xl ul ol, .lg\\\\:prose-2xl ol ul, .lg\\\\:prose-2xl ol ol {
+      .lg\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .lg\\\\:prose-2xl hr {
+      .lg\\\\:prose-2xl :where(hr) {
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .lg\\\\:prose-2xl hr + * {
+      .lg\\\\:prose-2xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-2xl h2 + * {
+      .lg\\\\:prose-2xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-2xl h3 + * {
+      .lg\\\\:prose-2xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-2xl h4 + * {
+      .lg\\\\:prose-2xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-2xl table {
+      .lg\\\\:prose-2xl :where(table) {
         font-size: 0.8333333em;
         line-height: 1.4;
       }
 
-      .lg\\\\:prose-2xl thead th {
+      .lg\\\\:prose-2xl :where(thead th) {
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .lg\\\\:prose-2xl thead th:first-child {
+      .lg\\\\:prose-2xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-2xl thead th:last-child {
+      .lg\\\\:prose-2xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-2xl tbody td {
+      .lg\\\\:prose-2xl :where(tbody td) {
         padding-top: 0.8em;
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .lg\\\\:prose-2xl tbody td:first-child {
+      .lg\\\\:prose-2xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .lg\\\\:prose-2xl tbody td:last-child {
+      .lg\\\\:prose-2xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .lg\\\\:prose-2xl > :first-child {
+      .lg\\\\:prose-2xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .lg\\\\:prose-2xl > :last-child {
+      .lg\\\\:prose-2xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
-      .lg\\\\:prose-red a {
+      .lg\\\\:prose-red :where(a) {
         color: #dc2626;
       }
 
-      .lg\\\\:prose-red a code {
+      .lg\\\\:prose-red :where(a code) {
         color: #dc2626;
       }
 
-      .lg\\\\:prose-yellow a {
+      .lg\\\\:prose-yellow :where(a) {
         color: #d97706;
       }
 
-      .lg\\\\:prose-yellow a code {
+      .lg\\\\:prose-yellow :where(a code) {
         color: #d97706;
       }
 
-      .lg\\\\:prose-green a {
+      .lg\\\\:prose-green :where(a) {
         color: #059669;
       }
 
-      .lg\\\\:prose-green a code {
+      .lg\\\\:prose-green :where(a code) {
         color: #059669;
       }
 
-      .lg\\\\:prose-blue a {
+      .lg\\\\:prose-blue :where(a) {
         color: #2563eb;
       }
 
-      .lg\\\\:prose-blue a code {
+      .lg\\\\:prose-blue :where(a code) {
         color: #2563eb;
       }
 
-      .lg\\\\:prose-indigo a {
+      .lg\\\\:prose-indigo :where(a) {
         color: #4f46e5;
       }
 
-      .lg\\\\:prose-indigo a code {
+      .lg\\\\:prose-indigo :where(a code) {
         color: #4f46e5;
       }
 
-      .lg\\\\:prose-purple a {
+      .lg\\\\:prose-purple :where(a) {
         color: #7c3aed;
       }
 
-      .lg\\\\:prose-purple a code {
+      .lg\\\\:prose-purple :where(a code) {
         color: #7c3aed;
       }
 
-      .lg\\\\:prose-pink a {
+      .lg\\\\:prose-pink :where(a) {
         color: #db2777;
       }
 
-      .lg\\\\:prose-pink a code {
+      .lg\\\\:prose-pink :where(a code) {
         color: #db2777;
       }
     }
 
     @media (min-width: 1280px) {
       .xl\\\\:prose {
-        color: #374151;
-        max-width: 65ch;
+        :where(color): #374151;
+        :where(max-width): 65ch;
       }
 
-      .xl\\\\:prose [class~=\\"lead\\"] {
+      .xl\\\\:prose :where([class~=\\"lead\\"]) {
         color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
@@ -5391,59 +5391,59 @@ it('should generate the default classes for the typography components', async ()
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose a {
+      .xl\\\\:prose :where(a) {
         color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
-      .xl\\\\:prose strong {
+      .xl\\\\:prose :where(strong) {
         color: #111827;
         font-weight: 600;
       }
 
-      .xl\\\\:prose ol[type=\\"A\\"] {
+      .xl\\\\:prose :where(ol[type=\\"A\\"]) {
         --list-counter-style: upper-alpha;
       }
 
-      .xl\\\\:prose ol[type=\\"a\\"] {
+      .xl\\\\:prose :where(ol[type=\\"a\\"]) {
         --list-counter-style: lower-alpha;
       }
 
-      .xl\\\\:prose ol[type=\\"A\\" s] {
+      .xl\\\\:prose :where(ol[type=\\"A\\" s]) {
         --list-counter-style: upper-alpha;
       }
 
-      .xl\\\\:prose ol[type=\\"a\\" s] {
+      .xl\\\\:prose :where(ol[type=\\"a\\" s]) {
         --list-counter-style: lower-alpha;
       }
 
-      .xl\\\\:prose ol[type=\\"I\\"] {
+      .xl\\\\:prose :where(ol[type=\\"I\\"]) {
         --list-counter-style: upper-roman;
       }
 
-      .xl\\\\:prose ol[type=\\"i\\"] {
+      .xl\\\\:prose :where(ol[type=\\"i\\"]) {
         --list-counter-style: lower-roman;
       }
 
-      .xl\\\\:prose ol[type=\\"I\\" s] {
+      .xl\\\\:prose :where(ol[type=\\"I\\" s]) {
         --list-counter-style: upper-roman;
       }
 
-      .xl\\\\:prose ol[type=\\"i\\" s] {
+      .xl\\\\:prose :where(ol[type=\\"i\\" s]) {
         --list-counter-style: lower-roman;
       }
 
-      .xl\\\\:prose ol[type=\\"1\\"] {
+      .xl\\\\:prose :where(ol[type=\\"1\\"]) {
         --list-counter-style: decimal;
       }
 
-      .xl\\\\:prose ol > li {
+      .xl\\\\:prose :where(ol > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .xl\\\\:prose ol > li::before {
+      .xl\\\\:prose :where(ol > li::before) {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -5451,12 +5451,12 @@ it('should generate the default classes for the typography components', async ()
         left: 0;
       }
 
-      .xl\\\\:prose ul > li {
+      .xl\\\\:prose :where(ul > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .xl\\\\:prose ul > li::before {
+      .xl\\\\:prose :where(ul > li::before) {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -5467,14 +5467,14 @@ it('should generate the default classes for the typography components', async ()
         left: 0.25em;
       }
 
-      .xl\\\\:prose hr {
+      .xl\\\\:prose :where(hr) {
         border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .xl\\\\:prose blockquote {
+      .xl\\\\:prose :where(blockquote) {
         font-weight: 500;
         font-style: italic;
         color: #111827;
@@ -5486,15 +5486,15 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .xl\\\\:prose blockquote p:first-of-type::before {
+      .xl\\\\:prose :where(blockquote p:first-of-type::before) {
         content: open-quote;
       }
 
-      .xl\\\\:prose blockquote p:last-of-type::after {
+      .xl\\\\:prose :where(blockquote p:last-of-type::after) {
         content: close-quote;
       }
 
-      .xl\\\\:prose h1 {
+      .xl\\\\:prose :where(h1) {
         color: #111827;
         font-weight: 800;
         font-size: 2.25em;
@@ -5503,11 +5503,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.1111111;
       }
 
-      .xl\\\\:prose h1 strong {
+      .xl\\\\:prose :where(h1 strong) {
         font-weight: 900;
       }
 
-      .xl\\\\:prose h2 {
+      .xl\\\\:prose :where(h2) {
         color: #111827;
         font-weight: 700;
         font-size: 1.5em;
@@ -5516,11 +5516,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.3333333;
       }
 
-      .xl\\\\:prose h2 strong {
+      .xl\\\\:prose :where(h2 strong) {
         font-weight: 800;
       }
 
-      .xl\\\\:prose h3 {
+      .xl\\\\:prose :where(h3) {
         color: #111827;
         font-weight: 600;
         font-size: 1.25em;
@@ -5529,11 +5529,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.6;
       }
 
-      .xl\\\\:prose h3 strong {
+      .xl\\\\:prose :where(h3 strong) {
         font-weight: 700;
       }
 
-      .xl\\\\:prose h4 {
+      .xl\\\\:prose :where(h4) {
         color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
@@ -5541,36 +5541,36 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.5;
       }
 
-      .xl\\\\:prose h4 strong {
+      .xl\\\\:prose :where(h4 strong) {
         font-weight: 700;
       }
 
-      .xl\\\\:prose figure figcaption {
+      .xl\\\\:prose :where(figure figcaption) {
         color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
-      .xl\\\\:prose code {
+      .xl\\\\:prose :where(code) {
         color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
 
-      .xl\\\\:prose code::before {
+      .xl\\\\:prose :where(code::before) {
         content: \\"\`\\";
       }
 
-      .xl\\\\:prose code::after {
+      .xl\\\\:prose :where(code::after) {
         content: \\"\`\\";
       }
 
-      .xl\\\\:prose a code {
+      .xl\\\\:prose :where(a code) {
         color: #111827;
       }
 
-      .xl\\\\:prose pre {
+      .xl\\\\:prose :where(pre) {
         color: #e5e7eb;
         background-color: #1f2937;
         overflow-x: auto;
@@ -5585,7 +5585,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.1428571em;
       }
 
-      .xl\\\\:prose pre code {
+      .xl\\\\:prose :where(pre code) {
         background-color: transparent;
         border-width: 0;
         border-radius: 0;
@@ -5597,15 +5597,15 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .xl\\\\:prose pre code::before {
+      .xl\\\\:prose :where(pre code::before) {
         content: none;
       }
 
-      .xl\\\\:prose pre code::after {
+      .xl\\\\:prose :where(pre code::after) {
         content: none;
       }
 
-      .xl\\\\:prose table {
+      .xl\\\\:prose :where(table) {
         width: 100%;
         table-layout: auto;
         text-align: left;
@@ -5615,30 +5615,30 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.7142857;
       }
 
-      .xl\\\\:prose thead {
+      .xl\\\\:prose :where(thead) {
         color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
         border-bottom-color: #d1d5db;
       }
 
-      .xl\\\\:prose thead th {
+      .xl\\\\:prose :where(thead th) {
         vertical-align: bottom;
         padding-right: 0.5714286em;
         padding-bottom: 0.5714286em;
         padding-left: 0.5714286em;
       }
 
-      .xl\\\\:prose tbody tr {
+      .xl\\\\:prose :where(tbody tr) {
         border-bottom-width: 1px;
         border-bottom-color: #e5e7eb;
       }
 
-      .xl\\\\:prose tbody tr:last-child {
+      .xl\\\\:prose :where(tbody tr:last-child) {
         border-bottom-width: 0;
       }
 
-      .xl\\\\:prose tbody td {
+      .xl\\\\:prose :where(tbody td) {
         vertical-align: top;
         padding-top: 0.5714286em;
         padding-right: 0.5714286em;
@@ -5647,213 +5647,213 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose {
-        font-size: 1rem;
-        line-height: 1.75;
+        :where(font-size): 1rem;
+        :where(line-height): 1.75;
       }
 
-      .xl\\\\:prose p {
+      .xl\\\\:prose :where(p) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .xl\\\\:prose img {
+      .xl\\\\:prose :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose video {
+      .xl\\\\:prose :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose figure {
+      .xl\\\\:prose :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose figure > * {
+      .xl\\\\:prose :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose h2 code {
+      .xl\\\\:prose :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .xl\\\\:prose h3 code {
+      .xl\\\\:prose :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .xl\\\\:prose ol {
+      .xl\\\\:prose :where(ol) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .xl\\\\:prose ul {
+      .xl\\\\:prose :where(ul) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .xl\\\\:prose li {
+      .xl\\\\:prose :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .xl\\\\:prose > ul > li p {
+      .xl\\\\:prose :where(> ul > li p) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .xl\\\\:prose > ul > li > *:first-child {
+      .xl\\\\:prose :where(> ul > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .xl\\\\:prose > ul > li > *:last-child {
+      .xl\\\\:prose :where(> ul > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .xl\\\\:prose > ol > li > *:first-child {
+      .xl\\\\:prose :where(> ol > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .xl\\\\:prose > ol > li > *:last-child {
+      .xl\\\\:prose :where(> ol > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .xl\\\\:prose ul ul, .xl\\\\:prose ul ol, .xl\\\\:prose ol ul, .xl\\\\:prose ol ol {
+      .xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .xl\\\\:prose hr + * {
+      .xl\\\\:prose :where(hr + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose h2 + * {
+      .xl\\\\:prose :where(h2 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose h3 + * {
+      .xl\\\\:prose :where(h3 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose h4 + * {
+      .xl\\\\:prose :where(h4 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose thead th:first-child {
+      .xl\\\\:prose :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose thead th:last-child {
+      .xl\\\\:prose :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose tbody td:first-child {
+      .xl\\\\:prose :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose tbody td:last-child {
+      .xl\\\\:prose :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose > :first-child {
+      .xl\\\\:prose :where(> :first-child) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose > :last-child {
+      .xl\\\\:prose :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .xl\\\\:prose-sm {
-        font-size: 0.875rem;
-        line-height: 1.7142857;
+        :where(font-size): 0.875rem;
+        :where(line-height): 1.7142857;
       }
 
-      .xl\\\\:prose-sm p {
+      .xl\\\\:prose-sm :where(p) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm [class~=\\"lead\\"] {
+      .xl\\\\:prose-sm :where([class~=\\"lead\\"]) {
         font-size: 1.2857143em;
         line-height: 1.5555556;
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .xl\\\\:prose-sm blockquote {
+      .xl\\\\:prose-sm :where(blockquote) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
         padding-left: 1.1111111em;
       }
 
-      .xl\\\\:prose-sm h1 {
+      .xl\\\\:prose-sm :where(h1) {
         font-size: 2.1428571em;
         margin-top: 0;
         margin-bottom: 0.8em;
         line-height: 1.2;
       }
 
-      .xl\\\\:prose-sm h2 {
+      .xl\\\\:prose-sm :where(h2) {
         font-size: 1.4285714em;
         margin-top: 1.6em;
         margin-bottom: 0.8em;
         line-height: 1.4;
       }
 
-      .xl\\\\:prose-sm h3 {
+      .xl\\\\:prose-sm :where(h3) {
         font-size: 1.2857143em;
         margin-top: 1.5555556em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .xl\\\\:prose-sm h4 {
+      .xl\\\\:prose-sm :where(h4) {
         margin-top: 1.4285714em;
         margin-bottom: 0.5714286em;
         line-height: 1.4285714;
       }
 
-      .xl\\\\:prose-sm img {
+      .xl\\\\:prose-sm :where(img) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .xl\\\\:prose-sm video {
+      .xl\\\\:prose-sm :where(video) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .xl\\\\:prose-sm figure {
+      .xl\\\\:prose-sm :where(figure) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .xl\\\\:prose-sm figure > * {
+      .xl\\\\:prose-sm :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose-sm figure figcaption {
+      .xl\\\\:prose-sm :where(figure figcaption) {
         font-size: 0.8571429em;
         line-height: 1.3333333;
         margin-top: 0.6666667em;
       }
 
-      .xl\\\\:prose-sm code {
+      .xl\\\\:prose-sm :where(code) {
         font-size: 0.8571429em;
       }
 
-      .xl\\\\:prose-sm h2 code {
+      .xl\\\\:prose-sm :where(h2 code) {
         font-size: 0.9em;
       }
 
-      .xl\\\\:prose-sm h3 code {
+      .xl\\\\:prose-sm :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .xl\\\\:prose-sm pre {
+      .xl\\\\:prose-sm :where(pre) {
         font-size: 0.8571429em;
         line-height: 1.6666667;
         margin-top: 1.6666667em;
@@ -5865,218 +5865,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .xl\\\\:prose-sm ol {
+      .xl\\\\:prose-sm :where(ol) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm ul {
+      .xl\\\\:prose-sm :where(ul) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm li {
+      .xl\\\\:prose-sm :where(li) {
         margin-top: 0.2857143em;
         margin-bottom: 0.2857143em;
       }
 
-      .xl\\\\:prose-sm ol > li {
+      .xl\\\\:prose-sm :where(ol > li) {
         padding-left: 1.5714286em;
       }
 
-      .xl\\\\:prose-sm ol > li::before {
+      .xl\\\\:prose-sm :where(ol > li::before) {
         left: 0;
       }
 
-      .xl\\\\:prose-sm ul > li {
+      .xl\\\\:prose-sm :where(ul > li) {
         padding-left: 1.5714286em;
       }
 
-      .xl\\\\:prose-sm ul > li::before {
+      .xl\\\\:prose-sm :where(ul > li::before) {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
         left: 0.2142857em;
       }
 
-      .xl\\\\:prose-sm > ul > li p {
+      .xl\\\\:prose-sm :where(> ul > li p) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .xl\\\\:prose-sm > ul > li > *:first-child {
+      .xl\\\\:prose-sm :where(> ul > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm > ul > li > *:last-child {
+      .xl\\\\:prose-sm :where(> ul > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm > ol > li > *:first-child {
+      .xl\\\\:prose-sm :where(> ol > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm > ol > li > *:last-child {
+      .xl\\\\:prose-sm :where(> ol > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .xl\\\\:prose-sm ul ul, .xl\\\\:prose-sm ul ol, .xl\\\\:prose-sm ol ul, .xl\\\\:prose-sm ol ol {
+      .xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .xl\\\\:prose-sm hr {
+      .xl\\\\:prose-sm :where(hr) {
         margin-top: 2.8571429em;
         margin-bottom: 2.8571429em;
       }
 
-      .xl\\\\:prose-sm hr + * {
+      .xl\\\\:prose-sm :where(hr + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-sm h2 + * {
+      .xl\\\\:prose-sm :where(h2 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-sm h3 + * {
+      .xl\\\\:prose-sm :where(h3 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-sm h4 + * {
+      .xl\\\\:prose-sm :where(h4 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-sm table {
+      .xl\\\\:prose-sm :where(table) {
         font-size: 0.8571429em;
         line-height: 1.5;
       }
 
-      .xl\\\\:prose-sm thead th {
+      .xl\\\\:prose-sm :where(thead th) {
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .xl\\\\:prose-sm thead th:first-child {
+      .xl\\\\:prose-sm :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-sm thead th:last-child {
+      .xl\\\\:prose-sm :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-sm tbody td {
+      .xl\\\\:prose-sm :where(tbody td) {
         padding-top: 0.6666667em;
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .xl\\\\:prose-sm tbody td:first-child {
+      .xl\\\\:prose-sm :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-sm tbody td:last-child {
+      .xl\\\\:prose-sm :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-sm > :first-child {
+      .xl\\\\:prose-sm :where(> :first-child) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-sm > :last-child {
+      .xl\\\\:prose-sm :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .xl\\\\:prose-lg {
-        font-size: 1.125rem;
-        line-height: 1.7777778;
+        :where(font-size): 1.125rem;
+        :where(line-height): 1.7777778;
       }
 
-      .xl\\\\:prose-lg p {
+      .xl\\\\:prose-lg :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg [class~=\\"lead\\"] {
+      .xl\\\\:prose-lg :where([class~=\\"lead\\"]) {
         font-size: 1.2222222em;
         line-height: 1.4545455;
         margin-top: 1.0909091em;
         margin-bottom: 1.0909091em;
       }
 
-      .xl\\\\:prose-lg blockquote {
+      .xl\\\\:prose-lg :where(blockquote) {
         margin-top: 1.6666667em;
         margin-bottom: 1.6666667em;
         padding-left: 1em;
       }
 
-      .xl\\\\:prose-lg h1 {
+      .xl\\\\:prose-lg :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.8333333em;
         line-height: 1;
       }
 
-      .xl\\\\:prose-lg h2 {
+      .xl\\\\:prose-lg :where(h2) {
         font-size: 1.6666667em;
         margin-top: 1.8666667em;
         margin-bottom: 1.0666667em;
         line-height: 1.3333333;
       }
 
-      .xl\\\\:prose-lg h3 {
+      .xl\\\\:prose-lg :where(h3) {
         font-size: 1.3333333em;
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .xl\\\\:prose-lg h4 {
+      .xl\\\\:prose-lg :where(h4) {
         margin-top: 1.7777778em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .xl\\\\:prose-lg img {
+      .xl\\\\:prose-lg :where(img) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .xl\\\\:prose-lg video {
+      .xl\\\\:prose-lg :where(video) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .xl\\\\:prose-lg figure {
+      .xl\\\\:prose-lg :where(figure) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .xl\\\\:prose-lg figure > * {
+      .xl\\\\:prose-lg :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose-lg figure figcaption {
+      .xl\\\\:prose-lg :where(figure figcaption) {
         font-size: 0.8888889em;
         line-height: 1.5;
         margin-top: 1em;
       }
 
-      .xl\\\\:prose-lg code {
+      .xl\\\\:prose-lg :where(code) {
         font-size: 0.8888889em;
       }
 
-      .xl\\\\:prose-lg h2 code {
+      .xl\\\\:prose-lg :where(h2 code) {
         font-size: 0.8666667em;
       }
 
-      .xl\\\\:prose-lg h3 code {
+      .xl\\\\:prose-lg :where(h3 code) {
         font-size: 0.875em;
       }
 
-      .xl\\\\:prose-lg pre {
+      .xl\\\\:prose-lg :where(pre) {
         font-size: 0.8888889em;
         line-height: 1.75;
         margin-top: 2em;
@@ -6088,218 +6088,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5em;
       }
 
-      .xl\\\\:prose-lg ol {
+      .xl\\\\:prose-lg :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg ul {
+      .xl\\\\:prose-lg :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg li {
+      .xl\\\\:prose-lg :where(li) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .xl\\\\:prose-lg ol > li {
+      .xl\\\\:prose-lg :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-lg ol > li::before {
+      .xl\\\\:prose-lg :where(ol > li::before) {
         left: 0;
       }
 
-      .xl\\\\:prose-lg ul > li {
+      .xl\\\\:prose-lg :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-lg ul > li::before {
+      .xl\\\\:prose-lg :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
         left: 0.2222222em;
       }
 
-      .xl\\\\:prose-lg > ul > li p {
+      .xl\\\\:prose-lg :where(> ul > li p) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .xl\\\\:prose-lg > ul > li > *:first-child {
+      .xl\\\\:prose-lg :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg > ul > li > *:last-child {
+      .xl\\\\:prose-lg :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg > ol > li > *:first-child {
+      .xl\\\\:prose-lg :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg > ol > li > *:last-child {
+      .xl\\\\:prose-lg :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-lg ul ul, .xl\\\\:prose-lg ul ol, .xl\\\\:prose-lg ol ul, .xl\\\\:prose-lg ol ol {
+      .xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .xl\\\\:prose-lg hr {
+      .xl\\\\:prose-lg :where(hr) {
         margin-top: 3.1111111em;
         margin-bottom: 3.1111111em;
       }
 
-      .xl\\\\:prose-lg hr + * {
+      .xl\\\\:prose-lg :where(hr + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-lg h2 + * {
+      .xl\\\\:prose-lg :where(h2 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-lg h3 + * {
+      .xl\\\\:prose-lg :where(h3 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-lg h4 + * {
+      .xl\\\\:prose-lg :where(h4 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-lg table {
+      .xl\\\\:prose-lg :where(table) {
         font-size: 0.8888889em;
         line-height: 1.5;
       }
 
-      .xl\\\\:prose-lg thead th {
+      .xl\\\\:prose-lg :where(thead th) {
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .xl\\\\:prose-lg thead th:first-child {
+      .xl\\\\:prose-lg :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-lg thead th:last-child {
+      .xl\\\\:prose-lg :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-lg tbody td {
+      .xl\\\\:prose-lg :where(tbody td) {
         padding-top: 0.75em;
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .xl\\\\:prose-lg tbody td:first-child {
+      .xl\\\\:prose-lg :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-lg tbody td:last-child {
+      .xl\\\\:prose-lg :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-lg > :first-child {
+      .xl\\\\:prose-lg :where(> :first-child) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-lg > :last-child {
+      .xl\\\\:prose-lg :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .xl\\\\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
+        :where(font-size): 1.25rem;
+        :where(line-height): 1.8;
       }
 
-      .xl\\\\:prose-xl p {
+      .xl\\\\:prose-xl :where(p) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose-xl [class~=\\"lead\\"] {
+      .xl\\\\:prose-xl :where([class~=\\"lead\\"]) {
         font-size: 1.2em;
         line-height: 1.5;
         margin-top: 1em;
         margin-bottom: 1em;
       }
 
-      .xl\\\\:prose-xl blockquote {
+      .xl\\\\:prose-xl :where(blockquote) {
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1.0666667em;
       }
 
-      .xl\\\\:prose-xl h1 {
+      .xl\\\\:prose-xl :where(h1) {
         font-size: 2.8em;
         margin-top: 0;
         margin-bottom: 0.8571429em;
         line-height: 1;
       }
 
-      .xl\\\\:prose-xl h2 {
+      .xl\\\\:prose-xl :where(h2) {
         font-size: 1.8em;
         margin-top: 1.5555556em;
         margin-bottom: 0.8888889em;
         line-height: 1.1111111;
       }
 
-      .xl\\\\:prose-xl h3 {
+      .xl\\\\:prose-xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.6em;
         margin-bottom: 0.6666667em;
         line-height: 1.3333333;
       }
 
-      .xl\\\\:prose-xl h4 {
+      .xl\\\\:prose-xl :where(h4) {
         margin-top: 1.8em;
         margin-bottom: 0.6em;
         line-height: 1.6;
       }
 
-      .xl\\\\:prose-xl img {
+      .xl\\\\:prose-xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-xl video {
+      .xl\\\\:prose-xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-xl figure {
+      .xl\\\\:prose-xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-xl figure > * {
+      .xl\\\\:prose-xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose-xl figure figcaption {
+      .xl\\\\:prose-xl :where(figure figcaption) {
         font-size: 0.9em;
         line-height: 1.5555556;
         margin-top: 1em;
       }
 
-      .xl\\\\:prose-xl code {
+      .xl\\\\:prose-xl :where(code) {
         font-size: 0.9em;
       }
 
-      .xl\\\\:prose-xl h2 code {
+      .xl\\\\:prose-xl :where(h2 code) {
         font-size: 0.8611111em;
       }
 
-      .xl\\\\:prose-xl h3 code {
+      .xl\\\\:prose-xl :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .xl\\\\:prose-xl pre {
+      .xl\\\\:prose-xl :where(pre) {
         font-size: 0.9em;
         line-height: 1.7777778;
         margin-top: 2em;
@@ -6311,218 +6311,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.3333333em;
       }
 
-      .xl\\\\:prose-xl ol {
+      .xl\\\\:prose-xl :where(ol) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose-xl ul {
+      .xl\\\\:prose-xl :where(ul) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose-xl li {
+      .xl\\\\:prose-xl :where(li) {
         margin-top: 0.6em;
         margin-bottom: 0.6em;
       }
 
-      .xl\\\\:prose-xl ol > li {
+      .xl\\\\:prose-xl :where(ol > li) {
         padding-left: 1.8em;
       }
 
-      .xl\\\\:prose-xl ol > li::before {
+      .xl\\\\:prose-xl :where(ol > li::before) {
         left: 0;
       }
 
-      .xl\\\\:prose-xl ul > li {
+      .xl\\\\:prose-xl :where(ul > li) {
         padding-left: 1.8em;
       }
 
-      .xl\\\\:prose-xl ul > li::before {
+      .xl\\\\:prose-xl :where(ul > li::before) {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
         left: 0.25em;
       }
 
-      .xl\\\\:prose-xl > ul > li p {
+      .xl\\\\:prose-xl :where(> ul > li p) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .xl\\\\:prose-xl > ul > li > *:first-child {
+      .xl\\\\:prose-xl :where(> ul > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .xl\\\\:prose-xl > ul > li > *:last-child {
+      .xl\\\\:prose-xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose-xl > ol > li > *:first-child {
+      .xl\\\\:prose-xl :where(> ol > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .xl\\\\:prose-xl > ol > li > *:last-child {
+      .xl\\\\:prose-xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .xl\\\\:prose-xl ul ul, .xl\\\\:prose-xl ul ol, .xl\\\\:prose-xl ol ul, .xl\\\\:prose-xl ol ol {
+      .xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .xl\\\\:prose-xl hr {
+      .xl\\\\:prose-xl :where(hr) {
         margin-top: 2.8em;
         margin-bottom: 2.8em;
       }
 
-      .xl\\\\:prose-xl hr + * {
+      .xl\\\\:prose-xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-xl h2 + * {
+      .xl\\\\:prose-xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-xl h3 + * {
+      .xl\\\\:prose-xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-xl h4 + * {
+      .xl\\\\:prose-xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-xl table {
+      .xl\\\\:prose-xl :where(table) {
         font-size: 0.9em;
         line-height: 1.5555556;
       }
 
-      .xl\\\\:prose-xl thead th {
+      .xl\\\\:prose-xl :where(thead th) {
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .xl\\\\:prose-xl thead th:first-child {
+      .xl\\\\:prose-xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-xl thead th:last-child {
+      .xl\\\\:prose-xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-xl tbody td {
+      .xl\\\\:prose-xl :where(tbody td) {
         padding-top: 0.8888889em;
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .xl\\\\:prose-xl tbody td:first-child {
+      .xl\\\\:prose-xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-xl tbody td:last-child {
+      .xl\\\\:prose-xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-xl > :first-child {
+      .xl\\\\:prose-xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-xl > :last-child {
+      .xl\\\\:prose-xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .xl\\\\:prose-2xl {
-        font-size: 1.5rem;
-        line-height: 1.6666667;
+        :where(font-size): 1.5rem;
+        :where(line-height): 1.6666667;
       }
 
-      .xl\\\\:prose-2xl p {
+      .xl\\\\:prose-2xl :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl [class~=\\"lead\\"] {
+      .xl\\\\:prose-2xl :where([class~=\\"lead\\"]) {
         font-size: 1.25em;
         line-height: 1.4666667;
         margin-top: 1.0666667em;
         margin-bottom: 1.0666667em;
       }
 
-      .xl\\\\:prose-2xl blockquote {
+      .xl\\\\:prose-2xl :where(blockquote) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
         padding-left: 1.1111111em;
       }
 
-      .xl\\\\:prose-2xl h1 {
+      .xl\\\\:prose-2xl :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.875em;
         line-height: 1;
       }
 
-      .xl\\\\:prose-2xl h2 {
+      .xl\\\\:prose-2xl :where(h2) {
         font-size: 2em;
         margin-top: 1.5em;
         margin-bottom: 0.8333333em;
         line-height: 1.0833333;
       }
 
-      .xl\\\\:prose-2xl h3 {
+      .xl\\\\:prose-2xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.5555556em;
         margin-bottom: 0.6666667em;
         line-height: 1.2222222;
       }
 
-      .xl\\\\:prose-2xl h4 {
+      .xl\\\\:prose-2xl :where(h4) {
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .xl\\\\:prose-2xl img {
+      .xl\\\\:prose-2xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-2xl video {
+      .xl\\\\:prose-2xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-2xl figure {
+      .xl\\\\:prose-2xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .xl\\\\:prose-2xl figure > * {
+      .xl\\\\:prose-2xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose-2xl figure figcaption {
+      .xl\\\\:prose-2xl :where(figure figcaption) {
         font-size: 0.8333333em;
         line-height: 1.6;
         margin-top: 1em;
       }
 
-      .xl\\\\:prose-2xl code {
+      .xl\\\\:prose-2xl :where(code) {
         font-size: 0.8333333em;
       }
 
-      .xl\\\\:prose-2xl h2 code {
+      .xl\\\\:prose-2xl :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .xl\\\\:prose-2xl h3 code {
+      .xl\\\\:prose-2xl :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .xl\\\\:prose-2xl pre {
+      .xl\\\\:prose-2xl :where(pre) {
         font-size: 0.8333333em;
         line-height: 1.8;
         margin-top: 2em;
@@ -6534,193 +6534,193 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6em;
       }
 
-      .xl\\\\:prose-2xl ol {
+      .xl\\\\:prose-2xl :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl ul {
+      .xl\\\\:prose-2xl :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl li {
+      .xl\\\\:prose-2xl :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .xl\\\\:prose-2xl ol > li {
+      .xl\\\\:prose-2xl :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-2xl ol > li::before {
+      .xl\\\\:prose-2xl :where(ol > li::before) {
         left: 0;
       }
 
-      .xl\\\\:prose-2xl ul > li {
+      .xl\\\\:prose-2xl :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-2xl ul > li::before {
+      .xl\\\\:prose-2xl :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
         left: 0.25em;
       }
 
-      .xl\\\\:prose-2xl > ul > li p {
+      .xl\\\\:prose-2xl :where(> ul > li p) {
         margin-top: 0.8333333em;
         margin-bottom: 0.8333333em;
       }
 
-      .xl\\\\:prose-2xl > ul > li > *:first-child {
+      .xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl > ul > li > *:last-child {
+      .xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl > ol > li > *:first-child {
+      .xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl > ol > li > *:last-child {
+      .xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .xl\\\\:prose-2xl ul ul, .xl\\\\:prose-2xl ul ol, .xl\\\\:prose-2xl ol ul, .xl\\\\:prose-2xl ol ol {
+      .xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .xl\\\\:prose-2xl hr {
+      .xl\\\\:prose-2xl :where(hr) {
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .xl\\\\:prose-2xl hr + * {
+      .xl\\\\:prose-2xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-2xl h2 + * {
+      .xl\\\\:prose-2xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-2xl h3 + * {
+      .xl\\\\:prose-2xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-2xl h4 + * {
+      .xl\\\\:prose-2xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-2xl table {
+      .xl\\\\:prose-2xl :where(table) {
         font-size: 0.8333333em;
         line-height: 1.4;
       }
 
-      .xl\\\\:prose-2xl thead th {
+      .xl\\\\:prose-2xl :where(thead th) {
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .xl\\\\:prose-2xl thead th:first-child {
+      .xl\\\\:prose-2xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-2xl thead th:last-child {
+      .xl\\\\:prose-2xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-2xl tbody td {
+      .xl\\\\:prose-2xl :where(tbody td) {
         padding-top: 0.8em;
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .xl\\\\:prose-2xl tbody td:first-child {
+      .xl\\\\:prose-2xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .xl\\\\:prose-2xl tbody td:last-child {
+      .xl\\\\:prose-2xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .xl\\\\:prose-2xl > :first-child {
+      .xl\\\\:prose-2xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .xl\\\\:prose-2xl > :last-child {
+      .xl\\\\:prose-2xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
-      .xl\\\\:prose-red a {
+      .xl\\\\:prose-red :where(a) {
         color: #dc2626;
       }
 
-      .xl\\\\:prose-red a code {
+      .xl\\\\:prose-red :where(a code) {
         color: #dc2626;
       }
 
-      .xl\\\\:prose-yellow a {
+      .xl\\\\:prose-yellow :where(a) {
         color: #d97706;
       }
 
-      .xl\\\\:prose-yellow a code {
+      .xl\\\\:prose-yellow :where(a code) {
         color: #d97706;
       }
 
-      .xl\\\\:prose-green a {
+      .xl\\\\:prose-green :where(a) {
         color: #059669;
       }
 
-      .xl\\\\:prose-green a code {
+      .xl\\\\:prose-green :where(a code) {
         color: #059669;
       }
 
-      .xl\\\\:prose-blue a {
+      .xl\\\\:prose-blue :where(a) {
         color: #2563eb;
       }
 
-      .xl\\\\:prose-blue a code {
+      .xl\\\\:prose-blue :where(a code) {
         color: #2563eb;
       }
 
-      .xl\\\\:prose-indigo a {
+      .xl\\\\:prose-indigo :where(a) {
         color: #4f46e5;
       }
 
-      .xl\\\\:prose-indigo a code {
+      .xl\\\\:prose-indigo :where(a code) {
         color: #4f46e5;
       }
 
-      .xl\\\\:prose-purple a {
+      .xl\\\\:prose-purple :where(a) {
         color: #7c3aed;
       }
 
-      .xl\\\\:prose-purple a code {
+      .xl\\\\:prose-purple :where(a code) {
         color: #7c3aed;
       }
 
-      .xl\\\\:prose-pink a {
+      .xl\\\\:prose-pink :where(a) {
         color: #db2777;
       }
 
-      .xl\\\\:prose-pink a code {
+      .xl\\\\:prose-pink :where(a code) {
         color: #db2777;
       }
     }
 
     @media (min-width: 1536px) {
       .\\\\32xl\\\\:prose {
-        color: #374151;
-        max-width: 65ch;
+        :where(color): #374151;
+        :where(max-width): 65ch;
       }
 
-      .\\\\32xl\\\\:prose [class~=\\"lead\\"] {
+      .\\\\32xl\\\\:prose :where([class~=\\"lead\\"]) {
         color: #4b5563;
         font-size: 1.25em;
         line-height: 1.6;
@@ -6728,59 +6728,59 @@ it('should generate the default classes for the typography components', async ()
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose a {
+      .\\\\32xl\\\\:prose :where(a) {
         color: #111827;
         text-decoration: underline;
         font-weight: 500;
       }
 
-      .\\\\32xl\\\\:prose strong {
+      .\\\\32xl\\\\:prose :where(strong) {
         color: #111827;
         font-weight: 600;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"A\\"] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"A\\"]) {
         --list-counter-style: upper-alpha;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"a\\"] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"a\\"]) {
         --list-counter-style: lower-alpha;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"A\\" s] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"A\\" s]) {
         --list-counter-style: upper-alpha;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"a\\" s] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"a\\" s]) {
         --list-counter-style: lower-alpha;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"I\\"] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"I\\"]) {
         --list-counter-style: upper-roman;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"i\\"] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"i\\"]) {
         --list-counter-style: lower-roman;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"I\\" s] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"I\\" s]) {
         --list-counter-style: upper-roman;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"i\\" s] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"i\\" s]) {
         --list-counter-style: lower-roman;
       }
 
-      .\\\\32xl\\\\:prose ol[type=\\"1\\"] {
+      .\\\\32xl\\\\:prose :where(ol[type=\\"1\\"]) {
         --list-counter-style: decimal;
       }
 
-      .\\\\32xl\\\\:prose ol > li {
+      .\\\\32xl\\\\:prose :where(ol > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .\\\\32xl\\\\:prose ol > li::before {
+      .\\\\32xl\\\\:prose :where(ol > li::before) {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -6788,12 +6788,12 @@ it('should generate the default classes for the typography components', async ()
         left: 0;
       }
 
-      .\\\\32xl\\\\:prose ul > li {
+      .\\\\32xl\\\\:prose :where(ul > li) {
         position: relative;
         padding-left: 1.75em;
       }
 
-      .\\\\32xl\\\\:prose ul > li::before {
+      .\\\\32xl\\\\:prose :where(ul > li::before) {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -6804,14 +6804,14 @@ it('should generate the default classes for the typography components', async ()
         left: 0.25em;
       }
 
-      .\\\\32xl\\\\:prose hr {
+      .\\\\32xl\\\\:prose :where(hr) {
         border-color: #e5e7eb;
         border-top-width: 1px;
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .\\\\32xl\\\\:prose blockquote {
+      .\\\\32xl\\\\:prose :where(blockquote) {
         font-weight: 500;
         font-style: italic;
         color: #111827;
@@ -6823,15 +6823,15 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose blockquote p:first-of-type::before {
+      .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
         content: open-quote;
       }
 
-      .\\\\32xl\\\\:prose blockquote p:last-of-type::after {
+      .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
         content: close-quote;
       }
 
-      .\\\\32xl\\\\:prose h1 {
+      .\\\\32xl\\\\:prose :where(h1) {
         color: #111827;
         font-weight: 800;
         font-size: 2.25em;
@@ -6840,11 +6840,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.1111111;
       }
 
-      .\\\\32xl\\\\:prose h1 strong {
+      .\\\\32xl\\\\:prose :where(h1 strong) {
         font-weight: 900;
       }
 
-      .\\\\32xl\\\\:prose h2 {
+      .\\\\32xl\\\\:prose :where(h2) {
         color: #111827;
         font-weight: 700;
         font-size: 1.5em;
@@ -6853,11 +6853,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.3333333;
       }
 
-      .\\\\32xl\\\\:prose h2 strong {
+      .\\\\32xl\\\\:prose :where(h2 strong) {
         font-weight: 800;
       }
 
-      .\\\\32xl\\\\:prose h3 {
+      .\\\\32xl\\\\:prose :where(h3) {
         color: #111827;
         font-weight: 600;
         font-size: 1.25em;
@@ -6866,11 +6866,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.6;
       }
 
-      .\\\\32xl\\\\:prose h3 strong {
+      .\\\\32xl\\\\:prose :where(h3 strong) {
         font-weight: 700;
       }
 
-      .\\\\32xl\\\\:prose h4 {
+      .\\\\32xl\\\\:prose :where(h4) {
         color: #111827;
         font-weight: 600;
         margin-top: 1.5em;
@@ -6878,36 +6878,36 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.5;
       }
 
-      .\\\\32xl\\\\:prose h4 strong {
+      .\\\\32xl\\\\:prose :where(h4 strong) {
         font-weight: 700;
       }
 
-      .\\\\32xl\\\\:prose figure figcaption {
+      .\\\\32xl\\\\:prose :where(figure figcaption) {
         color: #6b7280;
         font-size: 0.875em;
         line-height: 1.4285714;
         margin-top: 0.8571429em;
       }
 
-      .\\\\32xl\\\\:prose code {
+      .\\\\32xl\\\\:prose :where(code) {
         color: #111827;
         font-weight: 600;
         font-size: 0.875em;
       }
 
-      .\\\\32xl\\\\:prose code::before {
+      .\\\\32xl\\\\:prose :where(code::before) {
         content: \\"\`\\";
       }
 
-      .\\\\32xl\\\\:prose code::after {
+      .\\\\32xl\\\\:prose :where(code::after) {
         content: \\"\`\\";
       }
 
-      .\\\\32xl\\\\:prose a code {
+      .\\\\32xl\\\\:prose :where(a code) {
         color: #111827;
       }
 
-      .\\\\32xl\\\\:prose pre {
+      .\\\\32xl\\\\:prose :where(pre) {
         color: #e5e7eb;
         background-color: #1f2937;
         overflow-x: auto;
@@ -6922,7 +6922,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose pre code {
+      .\\\\32xl\\\\:prose :where(pre code) {
         background-color: transparent;
         border-width: 0;
         border-radius: 0;
@@ -6934,15 +6934,15 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .\\\\32xl\\\\:prose pre code::before {
+      .\\\\32xl\\\\:prose :where(pre code::before) {
         content: none;
       }
 
-      .\\\\32xl\\\\:prose pre code::after {
+      .\\\\32xl\\\\:prose :where(pre code::after) {
         content: none;
       }
 
-      .\\\\32xl\\\\:prose table {
+      .\\\\32xl\\\\:prose :where(table) {
         width: 100%;
         table-layout: auto;
         text-align: left;
@@ -6952,30 +6952,30 @@ it('should generate the default classes for the typography components', async ()
         line-height: 1.7142857;
       }
 
-      .\\\\32xl\\\\:prose thead {
+      .\\\\32xl\\\\:prose :where(thead) {
         color: #111827;
         font-weight: 600;
         border-bottom-width: 1px;
         border-bottom-color: #d1d5db;
       }
 
-      .\\\\32xl\\\\:prose thead th {
+      .\\\\32xl\\\\:prose :where(thead th) {
         vertical-align: bottom;
         padding-right: 0.5714286em;
         padding-bottom: 0.5714286em;
         padding-left: 0.5714286em;
       }
 
-      .\\\\32xl\\\\:prose tbody tr {
+      .\\\\32xl\\\\:prose :where(tbody tr) {
         border-bottom-width: 1px;
         border-bottom-color: #e5e7eb;
       }
 
-      .\\\\32xl\\\\:prose tbody tr:last-child {
+      .\\\\32xl\\\\:prose :where(tbody tr:last-child) {
         border-bottom-width: 0;
       }
 
-      .\\\\32xl\\\\:prose tbody td {
+      .\\\\32xl\\\\:prose :where(tbody td) {
         vertical-align: top;
         padding-top: 0.5714286em;
         padding-right: 0.5714286em;
@@ -6984,213 +6984,213 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose {
-        font-size: 1rem;
-        line-height: 1.75;
+        :where(font-size): 1rem;
+        :where(line-height): 1.75;
       }
 
-      .\\\\32xl\\\\:prose p {
+      .\\\\32xl\\\\:prose :where(p) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose img {
+      .\\\\32xl\\\\:prose :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose video {
+      .\\\\32xl\\\\:prose :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose figure {
+      .\\\\32xl\\\\:prose :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose figure > * {
+      .\\\\32xl\\\\:prose :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose h2 code {
+      .\\\\32xl\\\\:prose :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .\\\\32xl\\\\:prose h3 code {
+      .\\\\32xl\\\\:prose :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .\\\\32xl\\\\:prose ol {
+      .\\\\32xl\\\\:prose :where(ol) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose ul {
+      .\\\\32xl\\\\:prose :where(ul) {
         margin-top: 1.25em;
         margin-bottom: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose li {
+      .\\\\32xl\\\\:prose :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .\\\\32xl\\\\:prose > ul > li p {
+      .\\\\32xl\\\\:prose :where(> ul > li p) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .\\\\32xl\\\\:prose > ul > li > *:first-child {
+      .\\\\32xl\\\\:prose :where(> ul > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose > ul > li > *:last-child {
+      .\\\\32xl\\\\:prose :where(> ul > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose > ol > li > *:first-child {
+      .\\\\32xl\\\\:prose :where(> ol > li > *:first-child) {
         margin-top: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose > ol > li > *:last-child {
+      .\\\\32xl\\\\:prose :where(> ol > li > *:last-child) {
         margin-bottom: 1.25em;
       }
 
-      .\\\\32xl\\\\:prose ul ul, .\\\\32xl\\\\:prose ul ol, .\\\\32xl\\\\:prose ol ul, .\\\\32xl\\\\:prose ol ol {
+      .\\\\32xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.75em;
         margin-bottom: 0.75em;
       }
 
-      .\\\\32xl\\\\:prose hr + * {
+      .\\\\32xl\\\\:prose :where(hr + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose h2 + * {
+      .\\\\32xl\\\\:prose :where(h2 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose h3 + * {
+      .\\\\32xl\\\\:prose :where(h3 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose h4 + * {
+      .\\\\32xl\\\\:prose :where(h4 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose thead th:first-child {
+      .\\\\32xl\\\\:prose :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose thead th:last-child {
+      .\\\\32xl\\\\:prose :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose tbody td:first-child {
+      .\\\\32xl\\\\:prose :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose tbody td:last-child {
+      .\\\\32xl\\\\:prose :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose > :first-child {
+      .\\\\32xl\\\\:prose :where(> :first-child) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose > :last-child {
+      .\\\\32xl\\\\:prose :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .\\\\32xl\\\\:prose-sm {
-        font-size: 0.875rem;
-        line-height: 1.7142857;
+        :where(font-size): 0.875rem;
+        :where(line-height): 1.7142857;
       }
 
-      .\\\\32xl\\\\:prose-sm p {
+      .\\\\32xl\\\\:prose-sm :where(p) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm [class~=\\"lead\\"] {
+      .\\\\32xl\\\\:prose-sm :where([class~=\\"lead\\"]) {
         font-size: 1.2857143em;
         line-height: 1.5555556;
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-sm blockquote {
+      .\\\\32xl\\\\:prose-sm :where(blockquote) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
         padding-left: 1.1111111em;
       }
 
-      .\\\\32xl\\\\:prose-sm h1 {
+      .\\\\32xl\\\\:prose-sm :where(h1) {
         font-size: 2.1428571em;
         margin-top: 0;
         margin-bottom: 0.8em;
         line-height: 1.2;
       }
 
-      .\\\\32xl\\\\:prose-sm h2 {
+      .\\\\32xl\\\\:prose-sm :where(h2) {
         font-size: 1.4285714em;
         margin-top: 1.6em;
         margin-bottom: 0.8em;
         line-height: 1.4;
       }
 
-      .\\\\32xl\\\\:prose-sm h3 {
+      .\\\\32xl\\\\:prose-sm :where(h3) {
         font-size: 1.2857143em;
         margin-top: 1.5555556em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .\\\\32xl\\\\:prose-sm h4 {
+      .\\\\32xl\\\\:prose-sm :where(h4) {
         margin-top: 1.4285714em;
         margin-bottom: 0.5714286em;
         line-height: 1.4285714;
       }
 
-      .\\\\32xl\\\\:prose-sm img {
+      .\\\\32xl\\\\:prose-sm :where(img) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .\\\\32xl\\\\:prose-sm video {
+      .\\\\32xl\\\\:prose-sm :where(video) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .\\\\32xl\\\\:prose-sm figure {
+      .\\\\32xl\\\\:prose-sm :where(figure) {
         margin-top: 1.7142857em;
         margin-bottom: 1.7142857em;
       }
 
-      .\\\\32xl\\\\:prose-sm figure > * {
+      .\\\\32xl\\\\:prose-sm :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm figure figcaption {
+      .\\\\32xl\\\\:prose-sm :where(figure figcaption) {
         font-size: 0.8571429em;
         line-height: 1.3333333;
         margin-top: 0.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-sm code {
+      .\\\\32xl\\\\:prose-sm :where(code) {
         font-size: 0.8571429em;
       }
 
-      .\\\\32xl\\\\:prose-sm h2 code {
+      .\\\\32xl\\\\:prose-sm :where(h2 code) {
         font-size: 0.9em;
       }
 
-      .\\\\32xl\\\\:prose-sm h3 code {
+      .\\\\32xl\\\\:prose-sm :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-sm pre {
+      .\\\\32xl\\\\:prose-sm :where(pre) {
         font-size: 0.8571429em;
         line-height: 1.6666667;
         margin-top: 1.6666667em;
@@ -7202,218 +7202,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose-sm ol {
+      .\\\\32xl\\\\:prose-sm :where(ol) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm ul {
+      .\\\\32xl\\\\:prose-sm :where(ul) {
         margin-top: 1.1428571em;
         margin-bottom: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm li {
+      .\\\\32xl\\\\:prose-sm :where(li) {
         margin-top: 0.2857143em;
         margin-bottom: 0.2857143em;
       }
 
-      .\\\\32xl\\\\:prose-sm ol > li {
+      .\\\\32xl\\\\:prose-sm :where(ol > li) {
         padding-left: 1.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm ol > li::before {
+      .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
         left: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm ul > li {
+      .\\\\32xl\\\\:prose-sm :where(ul > li) {
         padding-left: 1.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm ul > li::before {
+      .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
         left: 0.2142857em;
       }
 
-      .\\\\32xl\\\\:prose-sm > ul > li p {
+      .\\\\32xl\\\\:prose-sm :where(> ul > li p) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm > ul > li > *:first-child {
+      .\\\\32xl\\\\:prose-sm :where(> ul > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm > ul > li > *:last-child {
+      .\\\\32xl\\\\:prose-sm :where(> ul > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm > ol > li > *:first-child {
+      .\\\\32xl\\\\:prose-sm :where(> ol > li > *:first-child) {
         margin-top: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm > ol > li > *:last-child {
+      .\\\\32xl\\\\:prose-sm :where(> ol > li > *:last-child) {
         margin-bottom: 1.1428571em;
       }
 
-      .\\\\32xl\\\\:prose-sm ul ul, .\\\\32xl\\\\:prose-sm ul ol, .\\\\32xl\\\\:prose-sm ol ul, .\\\\32xl\\\\:prose-sm ol ol {
+      .\\\\32xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.5714286em;
         margin-bottom: 0.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm hr {
+      .\\\\32xl\\\\:prose-sm :where(hr) {
         margin-top: 2.8571429em;
         margin-bottom: 2.8571429em;
       }
 
-      .\\\\32xl\\\\:prose-sm hr + * {
+      .\\\\32xl\\\\:prose-sm :where(hr + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm h2 + * {
+      .\\\\32xl\\\\:prose-sm :where(h2 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm h3 + * {
+      .\\\\32xl\\\\:prose-sm :where(h3 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm h4 + * {
+      .\\\\32xl\\\\:prose-sm :where(h4 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm table {
+      .\\\\32xl\\\\:prose-sm :where(table) {
         font-size: 0.8571429em;
         line-height: 1.5;
       }
 
-      .\\\\32xl\\\\:prose-sm thead th {
+      .\\\\32xl\\\\:prose-sm :where(thead th) {
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose-sm thead th:first-child {
+      .\\\\32xl\\\\:prose-sm :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm thead th:last-child {
+      .\\\\32xl\\\\:prose-sm :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm tbody td {
+      .\\\\32xl\\\\:prose-sm :where(tbody td) {
         padding-top: 0.6666667em;
         padding-right: 1em;
         padding-bottom: 0.6666667em;
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose-sm tbody td:first-child {
+      .\\\\32xl\\\\:prose-sm :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm tbody td:last-child {
+      .\\\\32xl\\\\:prose-sm :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm > :first-child {
+      .\\\\32xl\\\\:prose-sm :where(> :first-child) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-sm > :last-child {
+      .\\\\32xl\\\\:prose-sm :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .\\\\32xl\\\\:prose-lg {
-        font-size: 1.125rem;
-        line-height: 1.7777778;
+        :where(font-size): 1.125rem;
+        :where(line-height): 1.7777778;
       }
 
-      .\\\\32xl\\\\:prose-lg p {
+      .\\\\32xl\\\\:prose-lg :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg [class~=\\"lead\\"] {
+      .\\\\32xl\\\\:prose-lg :where([class~=\\"lead\\"]) {
         font-size: 1.2222222em;
         line-height: 1.4545455;
         margin-top: 1.0909091em;
         margin-bottom: 1.0909091em;
       }
 
-      .\\\\32xl\\\\:prose-lg blockquote {
+      .\\\\32xl\\\\:prose-lg :where(blockquote) {
         margin-top: 1.6666667em;
         margin-bottom: 1.6666667em;
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose-lg h1 {
+      .\\\\32xl\\\\:prose-lg :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.8333333em;
         line-height: 1;
       }
 
-      .\\\\32xl\\\\:prose-lg h2 {
+      .\\\\32xl\\\\:prose-lg :where(h2) {
         font-size: 1.6666667em;
         margin-top: 1.8666667em;
         margin-bottom: 1.0666667em;
         line-height: 1.3333333;
       }
 
-      .\\\\32xl\\\\:prose-lg h3 {
+      .\\\\32xl\\\\:prose-lg :where(h3) {
         font-size: 1.3333333em;
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .\\\\32xl\\\\:prose-lg h4 {
+      .\\\\32xl\\\\:prose-lg :where(h4) {
         margin-top: 1.7777778em;
         margin-bottom: 0.4444444em;
         line-height: 1.5555556;
       }
 
-      .\\\\32xl\\\\:prose-lg img {
+      .\\\\32xl\\\\:prose-lg :where(img) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .\\\\32xl\\\\:prose-lg video {
+      .\\\\32xl\\\\:prose-lg :where(video) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .\\\\32xl\\\\:prose-lg figure {
+      .\\\\32xl\\\\:prose-lg :where(figure) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
       }
 
-      .\\\\32xl\\\\:prose-lg figure > * {
+      .\\\\32xl\\\\:prose-lg :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg figure figcaption {
+      .\\\\32xl\\\\:prose-lg :where(figure figcaption) {
         font-size: 0.8888889em;
         line-height: 1.5;
         margin-top: 1em;
       }
 
-      .\\\\32xl\\\\:prose-lg code {
+      .\\\\32xl\\\\:prose-lg :where(code) {
         font-size: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-lg h2 code {
+      .\\\\32xl\\\\:prose-lg :where(h2 code) {
         font-size: 0.8666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg h3 code {
+      .\\\\32xl\\\\:prose-lg :where(h3 code) {
         font-size: 0.875em;
       }
 
-      .\\\\32xl\\\\:prose-lg pre {
+      .\\\\32xl\\\\:prose-lg :where(pre) {
         font-size: 0.8888889em;
         line-height: 1.75;
         margin-top: 2em;
@@ -7425,218 +7425,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5em;
       }
 
-      .\\\\32xl\\\\:prose-lg ol {
+      .\\\\32xl\\\\:prose-lg :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg ul {
+      .\\\\32xl\\\\:prose-lg :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg li {
+      .\\\\32xl\\\\:prose-lg :where(li) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg ol > li {
+      .\\\\32xl\\\\:prose-lg :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg ol > li::before {
+      .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
         left: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg ul > li {
+      .\\\\32xl\\\\:prose-lg :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg ul > li::before {
+      .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
         left: 0.2222222em;
       }
 
-      .\\\\32xl\\\\:prose-lg > ul > li p {
+      .\\\\32xl\\\\:prose-lg :where(> ul > li p) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-lg > ul > li > *:first-child {
+      .\\\\32xl\\\\:prose-lg :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg > ul > li > *:last-child {
+      .\\\\32xl\\\\:prose-lg :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg > ol > li > *:first-child {
+      .\\\\32xl\\\\:prose-lg :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg > ol > li > *:last-child {
+      .\\\\32xl\\\\:prose-lg :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-lg ul ul, .\\\\32xl\\\\:prose-lg ul ol, .\\\\32xl\\\\:prose-lg ol ul, .\\\\32xl\\\\:prose-lg ol ol {
+      .\\\\32xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8888889em;
         margin-bottom: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-lg hr {
+      .\\\\32xl\\\\:prose-lg :where(hr) {
         margin-top: 3.1111111em;
         margin-bottom: 3.1111111em;
       }
 
-      .\\\\32xl\\\\:prose-lg hr + * {
+      .\\\\32xl\\\\:prose-lg :where(hr + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg h2 + * {
+      .\\\\32xl\\\\:prose-lg :where(h2 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg h3 + * {
+      .\\\\32xl\\\\:prose-lg :where(h3 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg h4 + * {
+      .\\\\32xl\\\\:prose-lg :where(h4 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg table {
+      .\\\\32xl\\\\:prose-lg :where(table) {
         font-size: 0.8888889em;
         line-height: 1.5;
       }
 
-      .\\\\32xl\\\\:prose-lg thead th {
+      .\\\\32xl\\\\:prose-lg :where(thead th) {
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .\\\\32xl\\\\:prose-lg thead th:first-child {
+      .\\\\32xl\\\\:prose-lg :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg thead th:last-child {
+      .\\\\32xl\\\\:prose-lg :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg tbody td {
+      .\\\\32xl\\\\:prose-lg :where(tbody td) {
         padding-top: 0.75em;
         padding-right: 0.75em;
         padding-bottom: 0.75em;
         padding-left: 0.75em;
       }
 
-      .\\\\32xl\\\\:prose-lg tbody td:first-child {
+      .\\\\32xl\\\\:prose-lg :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg tbody td:last-child {
+      .\\\\32xl\\\\:prose-lg :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg > :first-child {
+      .\\\\32xl\\\\:prose-lg :where(> :first-child) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-lg > :last-child {
+      .\\\\32xl\\\\:prose-lg :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .\\\\32xl\\\\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
+        :where(font-size): 1.25rem;
+        :where(line-height): 1.8;
       }
 
-      .\\\\32xl\\\\:prose-xl p {
+      .\\\\32xl\\\\:prose-xl :where(p) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl [class~=\\"lead\\"] {
+      .\\\\32xl\\\\:prose-xl :where([class~=\\"lead\\"]) {
         font-size: 1.2em;
         line-height: 1.5;
         margin-top: 1em;
         margin-bottom: 1em;
       }
 
-      .\\\\32xl\\\\:prose-xl blockquote {
+      .\\\\32xl\\\\:prose-xl :where(blockquote) {
         margin-top: 1.6em;
         margin-bottom: 1.6em;
         padding-left: 1.0666667em;
       }
 
-      .\\\\32xl\\\\:prose-xl h1 {
+      .\\\\32xl\\\\:prose-xl :where(h1) {
         font-size: 2.8em;
         margin-top: 0;
         margin-bottom: 0.8571429em;
         line-height: 1;
       }
 
-      .\\\\32xl\\\\:prose-xl h2 {
+      .\\\\32xl\\\\:prose-xl :where(h2) {
         font-size: 1.8em;
         margin-top: 1.5555556em;
         margin-bottom: 0.8888889em;
         line-height: 1.1111111;
       }
 
-      .\\\\32xl\\\\:prose-xl h3 {
+      .\\\\32xl\\\\:prose-xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.6em;
         margin-bottom: 0.6666667em;
         line-height: 1.3333333;
       }
 
-      .\\\\32xl\\\\:prose-xl h4 {
+      .\\\\32xl\\\\:prose-xl :where(h4) {
         margin-top: 1.8em;
         margin-bottom: 0.6em;
         line-height: 1.6;
       }
 
-      .\\\\32xl\\\\:prose-xl img {
+      .\\\\32xl\\\\:prose-xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-xl video {
+      .\\\\32xl\\\\:prose-xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-xl figure {
+      .\\\\32xl\\\\:prose-xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-xl figure > * {
+      .\\\\32xl\\\\:prose-xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl figure figcaption {
+      .\\\\32xl\\\\:prose-xl :where(figure figcaption) {
         font-size: 0.9em;
         line-height: 1.5555556;
         margin-top: 1em;
       }
 
-      .\\\\32xl\\\\:prose-xl code {
+      .\\\\32xl\\\\:prose-xl :where(code) {
         font-size: 0.9em;
       }
 
-      .\\\\32xl\\\\:prose-xl h2 code {
+      .\\\\32xl\\\\:prose-xl :where(h2 code) {
         font-size: 0.8611111em;
       }
 
-      .\\\\32xl\\\\:prose-xl h3 code {
+      .\\\\32xl\\\\:prose-xl :where(h3 code) {
         font-size: 0.9em;
       }
 
-      .\\\\32xl\\\\:prose-xl pre {
+      .\\\\32xl\\\\:prose-xl :where(pre) {
         font-size: 0.9em;
         line-height: 1.7777778;
         margin-top: 2em;
@@ -7648,218 +7648,218 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-xl ol {
+      .\\\\32xl\\\\:prose-xl :where(ol) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl ul {
+      .\\\\32xl\\\\:prose-xl :where(ul) {
         margin-top: 1.2em;
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl li {
+      .\\\\32xl\\\\:prose-xl :where(li) {
         margin-top: 0.6em;
         margin-bottom: 0.6em;
       }
 
-      .\\\\32xl\\\\:prose-xl ol > li {
+      .\\\\32xl\\\\:prose-xl :where(ol > li) {
         padding-left: 1.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl ol > li::before {
+      .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
         left: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl ul > li {
+      .\\\\32xl\\\\:prose-xl :where(ul > li) {
         padding-left: 1.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl ul > li::before {
+      .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
         left: 0.25em;
       }
 
-      .\\\\32xl\\\\:prose-xl > ul > li p {
+      .\\\\32xl\\\\:prose-xl :where(> ul > li p) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl > ul > li > *:first-child {
+      .\\\\32xl\\\\:prose-xl :where(> ul > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl > ul > li > *:last-child {
+      .\\\\32xl\\\\:prose-xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl > ol > li > *:first-child {
+      .\\\\32xl\\\\:prose-xl :where(> ol > li > *:first-child) {
         margin-top: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl > ol > li > *:last-child {
+      .\\\\32xl\\\\:prose-xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.2em;
       }
 
-      .\\\\32xl\\\\:prose-xl ul ul, .\\\\32xl\\\\:prose-xl ul ol, .\\\\32xl\\\\:prose-xl ol ul, .\\\\32xl\\\\:prose-xl ol ol {
+      .\\\\32xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.8em;
         margin-bottom: 0.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl hr {
+      .\\\\32xl\\\\:prose-xl :where(hr) {
         margin-top: 2.8em;
         margin-bottom: 2.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl hr + * {
+      .\\\\32xl\\\\:prose-xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl h2 + * {
+      .\\\\32xl\\\\:prose-xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl h3 + * {
+      .\\\\32xl\\\\:prose-xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl h4 + * {
+      .\\\\32xl\\\\:prose-xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl table {
+      .\\\\32xl\\\\:prose-xl :where(table) {
         font-size: 0.9em;
         line-height: 1.5555556;
       }
 
-      .\\\\32xl\\\\:prose-xl thead th {
+      .\\\\32xl\\\\:prose-xl :where(thead th) {
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-xl thead th:first-child {
+      .\\\\32xl\\\\:prose-xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl thead th:last-child {
+      .\\\\32xl\\\\:prose-xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl tbody td {
+      .\\\\32xl\\\\:prose-xl :where(tbody td) {
         padding-top: 0.8888889em;
         padding-right: 0.6666667em;
         padding-bottom: 0.8888889em;
         padding-left: 0.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-xl tbody td:first-child {
+      .\\\\32xl\\\\:prose-xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl tbody td:last-child {
+      .\\\\32xl\\\\:prose-xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl > :first-child {
+      .\\\\32xl\\\\:prose-xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-xl > :last-child {
+      .\\\\32xl\\\\:prose-xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
       .\\\\32xl\\\\:prose-2xl {
-        font-size: 1.5rem;
-        line-height: 1.6666667;
+        :where(font-size): 1.5rem;
+        :where(line-height): 1.6666667;
       }
 
-      .\\\\32xl\\\\:prose-2xl p {
+      .\\\\32xl\\\\:prose-2xl :where(p) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl [class~=\\"lead\\"] {
+      .\\\\32xl\\\\:prose-2xl :where([class~=\\"lead\\"]) {
         font-size: 1.25em;
         line-height: 1.4666667;
         margin-top: 1.0666667em;
         margin-bottom: 1.0666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl blockquote {
+      .\\\\32xl\\\\:prose-2xl :where(blockquote) {
         margin-top: 1.7777778em;
         margin-bottom: 1.7777778em;
         padding-left: 1.1111111em;
       }
 
-      .\\\\32xl\\\\:prose-2xl h1 {
+      .\\\\32xl\\\\:prose-2xl :where(h1) {
         font-size: 2.6666667em;
         margin-top: 0;
         margin-bottom: 0.875em;
         line-height: 1;
       }
 
-      .\\\\32xl\\\\:prose-2xl h2 {
+      .\\\\32xl\\\\:prose-2xl :where(h2) {
         font-size: 2em;
         margin-top: 1.5em;
         margin-bottom: 0.8333333em;
         line-height: 1.0833333;
       }
 
-      .\\\\32xl\\\\:prose-2xl h3 {
+      .\\\\32xl\\\\:prose-2xl :where(h3) {
         font-size: 1.5em;
         margin-top: 1.5555556em;
         margin-bottom: 0.6666667em;
         line-height: 1.2222222;
       }
 
-      .\\\\32xl\\\\:prose-2xl h4 {
+      .\\\\32xl\\\\:prose-2xl :where(h4) {
         margin-top: 1.6666667em;
         margin-bottom: 0.6666667em;
         line-height: 1.5;
       }
 
-      .\\\\32xl\\\\:prose-2xl img {
+      .\\\\32xl\\\\:prose-2xl :where(img) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-2xl video {
+      .\\\\32xl\\\\:prose-2xl :where(video) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-2xl figure {
+      .\\\\32xl\\\\:prose-2xl :where(figure) {
         margin-top: 2em;
         margin-bottom: 2em;
       }
 
-      .\\\\32xl\\\\:prose-2xl figure > * {
+      .\\\\32xl\\\\:prose-2xl :where(figure > *) {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl figure figcaption {
+      .\\\\32xl\\\\:prose-2xl :where(figure figcaption) {
         font-size: 0.8333333em;
         line-height: 1.6;
         margin-top: 1em;
       }
 
-      .\\\\32xl\\\\:prose-2xl code {
+      .\\\\32xl\\\\:prose-2xl :where(code) {
         font-size: 0.8333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl h2 code {
+      .\\\\32xl\\\\:prose-2xl :where(h2 code) {
         font-size: 0.875em;
       }
 
-      .\\\\32xl\\\\:prose-2xl h3 code {
+      .\\\\32xl\\\\:prose-2xl :where(h3 code) {
         font-size: 0.8888889em;
       }
 
-      .\\\\32xl\\\\:prose-2xl pre {
+      .\\\\32xl\\\\:prose-2xl :where(pre) {
         font-size: 0.8333333em;
         line-height: 1.8;
         margin-top: 2em;
@@ -7871,182 +7871,182 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ol {
+      .\\\\32xl\\\\:prose-2xl :where(ol) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ul {
+      .\\\\32xl\\\\:prose-2xl :where(ul) {
         margin-top: 1.3333333em;
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl li {
+      .\\\\32xl\\\\:prose-2xl :where(li) {
         margin-top: 0.5em;
         margin-bottom: 0.5em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ol > li {
+      .\\\\32xl\\\\:prose-2xl :where(ol > li) {
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ol > li::before {
+      .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
         left: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl ul > li {
+      .\\\\32xl\\\\:prose-2xl :where(ul > li) {
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ul > li::before {
+      .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
         left: 0.25em;
       }
 
-      .\\\\32xl\\\\:prose-2xl > ul > li p {
+      .\\\\32xl\\\\:prose-2xl :where(> ul > li p) {
         margin-top: 0.8333333em;
         margin-bottom: 0.8333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl > ul > li > *:first-child {
+      .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl > ul > li > *:last-child {
+      .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl > ol > li > *:first-child {
+      .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
         margin-top: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl > ol > li > *:last-child {
+      .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
         margin-bottom: 1.3333333em;
       }
 
-      .\\\\32xl\\\\:prose-2xl ul ul, .\\\\32xl\\\\:prose-2xl ul ol, .\\\\32xl\\\\:prose-2xl ol ul, .\\\\32xl\\\\:prose-2xl ol ol {
+      .\\\\32xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
         margin-top: 0.6666667em;
         margin-bottom: 0.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl hr {
+      .\\\\32xl\\\\:prose-2xl :where(hr) {
         margin-top: 3em;
         margin-bottom: 3em;
       }
 
-      .\\\\32xl\\\\:prose-2xl hr + * {
+      .\\\\32xl\\\\:prose-2xl :where(hr + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl h2 + * {
+      .\\\\32xl\\\\:prose-2xl :where(h2 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl h3 + * {
+      .\\\\32xl\\\\:prose-2xl :where(h3 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl h4 + * {
+      .\\\\32xl\\\\:prose-2xl :where(h4 + *) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl table {
+      .\\\\32xl\\\\:prose-2xl :where(table) {
         font-size: 0.8333333em;
         line-height: 1.4;
       }
 
-      .\\\\32xl\\\\:prose-2xl thead th {
+      .\\\\32xl\\\\:prose-2xl :where(thead th) {
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .\\\\32xl\\\\:prose-2xl thead th:first-child {
+      .\\\\32xl\\\\:prose-2xl :where(thead th:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl thead th:last-child {
+      .\\\\32xl\\\\:prose-2xl :where(thead th:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl tbody td {
+      .\\\\32xl\\\\:prose-2xl :where(tbody td) {
         padding-top: 0.8em;
         padding-right: 0.6em;
         padding-bottom: 0.8em;
         padding-left: 0.6em;
       }
 
-      .\\\\32xl\\\\:prose-2xl tbody td:first-child {
+      .\\\\32xl\\\\:prose-2xl :where(tbody td:first-child) {
         padding-left: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl tbody td:last-child {
+      .\\\\32xl\\\\:prose-2xl :where(tbody td:last-child) {
         padding-right: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl > :first-child {
+      .\\\\32xl\\\\:prose-2xl :where(> :first-child) {
         margin-top: 0;
       }
 
-      .\\\\32xl\\\\:prose-2xl > :last-child {
+      .\\\\32xl\\\\:prose-2xl :where(> :last-child) {
         margin-bottom: 0;
       }
 
-      .\\\\32xl\\\\:prose-red a {
+      .\\\\32xl\\\\:prose-red :where(a) {
         color: #dc2626;
       }
 
-      .\\\\32xl\\\\:prose-red a code {
+      .\\\\32xl\\\\:prose-red :where(a code) {
         color: #dc2626;
       }
 
-      .\\\\32xl\\\\:prose-yellow a {
+      .\\\\32xl\\\\:prose-yellow :where(a) {
         color: #d97706;
       }
 
-      .\\\\32xl\\\\:prose-yellow a code {
+      .\\\\32xl\\\\:prose-yellow :where(a code) {
         color: #d97706;
       }
 
-      .\\\\32xl\\\\:prose-green a {
+      .\\\\32xl\\\\:prose-green :where(a) {
         color: #059669;
       }
 
-      .\\\\32xl\\\\:prose-green a code {
+      .\\\\32xl\\\\:prose-green :where(a code) {
         color: #059669;
       }
 
-      .\\\\32xl\\\\:prose-blue a {
+      .\\\\32xl\\\\:prose-blue :where(a) {
         color: #2563eb;
       }
 
-      .\\\\32xl\\\\:prose-blue a code {
+      .\\\\32xl\\\\:prose-blue :where(a code) {
         color: #2563eb;
       }
 
-      .\\\\32xl\\\\:prose-indigo a {
+      .\\\\32xl\\\\:prose-indigo :where(a) {
         color: #4f46e5;
       }
 
-      .\\\\32xl\\\\:prose-indigo a code {
+      .\\\\32xl\\\\:prose-indigo :where(a code) {
         color: #4f46e5;
       }
 
-      .\\\\32xl\\\\:prose-purple a {
+      .\\\\32xl\\\\:prose-purple :where(a) {
         color: #7c3aed;
       }
 
-      .\\\\32xl\\\\:prose-purple a code {
+      .\\\\32xl\\\\:prose-purple :where(a code) {
         color: #7c3aed;
       }
 
-      .\\\\32xl\\\\:prose-pink a {
+      .\\\\32xl\\\\:prose-pink :where(a) {
         color: #db2777;
       }
 
-      .\\\\32xl\\\\:prose-pink a code {
+      .\\\\32xl\\\\:prose-pink :where(a code) {
         color: #db2777;
       }
     }"
@@ -8062,218 +8062,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose [class~='lead'] {
-      + .markdown [class~='lead'] {
+      - .prose :where([class~='lead']) {
+      + .markdown :where([class~='lead']) {
 
       ---
 
-      - .prose a {
-      + .markdown a {
+      - .prose :where(a) {
+      + .markdown :where(a) {
 
       ---
 
-      - .prose strong {
-      + .markdown strong {
+      - .prose :where(strong) {
+      + .markdown :where(strong) {
 
       ---
 
-      - .prose ol[type='A'] {
-      + .markdown ol[type='A'] {
+      - .prose :where(ol[type='A']) {
+      + .markdown :where(ol[type='A']) {
 
       ---
 
-      - .prose ol[type='a'] {
-      + .markdown ol[type='a'] {
+      - .prose :where(ol[type='a']) {
+      + .markdown :where(ol[type='a']) {
 
       ---
 
-      - .prose ol[type='A' s] {
-      + .markdown ol[type='A' s] {
+      - .prose :where(ol[type='A' s]) {
+      + .markdown :where(ol[type='A' s]) {
 
       ---
 
-      - .prose ol[type='a' s] {
-      + .markdown ol[type='a' s] {
+      - .prose :where(ol[type='a' s]) {
+      + .markdown :where(ol[type='a' s]) {
 
       ---
 
-      - .prose ol[type='I'] {
-      + .markdown ol[type='I'] {
+      - .prose :where(ol[type='I']) {
+      + .markdown :where(ol[type='I']) {
 
       ---
 
-      - .prose ol[type='i'] {
-      + .markdown ol[type='i'] {
+      - .prose :where(ol[type='i']) {
+      + .markdown :where(ol[type='i']) {
 
       ---
 
-      - .prose ol[type='I' s] {
-      + .markdown ol[type='I' s] {
+      - .prose :where(ol[type='I' s]) {
+      + .markdown :where(ol[type='I' s]) {
 
       ---
 
-      - .prose ol[type='i' s] {
-      + .markdown ol[type='i' s] {
+      - .prose :where(ol[type='i' s]) {
+      + .markdown :where(ol[type='i' s]) {
 
       ---
 
-      - .prose ol[type='1'] {
-      + .markdown ol[type='1'] {
+      - .prose :where(ol[type='1']) {
+      + .markdown :where(ol[type='1']) {
 
       ---
 
-      - .prose ol > li {
-      + .markdown ol > li {
+      - .prose :where(ol > li) {
+      + .markdown :where(ol > li) {
 
       ---
 
-      - .prose ol > li::before {
-      + .markdown ol > li::before {
+      - .prose :where(ol > li::before) {
+      + .markdown :where(ol > li::before) {
 
       ---
 
-      - .prose ul > li {
-      + .markdown ul > li {
+      - .prose :where(ul > li) {
+      + .markdown :where(ul > li) {
 
       ---
 
-      - .prose ul > li::before {
-      + .markdown ul > li::before {
+      - .prose :where(ul > li::before) {
+      + .markdown :where(ul > li::before) {
 
       ---
 
-      - .prose hr {
-      + .markdown hr {
+      - .prose :where(hr) {
+      + .markdown :where(hr) {
 
       ---
 
-      - .prose blockquote {
-      + .markdown blockquote {
+      - .prose :where(blockquote) {
+      + .markdown :where(blockquote) {
 
       ---
 
-      - .prose blockquote p:first-of-type::before {
-      + .markdown blockquote p:first-of-type::before {
+      - .prose :where(blockquote p:first-of-type::before) {
+      + .markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      - .prose blockquote p:last-of-type::after {
-      + .markdown blockquote p:last-of-type::after {
+      - .prose :where(blockquote p:last-of-type::after) {
+      + .markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      - .prose h1 {
-      + .markdown h1 {
+      - .prose :where(h1) {
+      + .markdown :where(h1) {
 
       ---
 
-      - .prose h1 strong {
-      + .markdown h1 strong {
+      - .prose :where(h1 strong) {
+      + .markdown :where(h1 strong) {
 
       ---
 
-      - .prose h2 {
-      + .markdown h2 {
+      - .prose :where(h2) {
+      + .markdown :where(h2) {
 
       ---
 
-      - .prose h2 strong {
-      + .markdown h2 strong {
+      - .prose :where(h2 strong) {
+      + .markdown :where(h2 strong) {
 
       ---
 
-      - .prose h3 {
-      + .markdown h3 {
+      - .prose :where(h3) {
+      + .markdown :where(h3) {
 
       ---
 
-      - .prose h3 strong {
-      + .markdown h3 strong {
+      - .prose :where(h3 strong) {
+      + .markdown :where(h3 strong) {
 
       ---
 
-      - .prose h4 {
-      + .markdown h4 {
+      - .prose :where(h4) {
+      + .markdown :where(h4) {
 
       ---
 
-      - .prose h4 strong {
-      + .markdown h4 strong {
+      - .prose :where(h4 strong) {
+      + .markdown :where(h4 strong) {
 
       ---
 
-      - .prose figure figcaption {
-      + .markdown figure figcaption {
+      - .prose :where(figure figcaption) {
+      + .markdown :where(figure figcaption) {
 
       ---
 
-      - .prose code {
-      + .markdown code {
+      - .prose :where(code) {
+      + .markdown :where(code) {
 
       ---
 
-      - .prose code::before {
-      + .markdown code::before {
+      - .prose :where(code::before) {
+      + .markdown :where(code::before) {
 
       ---
 
-      - .prose code::after {
-      + .markdown code::after {
+      - .prose :where(code::after) {
+      + .markdown :where(code::after) {
 
       ---
 
-      - .prose a code {
-      + .markdown a code {
+      - .prose :where(a code) {
+      + .markdown :where(a code) {
 
       ---
 
-      - .prose pre {
-      + .markdown pre {
+      - .prose :where(pre) {
+      + .markdown :where(pre) {
 
       ---
 
-      - .prose pre code {
-      + .markdown pre code {
+      - .prose :where(pre code) {
+      + .markdown :where(pre code) {
 
       ---
 
-      - .prose pre code::before {
-      + .markdown pre code::before {
+      - .prose :where(pre code::before) {
+      + .markdown :where(pre code::before) {
 
       ---
 
-      - .prose pre code::after {
-      + .markdown pre code::after {
+      - .prose :where(pre code::after) {
+      + .markdown :where(pre code::after) {
 
       ---
 
-      - .prose table {
-      + .markdown table {
+      - .prose :where(table) {
+      + .markdown :where(table) {
 
       ---
 
-      - .prose thead {
-      + .markdown thead {
+      - .prose :where(thead) {
+      + .markdown :where(thead) {
 
       ---
 
-      - .prose thead th {
-      + .markdown thead th {
+      - .prose :where(thead th) {
+      + .markdown :where(thead th) {
 
       ---
 
-      - .prose tbody tr {
-      + .markdown tbody tr {
+      - .prose :where(tbody tr) {
+      + .markdown :where(tbody tr) {
 
       ---
 
-      - .prose tbody tr:last-child {
-      + .markdown tbody tr:last-child {
+      - .prose :where(tbody tr:last-child) {
+      + .markdown :where(tbody tr:last-child) {
 
       ---
 
-      - .prose tbody td {
-      + .markdown tbody td {
+      - .prose :where(tbody td) {
+      + .markdown :where(tbody td) {
 
       ---
 
@@ -8282,133 +8282,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose p {
-      + .markdown p {
+      - .prose :where(p) {
+      + .markdown :where(p) {
 
       ---
 
-      - .prose img {
-      + .markdown img {
+      - .prose :where(img) {
+      + .markdown :where(img) {
 
       ---
 
-      - .prose video {
-      + .markdown video {
+      - .prose :where(video) {
+      + .markdown :where(video) {
 
       ---
 
-      - .prose figure {
-      + .markdown figure {
+      - .prose :where(figure) {
+      + .markdown :where(figure) {
 
       ---
 
-      - .prose figure > * {
-      + .markdown figure > * {
+      - .prose :where(figure > *) {
+      + .markdown :where(figure > *) {
 
       ---
 
-      - .prose h2 code {
-      + .markdown h2 code {
+      - .prose :where(h2 code) {
+      + .markdown :where(h2 code) {
 
       ---
 
-      - .prose h3 code {
-      + .markdown h3 code {
+      - .prose :where(h3 code) {
+      + .markdown :where(h3 code) {
 
       ---
 
-      - .prose ol {
-      + .markdown ol {
+      - .prose :where(ol) {
+      + .markdown :where(ol) {
 
       ---
 
-      - .prose ul {
-      + .markdown ul {
+      - .prose :where(ul) {
+      + .markdown :where(ul) {
 
       ---
 
-      - .prose li {
-      + .markdown li {
+      - .prose :where(li) {
+      + .markdown :where(li) {
 
       ---
 
-      - .prose > ul > li p {
-      + .markdown > ul > li p {
+      - .prose :where(> ul > li p) {
+      + .markdown :where(> ul > li p) {
 
       ---
 
-      - .prose > ul > li > *:first-child {
-      + .markdown > ul > li > *:first-child {
+      - .prose :where(> ul > li > *:first-child) {
+      + .markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose > ul > li > *:last-child {
-      + .markdown > ul > li > *:last-child {
+      - .prose :where(> ul > li > *:last-child) {
+      + .markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose > ol > li > *:first-child {
-      + .markdown > ol > li > *:first-child {
+      - .prose :where(> ol > li > *:first-child) {
+      + .markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose > ol > li > *:last-child {
-      + .markdown > ol > li > *:last-child {
+      - .prose :where(> ol > li > *:last-child) {
+      + .markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
-      + .markdown ul ul, .markdown ul ol, .markdown ol ul, .markdown ol ol {
+      - .prose :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose hr + * {
-      + .markdown hr + * {
+      - .prose :where(hr + *) {
+      + .markdown :where(hr + *) {
 
       ---
 
-      - .prose h2 + * {
-      + .markdown h2 + * {
+      - .prose :where(h2 + *) {
+      + .markdown :where(h2 + *) {
 
       ---
 
-      - .prose h3 + * {
-      + .markdown h3 + * {
+      - .prose :where(h3 + *) {
+      + .markdown :where(h3 + *) {
 
       ---
 
-      - .prose h4 + * {
-      + .markdown h4 + * {
+      - .prose :where(h4 + *) {
+      + .markdown :where(h4 + *) {
 
       ---
 
-      - .prose thead th:first-child {
-      + .markdown thead th:first-child {
+      - .prose :where(thead th:first-child) {
+      + .markdown :where(thead th:first-child) {
 
       ---
 
-      - .prose thead th:last-child {
-      + .markdown thead th:last-child {
+      - .prose :where(thead th:last-child) {
+      + .markdown :where(thead th:last-child) {
 
       ---
 
-      - .prose tbody td:first-child {
-      + .markdown tbody td:first-child {
+      - .prose :where(tbody td:first-child) {
+      + .markdown :where(tbody td:first-child) {
 
       ---
 
-      - .prose tbody td:last-child {
-      + .markdown tbody td:last-child {
+      - .prose :where(tbody td:last-child) {
+      + .markdown :where(tbody td:last-child) {
 
       ---
 
-      - .prose > :first-child {
-      + .markdown > :first-child {
+      - .prose :where(> :first-child) {
+      + .markdown :where(> :first-child) {
 
       ---
 
-      - .prose > :last-child {
-      + .markdown > :last-child {
+      - .prose :where(> :last-child) {
+      + .markdown :where(> :last-child) {
 
       ---
 
@@ -8417,218 +8417,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-sm p {
-      + .markdown-sm p {
+      - .prose-sm :where(p) {
+      + .markdown-sm :where(p) {
 
       ---
 
-      - .prose-sm [class~='lead'] {
-      + .markdown-sm [class~='lead'] {
+      - .prose-sm :where([class~='lead']) {
+      + .markdown-sm :where([class~='lead']) {
 
       ---
 
-      - .prose-sm blockquote {
-      + .markdown-sm blockquote {
+      - .prose-sm :where(blockquote) {
+      + .markdown-sm :where(blockquote) {
 
       ---
 
-      - .prose-sm h1 {
-      + .markdown-sm h1 {
+      - .prose-sm :where(h1) {
+      + .markdown-sm :where(h1) {
 
       ---
 
-      - .prose-sm h2 {
-      + .markdown-sm h2 {
+      - .prose-sm :where(h2) {
+      + .markdown-sm :where(h2) {
 
       ---
 
-      - .prose-sm h3 {
-      + .markdown-sm h3 {
+      - .prose-sm :where(h3) {
+      + .markdown-sm :where(h3) {
 
       ---
 
-      - .prose-sm h4 {
-      + .markdown-sm h4 {
+      - .prose-sm :where(h4) {
+      + .markdown-sm :where(h4) {
 
       ---
 
-      - .prose-sm img {
-      + .markdown-sm img {
+      - .prose-sm :where(img) {
+      + .markdown-sm :where(img) {
 
       ---
 
-      - .prose-sm video {
-      + .markdown-sm video {
+      - .prose-sm :where(video) {
+      + .markdown-sm :where(video) {
 
       ---
 
-      - .prose-sm figure {
-      + .markdown-sm figure {
+      - .prose-sm :where(figure) {
+      + .markdown-sm :where(figure) {
 
       ---
 
-      - .prose-sm figure > * {
-      + .markdown-sm figure > * {
+      - .prose-sm :where(figure > *) {
+      + .markdown-sm :where(figure > *) {
 
       ---
 
-      - .prose-sm figure figcaption {
-      + .markdown-sm figure figcaption {
+      - .prose-sm :where(figure figcaption) {
+      + .markdown-sm :where(figure figcaption) {
 
       ---
 
-      - .prose-sm code {
-      + .markdown-sm code {
+      - .prose-sm :where(code) {
+      + .markdown-sm :where(code) {
 
       ---
 
-      - .prose-sm h2 code {
-      + .markdown-sm h2 code {
+      - .prose-sm :where(h2 code) {
+      + .markdown-sm :where(h2 code) {
 
       ---
 
-      - .prose-sm h3 code {
-      + .markdown-sm h3 code {
+      - .prose-sm :where(h3 code) {
+      + .markdown-sm :where(h3 code) {
 
       ---
 
-      - .prose-sm pre {
-      + .markdown-sm pre {
+      - .prose-sm :where(pre) {
+      + .markdown-sm :where(pre) {
 
       ---
 
-      - .prose-sm ol {
-      + .markdown-sm ol {
+      - .prose-sm :where(ol) {
+      + .markdown-sm :where(ol) {
 
       ---
 
-      - .prose-sm ul {
-      + .markdown-sm ul {
+      - .prose-sm :where(ul) {
+      + .markdown-sm :where(ul) {
 
       ---
 
-      - .prose-sm li {
-      + .markdown-sm li {
+      - .prose-sm :where(li) {
+      + .markdown-sm :where(li) {
 
       ---
 
-      - .prose-sm ol > li {
-      + .markdown-sm ol > li {
+      - .prose-sm :where(ol > li) {
+      + .markdown-sm :where(ol > li) {
 
       ---
 
-      - .prose-sm ol > li::before {
-      + .markdown-sm ol > li::before {
+      - .prose-sm :where(ol > li::before) {
+      + .markdown-sm :where(ol > li::before) {
 
       ---
 
-      - .prose-sm ul > li {
-      + .markdown-sm ul > li {
+      - .prose-sm :where(ul > li) {
+      + .markdown-sm :where(ul > li) {
 
       ---
 
-      - .prose-sm ul > li::before {
-      + .markdown-sm ul > li::before {
+      - .prose-sm :where(ul > li::before) {
+      + .markdown-sm :where(ul > li::before) {
 
       ---
 
-      - .prose-sm > ul > li p {
-      + .markdown-sm > ul > li p {
+      - .prose-sm :where(> ul > li p) {
+      + .markdown-sm :where(> ul > li p) {
 
       ---
 
-      - .prose-sm > ul > li > *:first-child {
-      + .markdown-sm > ul > li > *:first-child {
+      - .prose-sm :where(> ul > li > *:first-child) {
+      + .markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-sm > ul > li > *:last-child {
-      + .markdown-sm > ul > li > *:last-child {
+      - .prose-sm :where(> ul > li > *:last-child) {
+      + .markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-sm > ol > li > *:first-child {
-      + .markdown-sm > ol > li > *:first-child {
+      - .prose-sm :where(> ol > li > *:first-child) {
+      + .markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-sm > ol > li > *:last-child {
-      + .markdown-sm > ol > li > *:last-child {
+      - .prose-sm :where(> ol > li > *:last-child) {
+      + .markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-sm ul ul, .prose-sm ul ol, .prose-sm ol ul, .prose-sm ol ol {
-      + .markdown-sm ul ul, .markdown-sm ul ol, .markdown-sm ol ul, .markdown-sm ol ol {
+      - .prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-sm hr {
-      + .markdown-sm hr {
+      - .prose-sm :where(hr) {
+      + .markdown-sm :where(hr) {
 
       ---
 
-      - .prose-sm hr + * {
-      + .markdown-sm hr + * {
+      - .prose-sm :where(hr + *) {
+      + .markdown-sm :where(hr + *) {
 
       ---
 
-      - .prose-sm h2 + * {
-      + .markdown-sm h2 + * {
+      - .prose-sm :where(h2 + *) {
+      + .markdown-sm :where(h2 + *) {
 
       ---
 
-      - .prose-sm h3 + * {
-      + .markdown-sm h3 + * {
+      - .prose-sm :where(h3 + *) {
+      + .markdown-sm :where(h3 + *) {
 
       ---
 
-      - .prose-sm h4 + * {
-      + .markdown-sm h4 + * {
+      - .prose-sm :where(h4 + *) {
+      + .markdown-sm :where(h4 + *) {
 
       ---
 
-      - .prose-sm table {
-      + .markdown-sm table {
+      - .prose-sm :where(table) {
+      + .markdown-sm :where(table) {
 
       ---
 
-      - .prose-sm thead th {
-      + .markdown-sm thead th {
+      - .prose-sm :where(thead th) {
+      + .markdown-sm :where(thead th) {
 
       ---
 
-      - .prose-sm thead th:first-child {
-      + .markdown-sm thead th:first-child {
+      - .prose-sm :where(thead th:first-child) {
+      + .markdown-sm :where(thead th:first-child) {
 
       ---
 
-      - .prose-sm thead th:last-child {
-      + .markdown-sm thead th:last-child {
+      - .prose-sm :where(thead th:last-child) {
+      + .markdown-sm :where(thead th:last-child) {
 
       ---
 
-      - .prose-sm tbody td {
-      + .markdown-sm tbody td {
+      - .prose-sm :where(tbody td) {
+      + .markdown-sm :where(tbody td) {
 
       ---
 
-      - .prose-sm tbody td:first-child {
-      + .markdown-sm tbody td:first-child {
+      - .prose-sm :where(tbody td:first-child) {
+      + .markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      - .prose-sm tbody td:last-child {
-      + .markdown-sm tbody td:last-child {
+      - .prose-sm :where(tbody td:last-child) {
+      + .markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      - .prose-sm > :first-child {
-      + .markdown-sm > :first-child {
+      - .prose-sm :where(> :first-child) {
+      + .markdown-sm :where(> :first-child) {
 
       ---
 
-      - .prose-sm > :last-child {
-      + .markdown-sm > :last-child {
+      - .prose-sm :where(> :last-child) {
+      + .markdown-sm :where(> :last-child) {
 
       ---
 
@@ -8637,218 +8637,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-lg p {
-      + .markdown-lg p {
+      - .prose-lg :where(p) {
+      + .markdown-lg :where(p) {
 
       ---
 
-      - .prose-lg [class~='lead'] {
-      + .markdown-lg [class~='lead'] {
+      - .prose-lg :where([class~='lead']) {
+      + .markdown-lg :where([class~='lead']) {
 
       ---
 
-      - .prose-lg blockquote {
-      + .markdown-lg blockquote {
+      - .prose-lg :where(blockquote) {
+      + .markdown-lg :where(blockquote) {
 
       ---
 
-      - .prose-lg h1 {
-      + .markdown-lg h1 {
+      - .prose-lg :where(h1) {
+      + .markdown-lg :where(h1) {
 
       ---
 
-      - .prose-lg h2 {
-      + .markdown-lg h2 {
+      - .prose-lg :where(h2) {
+      + .markdown-lg :where(h2) {
 
       ---
 
-      - .prose-lg h3 {
-      + .markdown-lg h3 {
+      - .prose-lg :where(h3) {
+      + .markdown-lg :where(h3) {
 
       ---
 
-      - .prose-lg h4 {
-      + .markdown-lg h4 {
+      - .prose-lg :where(h4) {
+      + .markdown-lg :where(h4) {
 
       ---
 
-      - .prose-lg img {
-      + .markdown-lg img {
+      - .prose-lg :where(img) {
+      + .markdown-lg :where(img) {
 
       ---
 
-      - .prose-lg video {
-      + .markdown-lg video {
+      - .prose-lg :where(video) {
+      + .markdown-lg :where(video) {
 
       ---
 
-      - .prose-lg figure {
-      + .markdown-lg figure {
+      - .prose-lg :where(figure) {
+      + .markdown-lg :where(figure) {
 
       ---
 
-      - .prose-lg figure > * {
-      + .markdown-lg figure > * {
+      - .prose-lg :where(figure > *) {
+      + .markdown-lg :where(figure > *) {
 
       ---
 
-      - .prose-lg figure figcaption {
-      + .markdown-lg figure figcaption {
+      - .prose-lg :where(figure figcaption) {
+      + .markdown-lg :where(figure figcaption) {
 
       ---
 
-      - .prose-lg code {
-      + .markdown-lg code {
+      - .prose-lg :where(code) {
+      + .markdown-lg :where(code) {
 
       ---
 
-      - .prose-lg h2 code {
-      + .markdown-lg h2 code {
+      - .prose-lg :where(h2 code) {
+      + .markdown-lg :where(h2 code) {
 
       ---
 
-      - .prose-lg h3 code {
-      + .markdown-lg h3 code {
+      - .prose-lg :where(h3 code) {
+      + .markdown-lg :where(h3 code) {
 
       ---
 
-      - .prose-lg pre {
-      + .markdown-lg pre {
+      - .prose-lg :where(pre) {
+      + .markdown-lg :where(pre) {
 
       ---
 
-      - .prose-lg ol {
-      + .markdown-lg ol {
+      - .prose-lg :where(ol) {
+      + .markdown-lg :where(ol) {
 
       ---
 
-      - .prose-lg ul {
-      + .markdown-lg ul {
+      - .prose-lg :where(ul) {
+      + .markdown-lg :where(ul) {
 
       ---
 
-      - .prose-lg li {
-      + .markdown-lg li {
+      - .prose-lg :where(li) {
+      + .markdown-lg :where(li) {
 
       ---
 
-      - .prose-lg ol > li {
-      + .markdown-lg ol > li {
+      - .prose-lg :where(ol > li) {
+      + .markdown-lg :where(ol > li) {
 
       ---
 
-      - .prose-lg ol > li::before {
-      + .markdown-lg ol > li::before {
+      - .prose-lg :where(ol > li::before) {
+      + .markdown-lg :where(ol > li::before) {
 
       ---
 
-      - .prose-lg ul > li {
-      + .markdown-lg ul > li {
+      - .prose-lg :where(ul > li) {
+      + .markdown-lg :where(ul > li) {
 
       ---
 
-      - .prose-lg ul > li::before {
-      + .markdown-lg ul > li::before {
+      - .prose-lg :where(ul > li::before) {
+      + .markdown-lg :where(ul > li::before) {
 
       ---
 
-      - .prose-lg > ul > li p {
-      + .markdown-lg > ul > li p {
+      - .prose-lg :where(> ul > li p) {
+      + .markdown-lg :where(> ul > li p) {
 
       ---
 
-      - .prose-lg > ul > li > *:first-child {
-      + .markdown-lg > ul > li > *:first-child {
+      - .prose-lg :where(> ul > li > *:first-child) {
+      + .markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-lg > ul > li > *:last-child {
-      + .markdown-lg > ul > li > *:last-child {
+      - .prose-lg :where(> ul > li > *:last-child) {
+      + .markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-lg > ol > li > *:first-child {
-      + .markdown-lg > ol > li > *:first-child {
+      - .prose-lg :where(> ol > li > *:first-child) {
+      + .markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-lg > ol > li > *:last-child {
-      + .markdown-lg > ol > li > *:last-child {
+      - .prose-lg :where(> ol > li > *:last-child) {
+      + .markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
-      + .markdown-lg ul ul, .markdown-lg ul ol, .markdown-lg ol ul, .markdown-lg ol ol {
+      - .prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-lg hr {
-      + .markdown-lg hr {
+      - .prose-lg :where(hr) {
+      + .markdown-lg :where(hr) {
 
       ---
 
-      - .prose-lg hr + * {
-      + .markdown-lg hr + * {
+      - .prose-lg :where(hr + *) {
+      + .markdown-lg :where(hr + *) {
 
       ---
 
-      - .prose-lg h2 + * {
-      + .markdown-lg h2 + * {
+      - .prose-lg :where(h2 + *) {
+      + .markdown-lg :where(h2 + *) {
 
       ---
 
-      - .prose-lg h3 + * {
-      + .markdown-lg h3 + * {
+      - .prose-lg :where(h3 + *) {
+      + .markdown-lg :where(h3 + *) {
 
       ---
 
-      - .prose-lg h4 + * {
-      + .markdown-lg h4 + * {
+      - .prose-lg :where(h4 + *) {
+      + .markdown-lg :where(h4 + *) {
 
       ---
 
-      - .prose-lg table {
-      + .markdown-lg table {
+      - .prose-lg :where(table) {
+      + .markdown-lg :where(table) {
 
       ---
 
-      - .prose-lg thead th {
-      + .markdown-lg thead th {
+      - .prose-lg :where(thead th) {
+      + .markdown-lg :where(thead th) {
 
       ---
 
-      - .prose-lg thead th:first-child {
-      + .markdown-lg thead th:first-child {
+      - .prose-lg :where(thead th:first-child) {
+      + .markdown-lg :where(thead th:first-child) {
 
       ---
 
-      - .prose-lg thead th:last-child {
-      + .markdown-lg thead th:last-child {
+      - .prose-lg :where(thead th:last-child) {
+      + .markdown-lg :where(thead th:last-child) {
 
       ---
 
-      - .prose-lg tbody td {
-      + .markdown-lg tbody td {
+      - .prose-lg :where(tbody td) {
+      + .markdown-lg :where(tbody td) {
 
       ---
 
-      - .prose-lg tbody td:first-child {
-      + .markdown-lg tbody td:first-child {
+      - .prose-lg :where(tbody td:first-child) {
+      + .markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      - .prose-lg tbody td:last-child {
-      + .markdown-lg tbody td:last-child {
+      - .prose-lg :where(tbody td:last-child) {
+      + .markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      - .prose-lg > :first-child {
-      + .markdown-lg > :first-child {
+      - .prose-lg :where(> :first-child) {
+      + .markdown-lg :where(> :first-child) {
 
       ---
 
-      - .prose-lg > :last-child {
-      + .markdown-lg > :last-child {
+      - .prose-lg :where(> :last-child) {
+      + .markdown-lg :where(> :last-child) {
 
       ---
 
@@ -8857,218 +8857,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-xl p {
-      + .markdown-xl p {
+      - .prose-xl :where(p) {
+      + .markdown-xl :where(p) {
 
       ---
 
-      - .prose-xl [class~='lead'] {
-      + .markdown-xl [class~='lead'] {
+      - .prose-xl :where([class~='lead']) {
+      + .markdown-xl :where([class~='lead']) {
 
       ---
 
-      - .prose-xl blockquote {
-      + .markdown-xl blockquote {
+      - .prose-xl :where(blockquote) {
+      + .markdown-xl :where(blockquote) {
 
       ---
 
-      - .prose-xl h1 {
-      + .markdown-xl h1 {
+      - .prose-xl :where(h1) {
+      + .markdown-xl :where(h1) {
 
       ---
 
-      - .prose-xl h2 {
-      + .markdown-xl h2 {
+      - .prose-xl :where(h2) {
+      + .markdown-xl :where(h2) {
 
       ---
 
-      - .prose-xl h3 {
-      + .markdown-xl h3 {
+      - .prose-xl :where(h3) {
+      + .markdown-xl :where(h3) {
 
       ---
 
-      - .prose-xl h4 {
-      + .markdown-xl h4 {
+      - .prose-xl :where(h4) {
+      + .markdown-xl :where(h4) {
 
       ---
 
-      - .prose-xl img {
-      + .markdown-xl img {
+      - .prose-xl :where(img) {
+      + .markdown-xl :where(img) {
 
       ---
 
-      - .prose-xl video {
-      + .markdown-xl video {
+      - .prose-xl :where(video) {
+      + .markdown-xl :where(video) {
 
       ---
 
-      - .prose-xl figure {
-      + .markdown-xl figure {
+      - .prose-xl :where(figure) {
+      + .markdown-xl :where(figure) {
 
       ---
 
-      - .prose-xl figure > * {
-      + .markdown-xl figure > * {
+      - .prose-xl :where(figure > *) {
+      + .markdown-xl :where(figure > *) {
 
       ---
 
-      - .prose-xl figure figcaption {
-      + .markdown-xl figure figcaption {
+      - .prose-xl :where(figure figcaption) {
+      + .markdown-xl :where(figure figcaption) {
 
       ---
 
-      - .prose-xl code {
-      + .markdown-xl code {
+      - .prose-xl :where(code) {
+      + .markdown-xl :where(code) {
 
       ---
 
-      - .prose-xl h2 code {
-      + .markdown-xl h2 code {
+      - .prose-xl :where(h2 code) {
+      + .markdown-xl :where(h2 code) {
 
       ---
 
-      - .prose-xl h3 code {
-      + .markdown-xl h3 code {
+      - .prose-xl :where(h3 code) {
+      + .markdown-xl :where(h3 code) {
 
       ---
 
-      - .prose-xl pre {
-      + .markdown-xl pre {
+      - .prose-xl :where(pre) {
+      + .markdown-xl :where(pre) {
 
       ---
 
-      - .prose-xl ol {
-      + .markdown-xl ol {
+      - .prose-xl :where(ol) {
+      + .markdown-xl :where(ol) {
 
       ---
 
-      - .prose-xl ul {
-      + .markdown-xl ul {
+      - .prose-xl :where(ul) {
+      + .markdown-xl :where(ul) {
 
       ---
 
-      - .prose-xl li {
-      + .markdown-xl li {
+      - .prose-xl :where(li) {
+      + .markdown-xl :where(li) {
 
       ---
 
-      - .prose-xl ol > li {
-      + .markdown-xl ol > li {
+      - .prose-xl :where(ol > li) {
+      + .markdown-xl :where(ol > li) {
 
       ---
 
-      - .prose-xl ol > li::before {
-      + .markdown-xl ol > li::before {
+      - .prose-xl :where(ol > li::before) {
+      + .markdown-xl :where(ol > li::before) {
 
       ---
 
-      - .prose-xl ul > li {
-      + .markdown-xl ul > li {
+      - .prose-xl :where(ul > li) {
+      + .markdown-xl :where(ul > li) {
 
       ---
 
-      - .prose-xl ul > li::before {
-      + .markdown-xl ul > li::before {
+      - .prose-xl :where(ul > li::before) {
+      + .markdown-xl :where(ul > li::before) {
 
       ---
 
-      - .prose-xl > ul > li p {
-      + .markdown-xl > ul > li p {
+      - .prose-xl :where(> ul > li p) {
+      + .markdown-xl :where(> ul > li p) {
 
       ---
 
-      - .prose-xl > ul > li > *:first-child {
-      + .markdown-xl > ul > li > *:first-child {
+      - .prose-xl :where(> ul > li > *:first-child) {
+      + .markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-xl > ul > li > *:last-child {
-      + .markdown-xl > ul > li > *:last-child {
+      - .prose-xl :where(> ul > li > *:last-child) {
+      + .markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-xl > ol > li > *:first-child {
-      + .markdown-xl > ol > li > *:first-child {
+      - .prose-xl :where(> ol > li > *:first-child) {
+      + .markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-xl > ol > li > *:last-child {
-      + .markdown-xl > ol > li > *:last-child {
+      - .prose-xl :where(> ol > li > *:last-child) {
+      + .markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-xl ul ul, .prose-xl ul ol, .prose-xl ol ul, .prose-xl ol ol {
-      + .markdown-xl ul ul, .markdown-xl ul ol, .markdown-xl ol ul, .markdown-xl ol ol {
+      - .prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-xl hr {
-      + .markdown-xl hr {
+      - .prose-xl :where(hr) {
+      + .markdown-xl :where(hr) {
 
       ---
 
-      - .prose-xl hr + * {
-      + .markdown-xl hr + * {
+      - .prose-xl :where(hr + *) {
+      + .markdown-xl :where(hr + *) {
 
       ---
 
-      - .prose-xl h2 + * {
-      + .markdown-xl h2 + * {
+      - .prose-xl :where(h2 + *) {
+      + .markdown-xl :where(h2 + *) {
 
       ---
 
-      - .prose-xl h3 + * {
-      + .markdown-xl h3 + * {
+      - .prose-xl :where(h3 + *) {
+      + .markdown-xl :where(h3 + *) {
 
       ---
 
-      - .prose-xl h4 + * {
-      + .markdown-xl h4 + * {
+      - .prose-xl :where(h4 + *) {
+      + .markdown-xl :where(h4 + *) {
 
       ---
 
-      - .prose-xl table {
-      + .markdown-xl table {
+      - .prose-xl :where(table) {
+      + .markdown-xl :where(table) {
 
       ---
 
-      - .prose-xl thead th {
-      + .markdown-xl thead th {
+      - .prose-xl :where(thead th) {
+      + .markdown-xl :where(thead th) {
 
       ---
 
-      - .prose-xl thead th:first-child {
-      + .markdown-xl thead th:first-child {
+      - .prose-xl :where(thead th:first-child) {
+      + .markdown-xl :where(thead th:first-child) {
 
       ---
 
-      - .prose-xl thead th:last-child {
-      + .markdown-xl thead th:last-child {
+      - .prose-xl :where(thead th:last-child) {
+      + .markdown-xl :where(thead th:last-child) {
 
       ---
 
-      - .prose-xl tbody td {
-      + .markdown-xl tbody td {
+      - .prose-xl :where(tbody td) {
+      + .markdown-xl :where(tbody td) {
 
       ---
 
-      - .prose-xl tbody td:first-child {
-      + .markdown-xl tbody td:first-child {
+      - .prose-xl :where(tbody td:first-child) {
+      + .markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      - .prose-xl tbody td:last-child {
-      + .markdown-xl tbody td:last-child {
+      - .prose-xl :where(tbody td:last-child) {
+      + .markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      - .prose-xl > :first-child {
-      + .markdown-xl > :first-child {
+      - .prose-xl :where(> :first-child) {
+      + .markdown-xl :where(> :first-child) {
 
       ---
 
-      - .prose-xl > :last-child {
-      + .markdown-xl > :last-child {
+      - .prose-xl :where(> :last-child) {
+      + .markdown-xl :where(> :last-child) {
 
       ---
 
@@ -9077,288 +9077,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-2xl p {
-      + .markdown-2xl p {
+      - .prose-2xl :where(p) {
+      + .markdown-2xl :where(p) {
 
       ---
 
-      - .prose-2xl [class~='lead'] {
-      + .markdown-2xl [class~='lead'] {
+      - .prose-2xl :where([class~='lead']) {
+      + .markdown-2xl :where([class~='lead']) {
 
       ---
 
-      - .prose-2xl blockquote {
-      + .markdown-2xl blockquote {
+      - .prose-2xl :where(blockquote) {
+      + .markdown-2xl :where(blockquote) {
 
       ---
 
-      - .prose-2xl h1 {
-      + .markdown-2xl h1 {
+      - .prose-2xl :where(h1) {
+      + .markdown-2xl :where(h1) {
 
       ---
 
-      - .prose-2xl h2 {
-      + .markdown-2xl h2 {
+      - .prose-2xl :where(h2) {
+      + .markdown-2xl :where(h2) {
 
       ---
 
-      - .prose-2xl h3 {
-      + .markdown-2xl h3 {
+      - .prose-2xl :where(h3) {
+      + .markdown-2xl :where(h3) {
 
       ---
 
-      - .prose-2xl h4 {
-      + .markdown-2xl h4 {
+      - .prose-2xl :where(h4) {
+      + .markdown-2xl :where(h4) {
 
       ---
 
-      - .prose-2xl img {
-      + .markdown-2xl img {
+      - .prose-2xl :where(img) {
+      + .markdown-2xl :where(img) {
 
       ---
 
-      - .prose-2xl video {
-      + .markdown-2xl video {
+      - .prose-2xl :where(video) {
+      + .markdown-2xl :where(video) {
 
       ---
 
-      - .prose-2xl figure {
-      + .markdown-2xl figure {
+      - .prose-2xl :where(figure) {
+      + .markdown-2xl :where(figure) {
 
       ---
 
-      - .prose-2xl figure > * {
-      + .markdown-2xl figure > * {
+      - .prose-2xl :where(figure > *) {
+      + .markdown-2xl :where(figure > *) {
 
       ---
 
-      - .prose-2xl figure figcaption {
-      + .markdown-2xl figure figcaption {
+      - .prose-2xl :where(figure figcaption) {
+      + .markdown-2xl :where(figure figcaption) {
 
       ---
 
-      - .prose-2xl code {
-      + .markdown-2xl code {
+      - .prose-2xl :where(code) {
+      + .markdown-2xl :where(code) {
 
       ---
 
-      - .prose-2xl h2 code {
-      + .markdown-2xl h2 code {
+      - .prose-2xl :where(h2 code) {
+      + .markdown-2xl :where(h2 code) {
 
       ---
 
-      - .prose-2xl h3 code {
-      + .markdown-2xl h3 code {
+      - .prose-2xl :where(h3 code) {
+      + .markdown-2xl :where(h3 code) {
 
       ---
 
-      - .prose-2xl pre {
-      + .markdown-2xl pre {
+      - .prose-2xl :where(pre) {
+      + .markdown-2xl :where(pre) {
 
       ---
 
-      - .prose-2xl ol {
-      + .markdown-2xl ol {
+      - .prose-2xl :where(ol) {
+      + .markdown-2xl :where(ol) {
 
       ---
 
-      - .prose-2xl ul {
-      + .markdown-2xl ul {
+      - .prose-2xl :where(ul) {
+      + .markdown-2xl :where(ul) {
 
       ---
 
-      - .prose-2xl li {
-      + .markdown-2xl li {
+      - .prose-2xl :where(li) {
+      + .markdown-2xl :where(li) {
 
       ---
 
-      - .prose-2xl ol > li {
-      + .markdown-2xl ol > li {
+      - .prose-2xl :where(ol > li) {
+      + .markdown-2xl :where(ol > li) {
 
       ---
 
-      - .prose-2xl ol > li::before {
-      + .markdown-2xl ol > li::before {
+      - .prose-2xl :where(ol > li::before) {
+      + .markdown-2xl :where(ol > li::before) {
 
       ---
 
-      - .prose-2xl ul > li {
-      + .markdown-2xl ul > li {
+      - .prose-2xl :where(ul > li) {
+      + .markdown-2xl :where(ul > li) {
 
       ---
 
-      - .prose-2xl ul > li::before {
-      + .markdown-2xl ul > li::before {
+      - .prose-2xl :where(ul > li::before) {
+      + .markdown-2xl :where(ul > li::before) {
 
       ---
 
-      - .prose-2xl > ul > li p {
-      + .markdown-2xl > ul > li p {
+      - .prose-2xl :where(> ul > li p) {
+      + .markdown-2xl :where(> ul > li p) {
 
       ---
 
-      - .prose-2xl > ul > li > *:first-child {
-      + .markdown-2xl > ul > li > *:first-child {
+      - .prose-2xl :where(> ul > li > *:first-child) {
+      + .markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-2xl > ul > li > *:last-child {
-      + .markdown-2xl > ul > li > *:last-child {
+      - .prose-2xl :where(> ul > li > *:last-child) {
+      + .markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-2xl > ol > li > *:first-child {
-      + .markdown-2xl > ol > li > *:first-child {
+      - .prose-2xl :where(> ol > li > *:first-child) {
+      + .markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-2xl > ol > li > *:last-child {
-      + .markdown-2xl > ol > li > *:last-child {
+      - .prose-2xl :where(> ol > li > *:last-child) {
+      + .markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-2xl ul ul, .prose-2xl ul ol, .prose-2xl ol ul, .prose-2xl ol ol {
-      + .markdown-2xl ul ul, .markdown-2xl ul ol, .markdown-2xl ol ul, .markdown-2xl ol ol {
+      - .prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-2xl hr {
-      + .markdown-2xl hr {
+      - .prose-2xl :where(hr) {
+      + .markdown-2xl :where(hr) {
 
       ---
 
-      - .prose-2xl hr + * {
-      + .markdown-2xl hr + * {
+      - .prose-2xl :where(hr + *) {
+      + .markdown-2xl :where(hr + *) {
 
       ---
 
-      - .prose-2xl h2 + * {
-      + .markdown-2xl h2 + * {
+      - .prose-2xl :where(h2 + *) {
+      + .markdown-2xl :where(h2 + *) {
 
       ---
 
-      - .prose-2xl h3 + * {
-      + .markdown-2xl h3 + * {
+      - .prose-2xl :where(h3 + *) {
+      + .markdown-2xl :where(h3 + *) {
 
       ---
 
-      - .prose-2xl h4 + * {
-      + .markdown-2xl h4 + * {
+      - .prose-2xl :where(h4 + *) {
+      + .markdown-2xl :where(h4 + *) {
 
       ---
 
-      - .prose-2xl table {
-      + .markdown-2xl table {
+      - .prose-2xl :where(table) {
+      + .markdown-2xl :where(table) {
 
       ---
 
-      - .prose-2xl thead th {
-      + .markdown-2xl thead th {
+      - .prose-2xl :where(thead th) {
+      + .markdown-2xl :where(thead th) {
 
       ---
 
-      - .prose-2xl thead th:first-child {
-      + .markdown-2xl thead th:first-child {
+      - .prose-2xl :where(thead th:first-child) {
+      + .markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      - .prose-2xl thead th:last-child {
-      + .markdown-2xl thead th:last-child {
+      - .prose-2xl :where(thead th:last-child) {
+      + .markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      - .prose-2xl tbody td {
-      + .markdown-2xl tbody td {
+      - .prose-2xl :where(tbody td) {
+      + .markdown-2xl :where(tbody td) {
 
       ---
 
-      - .prose-2xl tbody td:first-child {
-      + .markdown-2xl tbody td:first-child {
+      - .prose-2xl :where(tbody td:first-child) {
+      + .markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      - .prose-2xl tbody td:last-child {
-      + .markdown-2xl tbody td:last-child {
+      - .prose-2xl :where(tbody td:last-child) {
+      + .markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      - .prose-2xl > :first-child {
-      + .markdown-2xl > :first-child {
+      - .prose-2xl :where(> :first-child) {
+      + .markdown-2xl :where(> :first-child) {
 
       ---
 
-      - .prose-2xl > :last-child {
-      + .markdown-2xl > :last-child {
+      - .prose-2xl :where(> :last-child) {
+      + .markdown-2xl :where(> :last-child) {
 
       ---
 
-      - .prose-red a {
-      + .markdown-red a {
+      - .prose-red :where(a) {
+      + .markdown-red :where(a) {
 
       ---
 
-      - .prose-red a code {
-      + .markdown-red a code {
+      - .prose-red :where(a code) {
+      + .markdown-red :where(a code) {
 
       ---
 
-      - .prose-yellow a {
-      + .markdown-yellow a {
+      - .prose-yellow :where(a) {
+      + .markdown-yellow :where(a) {
 
       ---
 
-      - .prose-yellow a code {
-      + .markdown-yellow a code {
+      - .prose-yellow :where(a code) {
+      + .markdown-yellow :where(a code) {
 
       ---
 
-      - .prose-green a {
-      + .markdown-green a {
+      - .prose-green :where(a) {
+      + .markdown-green :where(a) {
 
       ---
 
-      - .prose-green a code {
-      + .markdown-green a code {
+      - .prose-green :where(a code) {
+      + .markdown-green :where(a code) {
 
       ---
 
-      - .prose-blue a {
-      + .markdown-blue a {
+      - .prose-blue :where(a) {
+      + .markdown-blue :where(a) {
 
       ---
 
-      - .prose-blue a code {
-      + .markdown-blue a code {
+      - .prose-blue :where(a code) {
+      + .markdown-blue :where(a code) {
 
       ---
 
-      - .prose-indigo a {
-      + .markdown-indigo a {
+      - .prose-indigo :where(a) {
+      + .markdown-indigo :where(a) {
 
       ---
 
-      - .prose-indigo a code {
-      + .markdown-indigo a code {
+      - .prose-indigo :where(a code) {
+      + .markdown-indigo :where(a code) {
 
       ---
 
-      - .prose-purple a {
-      + .markdown-purple a {
+      - .prose-purple :where(a) {
+      + .markdown-purple :where(a) {
 
       ---
 
-      - .prose-purple a code {
-      + .markdown-purple a code {
+      - .prose-purple :where(a code) {
+      + .markdown-purple :where(a code) {
 
       ---
 
-      - .prose-pink a {
-      + .markdown-pink a {
+      - .prose-pink :where(a) {
+      + .markdown-pink :where(a) {
 
       ---
 
-      - .prose-pink a code {
-      + .markdown-pink a code {
+      - .prose-pink :where(a code) {
+      + .markdown-pink :where(a code) {
 
       ---
 
@@ -9367,218 +9367,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose [class~='lead'] {
-      +   .sm\\\\:markdown [class~='lead'] {
+      -   .sm\\\\:prose :where([class~='lead']) {
+      +   .sm\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose a {
-      +   .sm\\\\:markdown a {
+      -   .sm\\\\:prose :where(a) {
+      +   .sm\\\\:markdown :where(a) {
 
       ---
 
-      -   .sm\\\\:prose strong {
-      +   .sm\\\\:markdown strong {
+      -   .sm\\\\:prose :where(strong) {
+      +   .sm\\\\:markdown :where(strong) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='A'] {
-      +   .sm\\\\:markdown ol[type='A'] {
+      -   .sm\\\\:prose :where(ol[type='A']) {
+      +   .sm\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='a'] {
-      +   .sm\\\\:markdown ol[type='a'] {
+      -   .sm\\\\:prose :where(ol[type='a']) {
+      +   .sm\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='A' s] {
-      +   .sm\\\\:markdown ol[type='A' s] {
+      -   .sm\\\\:prose :where(ol[type='A' s]) {
+      +   .sm\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='a' s] {
-      +   .sm\\\\:markdown ol[type='a' s] {
+      -   .sm\\\\:prose :where(ol[type='a' s]) {
+      +   .sm\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='I'] {
-      +   .sm\\\\:markdown ol[type='I'] {
+      -   .sm\\\\:prose :where(ol[type='I']) {
+      +   .sm\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='i'] {
-      +   .sm\\\\:markdown ol[type='i'] {
+      -   .sm\\\\:prose :where(ol[type='i']) {
+      +   .sm\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='I' s] {
-      +   .sm\\\\:markdown ol[type='I' s] {
+      -   .sm\\\\:prose :where(ol[type='I' s]) {
+      +   .sm\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='i' s] {
-      +   .sm\\\\:markdown ol[type='i' s] {
+      -   .sm\\\\:prose :where(ol[type='i' s]) {
+      +   .sm\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='1'] {
-      +   .sm\\\\:markdown ol[type='1'] {
+      -   .sm\\\\:prose :where(ol[type='1']) {
+      +   .sm\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .sm\\\\:prose ol > li {
-      +   .sm\\\\:markdown ol > li {
+      -   .sm\\\\:prose :where(ol > li) {
+      +   .sm\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose ol > li::before {
-      +   .sm\\\\:markdown ol > li::before {
+      -   .sm\\\\:prose :where(ol > li::before) {
+      +   .sm\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose ul > li {
-      +   .sm\\\\:markdown ul > li {
+      -   .sm\\\\:prose :where(ul > li) {
+      +   .sm\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose ul > li::before {
-      +   .sm\\\\:markdown ul > li::before {
+      -   .sm\\\\:prose :where(ul > li::before) {
+      +   .sm\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose hr {
-      +   .sm\\\\:markdown hr {
+      -   .sm\\\\:prose :where(hr) {
+      +   .sm\\\\:markdown :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose blockquote {
-      +   .sm\\\\:markdown blockquote {
+      -   .sm\\\\:prose :where(blockquote) {
+      +   .sm\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose blockquote p:first-of-type::before {
-      +   .sm\\\\:markdown blockquote p:first-of-type::before {
+      -   .sm\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .sm\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .sm\\\\:prose blockquote p:last-of-type::after {
-      +   .sm\\\\:markdown blockquote p:last-of-type::after {
+      -   .sm\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .sm\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .sm\\\\:prose h1 {
-      +   .sm\\\\:markdown h1 {
+      -   .sm\\\\:prose :where(h1) {
+      +   .sm\\\\:markdown :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose h1 strong {
-      +   .sm\\\\:markdown h1 strong {
+      -   .sm\\\\:prose :where(h1 strong) {
+      +   .sm\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .sm\\\\:prose h2 {
-      +   .sm\\\\:markdown h2 {
+      -   .sm\\\\:prose :where(h2) {
+      +   .sm\\\\:markdown :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose h2 strong {
-      +   .sm\\\\:markdown h2 strong {
+      -   .sm\\\\:prose :where(h2 strong) {
+      +   .sm\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .sm\\\\:prose h3 {
-      +   .sm\\\\:markdown h3 {
+      -   .sm\\\\:prose :where(h3) {
+      +   .sm\\\\:markdown :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose h3 strong {
-      +   .sm\\\\:markdown h3 strong {
+      -   .sm\\\\:prose :where(h3 strong) {
+      +   .sm\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .sm\\\\:prose h4 {
-      +   .sm\\\\:markdown h4 {
+      -   .sm\\\\:prose :where(h4) {
+      +   .sm\\\\:markdown :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose h4 strong {
-      +   .sm\\\\:markdown h4 strong {
+      -   .sm\\\\:prose :where(h4 strong) {
+      +   .sm\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .sm\\\\:prose figure figcaption {
-      +   .sm\\\\:markdown figure figcaption {
+      -   .sm\\\\:prose :where(figure figcaption) {
+      +   .sm\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose code {
-      +   .sm\\\\:markdown code {
+      -   .sm\\\\:prose :where(code) {
+      +   .sm\\\\:markdown :where(code) {
 
       ---
 
-      -   .sm\\\\:prose code::before {
-      +   .sm\\\\:markdown code::before {
+      -   .sm\\\\:prose :where(code::before) {
+      +   .sm\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .sm\\\\:prose code::after {
-      +   .sm\\\\:markdown code::after {
+      -   .sm\\\\:prose :where(code::after) {
+      +   .sm\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .sm\\\\:prose a code {
-      +   .sm\\\\:markdown a code {
+      -   .sm\\\\:prose :where(a code) {
+      +   .sm\\\\:markdown :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose pre {
-      +   .sm\\\\:markdown pre {
+      -   .sm\\\\:prose :where(pre) {
+      +   .sm\\\\:markdown :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose pre code {
-      +   .sm\\\\:markdown pre code {
+      -   .sm\\\\:prose :where(pre code) {
+      +   .sm\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .sm\\\\:prose pre code::before {
-      +   .sm\\\\:markdown pre code::before {
+      -   .sm\\\\:prose :where(pre code::before) {
+      +   .sm\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .sm\\\\:prose pre code::after {
-      +   .sm\\\\:markdown pre code::after {
+      -   .sm\\\\:prose :where(pre code::after) {
+      +   .sm\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .sm\\\\:prose table {
-      +   .sm\\\\:markdown table {
+      -   .sm\\\\:prose :where(table) {
+      +   .sm\\\\:markdown :where(table) {
 
       ---
 
-      -   .sm\\\\:prose thead {
-      +   .sm\\\\:markdown thead {
+      -   .sm\\\\:prose :where(thead) {
+      +   .sm\\\\:markdown :where(thead) {
 
       ---
 
-      -   .sm\\\\:prose thead th {
-      +   .sm\\\\:markdown thead th {
+      -   .sm\\\\:prose :where(thead th) {
+      +   .sm\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose tbody tr {
-      +   .sm\\\\:markdown tbody tr {
+      -   .sm\\\\:prose :where(tbody tr) {
+      +   .sm\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .sm\\\\:prose tbody tr:last-child {
-      +   .sm\\\\:markdown tbody tr:last-child {
+      -   .sm\\\\:prose :where(tbody tr:last-child) {
+      +   .sm\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .sm\\\\:prose tbody td {
-      +   .sm\\\\:markdown tbody td {
+      -   .sm\\\\:prose :where(tbody td) {
+      +   .sm\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -9587,133 +9587,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose p {
-      +   .sm\\\\:markdown p {
+      -   .sm\\\\:prose :where(p) {
+      +   .sm\\\\:markdown :where(p) {
 
       ---
 
-      -   .sm\\\\:prose img {
-      +   .sm\\\\:markdown img {
+      -   .sm\\\\:prose :where(img) {
+      +   .sm\\\\:markdown :where(img) {
 
       ---
 
-      -   .sm\\\\:prose video {
-      +   .sm\\\\:markdown video {
+      -   .sm\\\\:prose :where(video) {
+      +   .sm\\\\:markdown :where(video) {
 
       ---
 
-      -   .sm\\\\:prose figure {
-      +   .sm\\\\:markdown figure {
+      -   .sm\\\\:prose :where(figure) {
+      +   .sm\\\\:markdown :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose figure > * {
-      +   .sm\\\\:markdown figure > * {
+      -   .sm\\\\:prose :where(figure > *) {
+      +   .sm\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose h2 code {
-      +   .sm\\\\:markdown h2 code {
+      -   .sm\\\\:prose :where(h2 code) {
+      +   .sm\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose h3 code {
-      +   .sm\\\\:markdown h3 code {
+      -   .sm\\\\:prose :where(h3 code) {
+      +   .sm\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose ol {
-      +   .sm\\\\:markdown ol {
+      -   .sm\\\\:prose :where(ol) {
+      +   .sm\\\\:markdown :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose ul {
-      +   .sm\\\\:markdown ul {
+      -   .sm\\\\:prose :where(ul) {
+      +   .sm\\\\:markdown :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose li {
-      +   .sm\\\\:markdown li {
+      -   .sm\\\\:prose :where(li) {
+      +   .sm\\\\:markdown :where(li) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li p {
-      +   .sm\\\\:markdown > ul > li p {
+      -   .sm\\\\:prose :where(> ul > li p) {
+      +   .sm\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li > *:first-child {
-      +   .sm\\\\:markdown > ul > li > *:first-child {
+      -   .sm\\\\:prose :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li > *:last-child {
-      +   .sm\\\\:markdown > ul > li > *:last-child {
+      -   .sm\\\\:prose :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose > ol > li > *:first-child {
-      +   .sm\\\\:markdown > ol > li > *:first-child {
+      -   .sm\\\\:prose :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose > ol > li > *:last-child {
-      +   .sm\\\\:markdown > ol > li > *:last-child {
+      -   .sm\\\\:prose :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose ul ul, .sm\\\\:prose ul ol, .sm\\\\:prose ol ul, .sm\\\\:prose ol ol {
-      +   .sm\\\\:markdown ul ul, .sm\\\\:markdown ul ol, .sm\\\\:markdown ol ul, .sm\\\\:markdown ol ol {
+      -   .sm\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose hr + * {
-      +   .sm\\\\:markdown hr + * {
+      -   .sm\\\\:prose :where(hr + *) {
+      +   .sm\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose h2 + * {
-      +   .sm\\\\:markdown h2 + * {
+      -   .sm\\\\:prose :where(h2 + *) {
+      +   .sm\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose h3 + * {
-      +   .sm\\\\:markdown h3 + * {
+      -   .sm\\\\:prose :where(h3 + *) {
+      +   .sm\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose h4 + * {
-      +   .sm\\\\:markdown h4 + * {
+      -   .sm\\\\:prose :where(h4 + *) {
+      +   .sm\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose thead th:first-child {
-      +   .sm\\\\:markdown thead th:first-child {
+      -   .sm\\\\:prose :where(thead th:first-child) {
+      +   .sm\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose thead th:last-child {
-      +   .sm\\\\:markdown thead th:last-child {
+      -   .sm\\\\:prose :where(thead th:last-child) {
+      +   .sm\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose tbody td:first-child {
-      +   .sm\\\\:markdown tbody td:first-child {
+      -   .sm\\\\:prose :where(tbody td:first-child) {
+      +   .sm\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose tbody td:last-child {
-      +   .sm\\\\:markdown tbody td:last-child {
+      -   .sm\\\\:prose :where(tbody td:last-child) {
+      +   .sm\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose > :first-child {
-      +   .sm\\\\:markdown > :first-child {
+      -   .sm\\\\:prose :where(> :first-child) {
+      +   .sm\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose > :last-child {
-      +   .sm\\\\:markdown > :last-child {
+      -   .sm\\\\:prose :where(> :last-child) {
+      +   .sm\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -9722,218 +9722,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-sm p {
-      +   .sm\\\\:markdown-sm p {
+      -   .sm\\\\:prose-sm :where(p) {
+      +   .sm\\\\:markdown-sm :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-sm [class~='lead'] {
-      +   .sm\\\\:markdown-sm [class~='lead'] {
+      -   .sm\\\\:prose-sm :where([class~='lead']) {
+      +   .sm\\\\:markdown-sm :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-sm blockquote {
-      +   .sm\\\\:markdown-sm blockquote {
+      -   .sm\\\\:prose-sm :where(blockquote) {
+      +   .sm\\\\:markdown-sm :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-sm h1 {
-      +   .sm\\\\:markdown-sm h1 {
+      -   .sm\\\\:prose-sm :where(h1) {
+      +   .sm\\\\:markdown-sm :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-sm h2 {
-      +   .sm\\\\:markdown-sm h2 {
+      -   .sm\\\\:prose-sm :where(h2) {
+      +   .sm\\\\:markdown-sm :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-sm h3 {
-      +   .sm\\\\:markdown-sm h3 {
+      -   .sm\\\\:prose-sm :where(h3) {
+      +   .sm\\\\:markdown-sm :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-sm h4 {
-      +   .sm\\\\:markdown-sm h4 {
+      -   .sm\\\\:prose-sm :where(h4) {
+      +   .sm\\\\:markdown-sm :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-sm img {
-      +   .sm\\\\:markdown-sm img {
+      -   .sm\\\\:prose-sm :where(img) {
+      +   .sm\\\\:markdown-sm :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-sm video {
-      +   .sm\\\\:markdown-sm video {
+      -   .sm\\\\:prose-sm :where(video) {
+      +   .sm\\\\:markdown-sm :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-sm figure {
-      +   .sm\\\\:markdown-sm figure {
+      -   .sm\\\\:prose-sm :where(figure) {
+      +   .sm\\\\:markdown-sm :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-sm figure > * {
-      +   .sm\\\\:markdown-sm figure > * {
+      -   .sm\\\\:prose-sm :where(figure > *) {
+      +   .sm\\\\:markdown-sm :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-sm figure figcaption {
-      +   .sm\\\\:markdown-sm figure figcaption {
+      -   .sm\\\\:prose-sm :where(figure figcaption) {
+      +   .sm\\\\:markdown-sm :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-sm code {
-      +   .sm\\\\:markdown-sm code {
+      -   .sm\\\\:prose-sm :where(code) {
+      +   .sm\\\\:markdown-sm :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-sm h2 code {
-      +   .sm\\\\:markdown-sm h2 code {
+      -   .sm\\\\:prose-sm :where(h2 code) {
+      +   .sm\\\\:markdown-sm :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-sm h3 code {
-      +   .sm\\\\:markdown-sm h3 code {
+      -   .sm\\\\:prose-sm :where(h3 code) {
+      +   .sm\\\\:markdown-sm :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-sm pre {
-      +   .sm\\\\:markdown-sm pre {
+      -   .sm\\\\:prose-sm :where(pre) {
+      +   .sm\\\\:markdown-sm :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-sm ol {
-      +   .sm\\\\:markdown-sm ol {
+      -   .sm\\\\:prose-sm :where(ol) {
+      +   .sm\\\\:markdown-sm :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-sm ul {
-      +   .sm\\\\:markdown-sm ul {
+      -   .sm\\\\:prose-sm :where(ul) {
+      +   .sm\\\\:markdown-sm :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-sm li {
-      +   .sm\\\\:markdown-sm li {
+      -   .sm\\\\:prose-sm :where(li) {
+      +   .sm\\\\:markdown-sm :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-sm ol > li {
-      +   .sm\\\\:markdown-sm ol > li {
+      -   .sm\\\\:prose-sm :where(ol > li) {
+      +   .sm\\\\:markdown-sm :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-sm ol > li::before {
-      +   .sm\\\\:markdown-sm ol > li::before {
+      -   .sm\\\\:prose-sm :where(ol > li::before) {
+      +   .sm\\\\:markdown-sm :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-sm ul > li {
-      +   .sm\\\\:markdown-sm ul > li {
+      -   .sm\\\\:prose-sm :where(ul > li) {
+      +   .sm\\\\:markdown-sm :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-sm ul > li::before {
-      +   .sm\\\\:markdown-sm ul > li::before {
+      -   .sm\\\\:prose-sm :where(ul > li::before) {
+      +   .sm\\\\:markdown-sm :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-sm > ul > li p {
-      +   .sm\\\\:markdown-sm > ul > li p {
+      -   .sm\\\\:prose-sm :where(> ul > li p) {
+      +   .sm\\\\:markdown-sm :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-sm > ul > li > *:first-child {
-      +   .sm\\\\:markdown-sm > ul > li > *:first-child {
+      -   .sm\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > ul > li > *:last-child {
-      +   .sm\\\\:markdown-sm > ul > li > *:last-child {
+      -   .sm\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > ol > li > *:first-child {
-      +   .sm\\\\:markdown-sm > ol > li > *:first-child {
+      -   .sm\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > ol > li > *:last-child {
-      +   .sm\\\\:markdown-sm > ol > li > *:last-child {
+      -   .sm\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm ul ul, .sm\\\\:prose-sm ul ol, .sm\\\\:prose-sm ol ul, .sm\\\\:prose-sm ol ol {
-      +   .sm\\\\:markdown-sm ul ul, .sm\\\\:markdown-sm ul ol, .sm\\\\:markdown-sm ol ul, .sm\\\\:markdown-sm ol ol {
+      -   .sm\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-sm hr {
-      +   .sm\\\\:markdown-sm hr {
+      -   .sm\\\\:prose-sm :where(hr) {
+      +   .sm\\\\:markdown-sm :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-sm hr + * {
-      +   .sm\\\\:markdown-sm hr + * {
+      -   .sm\\\\:prose-sm :where(hr + *) {
+      +   .sm\\\\:markdown-sm :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-sm h2 + * {
-      +   .sm\\\\:markdown-sm h2 + * {
+      -   .sm\\\\:prose-sm :where(h2 + *) {
+      +   .sm\\\\:markdown-sm :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-sm h3 + * {
-      +   .sm\\\\:markdown-sm h3 + * {
+      -   .sm\\\\:prose-sm :where(h3 + *) {
+      +   .sm\\\\:markdown-sm :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-sm h4 + * {
-      +   .sm\\\\:markdown-sm h4 + * {
+      -   .sm\\\\:prose-sm :where(h4 + *) {
+      +   .sm\\\\:markdown-sm :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-sm table {
-      +   .sm\\\\:markdown-sm table {
+      -   .sm\\\\:prose-sm :where(table) {
+      +   .sm\\\\:markdown-sm :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-sm thead th {
-      +   .sm\\\\:markdown-sm thead th {
+      -   .sm\\\\:prose-sm :where(thead th) {
+      +   .sm\\\\:markdown-sm :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-sm thead th:first-child {
-      +   .sm\\\\:markdown-sm thead th:first-child {
+      -   .sm\\\\:prose-sm :where(thead th:first-child) {
+      +   .sm\\\\:markdown-sm :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm thead th:last-child {
-      +   .sm\\\\:markdown-sm thead th:last-child {
+      -   .sm\\\\:prose-sm :where(thead th:last-child) {
+      +   .sm\\\\:markdown-sm :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm tbody td {
-      +   .sm\\\\:markdown-sm tbody td {
+      -   .sm\\\\:prose-sm :where(tbody td) {
+      +   .sm\\\\:markdown-sm :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-sm tbody td:first-child {
-      +   .sm\\\\:markdown-sm tbody td:first-child {
+      -   .sm\\\\:prose-sm :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm tbody td:last-child {
-      +   .sm\\\\:markdown-sm tbody td:last-child {
+      -   .sm\\\\:prose-sm :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > :first-child {
-      +   .sm\\\\:markdown-sm > :first-child {
+      -   .sm\\\\:prose-sm :where(> :first-child) {
+      +   .sm\\\\:markdown-sm :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > :last-child {
-      +   .sm\\\\:markdown-sm > :last-child {
+      -   .sm\\\\:prose-sm :where(> :last-child) {
+      +   .sm\\\\:markdown-sm :where(> :last-child) {
 
       ---
 
@@ -9942,218 +9942,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-lg p {
-      +   .sm\\\\:markdown-lg p {
+      -   .sm\\\\:prose-lg :where(p) {
+      +   .sm\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-lg [class~='lead'] {
-      +   .sm\\\\:markdown-lg [class~='lead'] {
+      -   .sm\\\\:prose-lg :where([class~='lead']) {
+      +   .sm\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-lg blockquote {
-      +   .sm\\\\:markdown-lg blockquote {
+      -   .sm\\\\:prose-lg :where(blockquote) {
+      +   .sm\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-lg h1 {
-      +   .sm\\\\:markdown-lg h1 {
+      -   .sm\\\\:prose-lg :where(h1) {
+      +   .sm\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 {
-      +   .sm\\\\:markdown-lg h2 {
+      -   .sm\\\\:prose-lg :where(h2) {
+      +   .sm\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 {
-      +   .sm\\\\:markdown-lg h3 {
+      -   .sm\\\\:prose-lg :where(h3) {
+      +   .sm\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-lg h4 {
-      +   .sm\\\\:markdown-lg h4 {
+      -   .sm\\\\:prose-lg :where(h4) {
+      +   .sm\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-lg img {
-      +   .sm\\\\:markdown-lg img {
+      -   .sm\\\\:prose-lg :where(img) {
+      +   .sm\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-lg video {
-      +   .sm\\\\:markdown-lg video {
+      -   .sm\\\\:prose-lg :where(video) {
+      +   .sm\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure {
-      +   .sm\\\\:markdown-lg figure {
+      -   .sm\\\\:prose-lg :where(figure) {
+      +   .sm\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure > * {
-      +   .sm\\\\:markdown-lg figure > * {
+      -   .sm\\\\:prose-lg :where(figure > *) {
+      +   .sm\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure figcaption {
-      +   .sm\\\\:markdown-lg figure figcaption {
+      -   .sm\\\\:prose-lg :where(figure figcaption) {
+      +   .sm\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-lg code {
-      +   .sm\\\\:markdown-lg code {
+      -   .sm\\\\:prose-lg :where(code) {
+      +   .sm\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 code {
-      +   .sm\\\\:markdown-lg h2 code {
+      -   .sm\\\\:prose-lg :where(h2 code) {
+      +   .sm\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 code {
-      +   .sm\\\\:markdown-lg h3 code {
+      -   .sm\\\\:prose-lg :where(h3 code) {
+      +   .sm\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-lg pre {
-      +   .sm\\\\:markdown-lg pre {
+      -   .sm\\\\:prose-lg :where(pre) {
+      +   .sm\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol {
-      +   .sm\\\\:markdown-lg ol {
+      -   .sm\\\\:prose-lg :where(ol) {
+      +   .sm\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul {
-      +   .sm\\\\:markdown-lg ul {
+      -   .sm\\\\:prose-lg :where(ul) {
+      +   .sm\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-lg li {
-      +   .sm\\\\:markdown-lg li {
+      -   .sm\\\\:prose-lg :where(li) {
+      +   .sm\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol > li {
-      +   .sm\\\\:markdown-lg ol > li {
+      -   .sm\\\\:prose-lg :where(ol > li) {
+      +   .sm\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol > li::before {
-      +   .sm\\\\:markdown-lg ol > li::before {
+      -   .sm\\\\:prose-lg :where(ol > li::before) {
+      +   .sm\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul > li {
-      +   .sm\\\\:markdown-lg ul > li {
+      -   .sm\\\\:prose-lg :where(ul > li) {
+      +   .sm\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul > li::before {
-      +   .sm\\\\:markdown-lg ul > li::before {
+      -   .sm\\\\:prose-lg :where(ul > li::before) {
+      +   .sm\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li p {
-      +   .sm\\\\:markdown-lg > ul > li p {
+      -   .sm\\\\:prose-lg :where(> ul > li p) {
+      +   .sm\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li > *:first-child {
-      +   .sm\\\\:markdown-lg > ul > li > *:first-child {
+      -   .sm\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li > *:last-child {
-      +   .sm\\\\:markdown-lg > ul > li > *:last-child {
+      -   .sm\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ol > li > *:first-child {
-      +   .sm\\\\:markdown-lg > ol > li > *:first-child {
+      -   .sm\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ol > li > *:last-child {
-      +   .sm\\\\:markdown-lg > ol > li > *:last-child {
+      -   .sm\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul ul, .sm\\\\:prose-lg ul ol, .sm\\\\:prose-lg ol ul, .sm\\\\:prose-lg ol ol {
-      +   .sm\\\\:markdown-lg ul ul, .sm\\\\:markdown-lg ul ol, .sm\\\\:markdown-lg ol ul, .sm\\\\:markdown-lg ol ol {
+      -   .sm\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-lg hr {
-      +   .sm\\\\:markdown-lg hr {
+      -   .sm\\\\:prose-lg :where(hr) {
+      +   .sm\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-lg hr + * {
-      +   .sm\\\\:markdown-lg hr + * {
+      -   .sm\\\\:prose-lg :where(hr + *) {
+      +   .sm\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 + * {
-      +   .sm\\\\:markdown-lg h2 + * {
+      -   .sm\\\\:prose-lg :where(h2 + *) {
+      +   .sm\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 + * {
-      +   .sm\\\\:markdown-lg h3 + * {
+      -   .sm\\\\:prose-lg :where(h3 + *) {
+      +   .sm\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h4 + * {
-      +   .sm\\\\:markdown-lg h4 + * {
+      -   .sm\\\\:prose-lg :where(h4 + *) {
+      +   .sm\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg table {
-      +   .sm\\\\:markdown-lg table {
+      -   .sm\\\\:prose-lg :where(table) {
+      +   .sm\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th {
-      +   .sm\\\\:markdown-lg thead th {
+      -   .sm\\\\:prose-lg :where(thead th) {
+      +   .sm\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th:first-child {
-      +   .sm\\\\:markdown-lg thead th:first-child {
+      -   .sm\\\\:prose-lg :where(thead th:first-child) {
+      +   .sm\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th:last-child {
-      +   .sm\\\\:markdown-lg thead th:last-child {
+      -   .sm\\\\:prose-lg :where(thead th:last-child) {
+      +   .sm\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td {
-      +   .sm\\\\:markdown-lg tbody td {
+      -   .sm\\\\:prose-lg :where(tbody td) {
+      +   .sm\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td:first-child {
-      +   .sm\\\\:markdown-lg tbody td:first-child {
+      -   .sm\\\\:prose-lg :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td:last-child {
-      +   .sm\\\\:markdown-lg tbody td:last-child {
+      -   .sm\\\\:prose-lg :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > :first-child {
-      +   .sm\\\\:markdown-lg > :first-child {
+      -   .sm\\\\:prose-lg :where(> :first-child) {
+      +   .sm\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > :last-child {
-      +   .sm\\\\:markdown-lg > :last-child {
+      -   .sm\\\\:prose-lg :where(> :last-child) {
+      +   .sm\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -10162,218 +10162,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-xl p {
-      +   .sm\\\\:markdown-xl p {
+      -   .sm\\\\:prose-xl :where(p) {
+      +   .sm\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-xl [class~='lead'] {
-      +   .sm\\\\:markdown-xl [class~='lead'] {
+      -   .sm\\\\:prose-xl :where([class~='lead']) {
+      +   .sm\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-xl blockquote {
-      +   .sm\\\\:markdown-xl blockquote {
+      -   .sm\\\\:prose-xl :where(blockquote) {
+      +   .sm\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-xl h1 {
-      +   .sm\\\\:markdown-xl h1 {
+      -   .sm\\\\:prose-xl :where(h1) {
+      +   .sm\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 {
-      +   .sm\\\\:markdown-xl h2 {
+      -   .sm\\\\:prose-xl :where(h2) {
+      +   .sm\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 {
-      +   .sm\\\\:markdown-xl h3 {
+      -   .sm\\\\:prose-xl :where(h3) {
+      +   .sm\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-xl h4 {
-      +   .sm\\\\:markdown-xl h4 {
+      -   .sm\\\\:prose-xl :where(h4) {
+      +   .sm\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-xl img {
-      +   .sm\\\\:markdown-xl img {
+      -   .sm\\\\:prose-xl :where(img) {
+      +   .sm\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-xl video {
-      +   .sm\\\\:markdown-xl video {
+      -   .sm\\\\:prose-xl :where(video) {
+      +   .sm\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure {
-      +   .sm\\\\:markdown-xl figure {
+      -   .sm\\\\:prose-xl :where(figure) {
+      +   .sm\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure > * {
-      +   .sm\\\\:markdown-xl figure > * {
+      -   .sm\\\\:prose-xl :where(figure > *) {
+      +   .sm\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure figcaption {
-      +   .sm\\\\:markdown-xl figure figcaption {
+      -   .sm\\\\:prose-xl :where(figure figcaption) {
+      +   .sm\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-xl code {
-      +   .sm\\\\:markdown-xl code {
+      -   .sm\\\\:prose-xl :where(code) {
+      +   .sm\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 code {
-      +   .sm\\\\:markdown-xl h2 code {
+      -   .sm\\\\:prose-xl :where(h2 code) {
+      +   .sm\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 code {
-      +   .sm\\\\:markdown-xl h3 code {
+      -   .sm\\\\:prose-xl :where(h3 code) {
+      +   .sm\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-xl pre {
-      +   .sm\\\\:markdown-xl pre {
+      -   .sm\\\\:prose-xl :where(pre) {
+      +   .sm\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol {
-      +   .sm\\\\:markdown-xl ol {
+      -   .sm\\\\:prose-xl :where(ol) {
+      +   .sm\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul {
-      +   .sm\\\\:markdown-xl ul {
+      -   .sm\\\\:prose-xl :where(ul) {
+      +   .sm\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-xl li {
-      +   .sm\\\\:markdown-xl li {
+      -   .sm\\\\:prose-xl :where(li) {
+      +   .sm\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol > li {
-      +   .sm\\\\:markdown-xl ol > li {
+      -   .sm\\\\:prose-xl :where(ol > li) {
+      +   .sm\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol > li::before {
-      +   .sm\\\\:markdown-xl ol > li::before {
+      -   .sm\\\\:prose-xl :where(ol > li::before) {
+      +   .sm\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul > li {
-      +   .sm\\\\:markdown-xl ul > li {
+      -   .sm\\\\:prose-xl :where(ul > li) {
+      +   .sm\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul > li::before {
-      +   .sm\\\\:markdown-xl ul > li::before {
+      -   .sm\\\\:prose-xl :where(ul > li::before) {
+      +   .sm\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li p {
-      +   .sm\\\\:markdown-xl > ul > li p {
+      -   .sm\\\\:prose-xl :where(> ul > li p) {
+      +   .sm\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li > *:first-child {
-      +   .sm\\\\:markdown-xl > ul > li > *:first-child {
+      -   .sm\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li > *:last-child {
-      +   .sm\\\\:markdown-xl > ul > li > *:last-child {
+      -   .sm\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ol > li > *:first-child {
-      +   .sm\\\\:markdown-xl > ol > li > *:first-child {
+      -   .sm\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ol > li > *:last-child {
-      +   .sm\\\\:markdown-xl > ol > li > *:last-child {
+      -   .sm\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul ul, .sm\\\\:prose-xl ul ol, .sm\\\\:prose-xl ol ul, .sm\\\\:prose-xl ol ol {
-      +   .sm\\\\:markdown-xl ul ul, .sm\\\\:markdown-xl ul ol, .sm\\\\:markdown-xl ol ul, .sm\\\\:markdown-xl ol ol {
+      -   .sm\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-xl hr {
-      +   .sm\\\\:markdown-xl hr {
+      -   .sm\\\\:prose-xl :where(hr) {
+      +   .sm\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-xl hr + * {
-      +   .sm\\\\:markdown-xl hr + * {
+      -   .sm\\\\:prose-xl :where(hr + *) {
+      +   .sm\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 + * {
-      +   .sm\\\\:markdown-xl h2 + * {
+      -   .sm\\\\:prose-xl :where(h2 + *) {
+      +   .sm\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 + * {
-      +   .sm\\\\:markdown-xl h3 + * {
+      -   .sm\\\\:prose-xl :where(h3 + *) {
+      +   .sm\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h4 + * {
-      +   .sm\\\\:markdown-xl h4 + * {
+      -   .sm\\\\:prose-xl :where(h4 + *) {
+      +   .sm\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl table {
-      +   .sm\\\\:markdown-xl table {
+      -   .sm\\\\:prose-xl :where(table) {
+      +   .sm\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th {
-      +   .sm\\\\:markdown-xl thead th {
+      -   .sm\\\\:prose-xl :where(thead th) {
+      +   .sm\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th:first-child {
-      +   .sm\\\\:markdown-xl thead th:first-child {
+      -   .sm\\\\:prose-xl :where(thead th:first-child) {
+      +   .sm\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th:last-child {
-      +   .sm\\\\:markdown-xl thead th:last-child {
+      -   .sm\\\\:prose-xl :where(thead th:last-child) {
+      +   .sm\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td {
-      +   .sm\\\\:markdown-xl tbody td {
+      -   .sm\\\\:prose-xl :where(tbody td) {
+      +   .sm\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td:first-child {
-      +   .sm\\\\:markdown-xl tbody td:first-child {
+      -   .sm\\\\:prose-xl :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td:last-child {
-      +   .sm\\\\:markdown-xl tbody td:last-child {
+      -   .sm\\\\:prose-xl :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > :first-child {
-      +   .sm\\\\:markdown-xl > :first-child {
+      -   .sm\\\\:prose-xl :where(> :first-child) {
+      +   .sm\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > :last-child {
-      +   .sm\\\\:markdown-xl > :last-child {
+      -   .sm\\\\:prose-xl :where(> :last-child) {
+      +   .sm\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -10382,288 +10382,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-2xl p {
-      +   .sm\\\\:markdown-2xl p {
+      -   .sm\\\\:prose-2xl :where(p) {
+      +   .sm\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-2xl [class~='lead'] {
-      +   .sm\\\\:markdown-2xl [class~='lead'] {
+      -   .sm\\\\:prose-2xl :where([class~='lead']) {
+      +   .sm\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-2xl blockquote {
-      +   .sm\\\\:markdown-2xl blockquote {
+      -   .sm\\\\:prose-2xl :where(blockquote) {
+      +   .sm\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h1 {
-      +   .sm\\\\:markdown-2xl h1 {
+      -   .sm\\\\:prose-2xl :where(h1) {
+      +   .sm\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 {
-      +   .sm\\\\:markdown-2xl h2 {
+      -   .sm\\\\:prose-2xl :where(h2) {
+      +   .sm\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 {
-      +   .sm\\\\:markdown-2xl h3 {
+      -   .sm\\\\:prose-2xl :where(h3) {
+      +   .sm\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h4 {
-      +   .sm\\\\:markdown-2xl h4 {
+      -   .sm\\\\:prose-2xl :where(h4) {
+      +   .sm\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-2xl img {
-      +   .sm\\\\:markdown-2xl img {
+      -   .sm\\\\:prose-2xl :where(img) {
+      +   .sm\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-2xl video {
-      +   .sm\\\\:markdown-2xl video {
+      -   .sm\\\\:prose-2xl :where(video) {
+      +   .sm\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure {
-      +   .sm\\\\:markdown-2xl figure {
+      -   .sm\\\\:prose-2xl :where(figure) {
+      +   .sm\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure > * {
-      +   .sm\\\\:markdown-2xl figure > * {
+      -   .sm\\\\:prose-2xl :where(figure > *) {
+      +   .sm\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure figcaption {
-      +   .sm\\\\:markdown-2xl figure figcaption {
+      -   .sm\\\\:prose-2xl :where(figure figcaption) {
+      +   .sm\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-2xl code {
-      +   .sm\\\\:markdown-2xl code {
+      -   .sm\\\\:prose-2xl :where(code) {
+      +   .sm\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 code {
-      +   .sm\\\\:markdown-2xl h2 code {
+      -   .sm\\\\:prose-2xl :where(h2 code) {
+      +   .sm\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 code {
-      +   .sm\\\\:markdown-2xl h3 code {
+      -   .sm\\\\:prose-2xl :where(h3 code) {
+      +   .sm\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl pre {
-      +   .sm\\\\:markdown-2xl pre {
+      -   .sm\\\\:prose-2xl :where(pre) {
+      +   .sm\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol {
-      +   .sm\\\\:markdown-2xl ol {
+      -   .sm\\\\:prose-2xl :where(ol) {
+      +   .sm\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul {
-      +   .sm\\\\:markdown-2xl ul {
+      -   .sm\\\\:prose-2xl :where(ul) {
+      +   .sm\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-2xl li {
-      +   .sm\\\\:markdown-2xl li {
+      -   .sm\\\\:prose-2xl :where(li) {
+      +   .sm\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol > li {
-      +   .sm\\\\:markdown-2xl ol > li {
+      -   .sm\\\\:prose-2xl :where(ol > li) {
+      +   .sm\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol > li::before {
-      +   .sm\\\\:markdown-2xl ol > li::before {
+      -   .sm\\\\:prose-2xl :where(ol > li::before) {
+      +   .sm\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul > li {
-      +   .sm\\\\:markdown-2xl ul > li {
+      -   .sm\\\\:prose-2xl :where(ul > li) {
+      +   .sm\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul > li::before {
-      +   .sm\\\\:markdown-2xl ul > li::before {
+      -   .sm\\\\:prose-2xl :where(ul > li::before) {
+      +   .sm\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li p {
-      +   .sm\\\\:markdown-2xl > ul > li p {
+      -   .sm\\\\:prose-2xl :where(> ul > li p) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li > *:first-child {
-      +   .sm\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li > *:last-child {
-      +   .sm\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ol > li > *:first-child {
-      +   .sm\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ol > li > *:last-child {
-      +   .sm\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul ul, .sm\\\\:prose-2xl ul ol, .sm\\\\:prose-2xl ol ul, .sm\\\\:prose-2xl ol ol {
-      +   .sm\\\\:markdown-2xl ul ul, .sm\\\\:markdown-2xl ul ol, .sm\\\\:markdown-2xl ol ul, .sm\\\\:markdown-2xl ol ol {
+      -   .sm\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-2xl hr {
-      +   .sm\\\\:markdown-2xl hr {
+      -   .sm\\\\:prose-2xl :where(hr) {
+      +   .sm\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-2xl hr + * {
-      +   .sm\\\\:markdown-2xl hr + * {
+      -   .sm\\\\:prose-2xl :where(hr + *) {
+      +   .sm\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 + * {
-      +   .sm\\\\:markdown-2xl h2 + * {
+      -   .sm\\\\:prose-2xl :where(h2 + *) {
+      +   .sm\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 + * {
-      +   .sm\\\\:markdown-2xl h3 + * {
+      -   .sm\\\\:prose-2xl :where(h3 + *) {
+      +   .sm\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h4 + * {
-      +   .sm\\\\:markdown-2xl h4 + * {
+      -   .sm\\\\:prose-2xl :where(h4 + *) {
+      +   .sm\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl table {
-      +   .sm\\\\:markdown-2xl table {
+      -   .sm\\\\:prose-2xl :where(table) {
+      +   .sm\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th {
-      +   .sm\\\\:markdown-2xl thead th {
+      -   .sm\\\\:prose-2xl :where(thead th) {
+      +   .sm\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th:first-child {
-      +   .sm\\\\:markdown-2xl thead th:first-child {
+      -   .sm\\\\:prose-2xl :where(thead th:first-child) {
+      +   .sm\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th:last-child {
-      +   .sm\\\\:markdown-2xl thead th:last-child {
+      -   .sm\\\\:prose-2xl :where(thead th:last-child) {
+      +   .sm\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td {
-      +   .sm\\\\:markdown-2xl tbody td {
+      -   .sm\\\\:prose-2xl :where(tbody td) {
+      +   .sm\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td:first-child {
-      +   .sm\\\\:markdown-2xl tbody td:first-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td:last-child {
-      +   .sm\\\\:markdown-2xl tbody td:last-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > :first-child {
-      +   .sm\\\\:markdown-2xl > :first-child {
+      -   .sm\\\\:prose-2xl :where(> :first-child) {
+      +   .sm\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > :last-child {
-      +   .sm\\\\:markdown-2xl > :last-child {
+      -   .sm\\\\:prose-2xl :where(> :last-child) {
+      +   .sm\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
-      -   .sm\\\\:prose-red a {
-      +   .sm\\\\:markdown-red a {
+      -   .sm\\\\:prose-red :where(a) {
+      +   .sm\\\\:markdown-red :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-red a code {
-      +   .sm\\\\:markdown-red a code {
+      -   .sm\\\\:prose-red :where(a code) {
+      +   .sm\\\\:markdown-red :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-yellow a {
-      +   .sm\\\\:markdown-yellow a {
+      -   .sm\\\\:prose-yellow :where(a) {
+      +   .sm\\\\:markdown-yellow :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-yellow a code {
-      +   .sm\\\\:markdown-yellow a code {
+      -   .sm\\\\:prose-yellow :where(a code) {
+      +   .sm\\\\:markdown-yellow :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-green a {
-      +   .sm\\\\:markdown-green a {
+      -   .sm\\\\:prose-green :where(a) {
+      +   .sm\\\\:markdown-green :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-green a code {
-      +   .sm\\\\:markdown-green a code {
+      -   .sm\\\\:prose-green :where(a code) {
+      +   .sm\\\\:markdown-green :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-blue a {
-      +   .sm\\\\:markdown-blue a {
+      -   .sm\\\\:prose-blue :where(a) {
+      +   .sm\\\\:markdown-blue :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-blue a code {
-      +   .sm\\\\:markdown-blue a code {
+      -   .sm\\\\:prose-blue :where(a code) {
+      +   .sm\\\\:markdown-blue :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-indigo a {
-      +   .sm\\\\:markdown-indigo a {
+      -   .sm\\\\:prose-indigo :where(a) {
+      +   .sm\\\\:markdown-indigo :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-indigo a code {
-      +   .sm\\\\:markdown-indigo a code {
+      -   .sm\\\\:prose-indigo :where(a code) {
+      +   .sm\\\\:markdown-indigo :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-purple a {
-      +   .sm\\\\:markdown-purple a {
+      -   .sm\\\\:prose-purple :where(a) {
+      +   .sm\\\\:markdown-purple :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-purple a code {
-      +   .sm\\\\:markdown-purple a code {
+      -   .sm\\\\:prose-purple :where(a code) {
+      +   .sm\\\\:markdown-purple :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose-pink a {
-      +   .sm\\\\:markdown-pink a {
+      -   .sm\\\\:prose-pink :where(a) {
+      +   .sm\\\\:markdown-pink :where(a) {
 
       ---
 
-      -   .sm\\\\:prose-pink a code {
-      +   .sm\\\\:markdown-pink a code {
+      -   .sm\\\\:prose-pink :where(a code) {
+      +   .sm\\\\:markdown-pink :where(a code) {
 
       ---
 
@@ -10672,218 +10672,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose [class~='lead'] {
-      +   .md\\\\:markdown [class~='lead'] {
+      -   .md\\\\:prose :where([class~='lead']) {
+      +   .md\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose a {
-      +   .md\\\\:markdown a {
+      -   .md\\\\:prose :where(a) {
+      +   .md\\\\:markdown :where(a) {
 
       ---
 
-      -   .md\\\\:prose strong {
-      +   .md\\\\:markdown strong {
+      -   .md\\\\:prose :where(strong) {
+      +   .md\\\\:markdown :where(strong) {
 
       ---
 
-      -   .md\\\\:prose ol[type='A'] {
-      +   .md\\\\:markdown ol[type='A'] {
+      -   .md\\\\:prose :where(ol[type='A']) {
+      +   .md\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='a'] {
-      +   .md\\\\:markdown ol[type='a'] {
+      -   .md\\\\:prose :where(ol[type='a']) {
+      +   .md\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='A' s] {
-      +   .md\\\\:markdown ol[type='A' s] {
+      -   .md\\\\:prose :where(ol[type='A' s]) {
+      +   .md\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='a' s] {
-      +   .md\\\\:markdown ol[type='a' s] {
+      -   .md\\\\:prose :where(ol[type='a' s]) {
+      +   .md\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='I'] {
-      +   .md\\\\:markdown ol[type='I'] {
+      -   .md\\\\:prose :where(ol[type='I']) {
+      +   .md\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='i'] {
-      +   .md\\\\:markdown ol[type='i'] {
+      -   .md\\\\:prose :where(ol[type='i']) {
+      +   .md\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='I' s] {
-      +   .md\\\\:markdown ol[type='I' s] {
+      -   .md\\\\:prose :where(ol[type='I' s]) {
+      +   .md\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='i' s] {
-      +   .md\\\\:markdown ol[type='i' s] {
+      -   .md\\\\:prose :where(ol[type='i' s]) {
+      +   .md\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='1'] {
-      +   .md\\\\:markdown ol[type='1'] {
+      -   .md\\\\:prose :where(ol[type='1']) {
+      +   .md\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .md\\\\:prose ol > li {
-      +   .md\\\\:markdown ol > li {
+      -   .md\\\\:prose :where(ol > li) {
+      +   .md\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose ol > li::before {
-      +   .md\\\\:markdown ol > li::before {
+      -   .md\\\\:prose :where(ol > li::before) {
+      +   .md\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose ul > li {
-      +   .md\\\\:markdown ul > li {
+      -   .md\\\\:prose :where(ul > li) {
+      +   .md\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose ul > li::before {
-      +   .md\\\\:markdown ul > li::before {
+      -   .md\\\\:prose :where(ul > li::before) {
+      +   .md\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose hr {
-      +   .md\\\\:markdown hr {
+      -   .md\\\\:prose :where(hr) {
+      +   .md\\\\:markdown :where(hr) {
 
       ---
 
-      -   .md\\\\:prose blockquote {
-      +   .md\\\\:markdown blockquote {
+      -   .md\\\\:prose :where(blockquote) {
+      +   .md\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose blockquote p:first-of-type::before {
-      +   .md\\\\:markdown blockquote p:first-of-type::before {
+      -   .md\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .md\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .md\\\\:prose blockquote p:last-of-type::after {
-      +   .md\\\\:markdown blockquote p:last-of-type::after {
+      -   .md\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .md\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .md\\\\:prose h1 {
-      +   .md\\\\:markdown h1 {
+      -   .md\\\\:prose :where(h1) {
+      +   .md\\\\:markdown :where(h1) {
 
       ---
 
-      -   .md\\\\:prose h1 strong {
-      +   .md\\\\:markdown h1 strong {
+      -   .md\\\\:prose :where(h1 strong) {
+      +   .md\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .md\\\\:prose h2 {
-      +   .md\\\\:markdown h2 {
+      -   .md\\\\:prose :where(h2) {
+      +   .md\\\\:markdown :where(h2) {
 
       ---
 
-      -   .md\\\\:prose h2 strong {
-      +   .md\\\\:markdown h2 strong {
+      -   .md\\\\:prose :where(h2 strong) {
+      +   .md\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .md\\\\:prose h3 {
-      +   .md\\\\:markdown h3 {
+      -   .md\\\\:prose :where(h3) {
+      +   .md\\\\:markdown :where(h3) {
 
       ---
 
-      -   .md\\\\:prose h3 strong {
-      +   .md\\\\:markdown h3 strong {
+      -   .md\\\\:prose :where(h3 strong) {
+      +   .md\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .md\\\\:prose h4 {
-      +   .md\\\\:markdown h4 {
+      -   .md\\\\:prose :where(h4) {
+      +   .md\\\\:markdown :where(h4) {
 
       ---
 
-      -   .md\\\\:prose h4 strong {
-      +   .md\\\\:markdown h4 strong {
+      -   .md\\\\:prose :where(h4 strong) {
+      +   .md\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .md\\\\:prose figure figcaption {
-      +   .md\\\\:markdown figure figcaption {
+      -   .md\\\\:prose :where(figure figcaption) {
+      +   .md\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose code {
-      +   .md\\\\:markdown code {
+      -   .md\\\\:prose :where(code) {
+      +   .md\\\\:markdown :where(code) {
 
       ---
 
-      -   .md\\\\:prose code::before {
-      +   .md\\\\:markdown code::before {
+      -   .md\\\\:prose :where(code::before) {
+      +   .md\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .md\\\\:prose code::after {
-      +   .md\\\\:markdown code::after {
+      -   .md\\\\:prose :where(code::after) {
+      +   .md\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .md\\\\:prose a code {
-      +   .md\\\\:markdown a code {
+      -   .md\\\\:prose :where(a code) {
+      +   .md\\\\:markdown :where(a code) {
 
       ---
 
-      -   .md\\\\:prose pre {
-      +   .md\\\\:markdown pre {
+      -   .md\\\\:prose :where(pre) {
+      +   .md\\\\:markdown :where(pre) {
 
       ---
 
-      -   .md\\\\:prose pre code {
-      +   .md\\\\:markdown pre code {
+      -   .md\\\\:prose :where(pre code) {
+      +   .md\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .md\\\\:prose pre code::before {
-      +   .md\\\\:markdown pre code::before {
+      -   .md\\\\:prose :where(pre code::before) {
+      +   .md\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .md\\\\:prose pre code::after {
-      +   .md\\\\:markdown pre code::after {
+      -   .md\\\\:prose :where(pre code::after) {
+      +   .md\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .md\\\\:prose table {
-      +   .md\\\\:markdown table {
+      -   .md\\\\:prose :where(table) {
+      +   .md\\\\:markdown :where(table) {
 
       ---
 
-      -   .md\\\\:prose thead {
-      +   .md\\\\:markdown thead {
+      -   .md\\\\:prose :where(thead) {
+      +   .md\\\\:markdown :where(thead) {
 
       ---
 
-      -   .md\\\\:prose thead th {
-      +   .md\\\\:markdown thead th {
+      -   .md\\\\:prose :where(thead th) {
+      +   .md\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose tbody tr {
-      +   .md\\\\:markdown tbody tr {
+      -   .md\\\\:prose :where(tbody tr) {
+      +   .md\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .md\\\\:prose tbody tr:last-child {
-      +   .md\\\\:markdown tbody tr:last-child {
+      -   .md\\\\:prose :where(tbody tr:last-child) {
+      +   .md\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .md\\\\:prose tbody td {
-      +   .md\\\\:markdown tbody td {
+      -   .md\\\\:prose :where(tbody td) {
+      +   .md\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -10892,133 +10892,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose p {
-      +   .md\\\\:markdown p {
+      -   .md\\\\:prose :where(p) {
+      +   .md\\\\:markdown :where(p) {
 
       ---
 
-      -   .md\\\\:prose img {
-      +   .md\\\\:markdown img {
+      -   .md\\\\:prose :where(img) {
+      +   .md\\\\:markdown :where(img) {
 
       ---
 
-      -   .md\\\\:prose video {
-      +   .md\\\\:markdown video {
+      -   .md\\\\:prose :where(video) {
+      +   .md\\\\:markdown :where(video) {
 
       ---
 
-      -   .md\\\\:prose figure {
-      +   .md\\\\:markdown figure {
+      -   .md\\\\:prose :where(figure) {
+      +   .md\\\\:markdown :where(figure) {
 
       ---
 
-      -   .md\\\\:prose figure > * {
-      +   .md\\\\:markdown figure > * {
+      -   .md\\\\:prose :where(figure > *) {
+      +   .md\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose h2 code {
-      +   .md\\\\:markdown h2 code {
+      -   .md\\\\:prose :where(h2 code) {
+      +   .md\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose h3 code {
-      +   .md\\\\:markdown h3 code {
+      -   .md\\\\:prose :where(h3 code) {
+      +   .md\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose ol {
-      +   .md\\\\:markdown ol {
+      -   .md\\\\:prose :where(ol) {
+      +   .md\\\\:markdown :where(ol) {
 
       ---
 
-      -   .md\\\\:prose ul {
-      +   .md\\\\:markdown ul {
+      -   .md\\\\:prose :where(ul) {
+      +   .md\\\\:markdown :where(ul) {
 
       ---
 
-      -   .md\\\\:prose li {
-      +   .md\\\\:markdown li {
+      -   .md\\\\:prose :where(li) {
+      +   .md\\\\:markdown :where(li) {
 
       ---
 
-      -   .md\\\\:prose > ul > li p {
-      +   .md\\\\:markdown > ul > li p {
+      -   .md\\\\:prose :where(> ul > li p) {
+      +   .md\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose > ul > li > *:first-child {
-      +   .md\\\\:markdown > ul > li > *:first-child {
+      -   .md\\\\:prose :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose > ul > li > *:last-child {
-      +   .md\\\\:markdown > ul > li > *:last-child {
+      -   .md\\\\:prose :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose > ol > li > *:first-child {
-      +   .md\\\\:markdown > ol > li > *:first-child {
+      -   .md\\\\:prose :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose > ol > li > *:last-child {
-      +   .md\\\\:markdown > ol > li > *:last-child {
+      -   .md\\\\:prose :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose ul ul, .md\\\\:prose ul ol, .md\\\\:prose ol ul, .md\\\\:prose ol ol {
-      +   .md\\\\:markdown ul ul, .md\\\\:markdown ul ol, .md\\\\:markdown ol ul, .md\\\\:markdown ol ol {
+      -   .md\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose hr + * {
-      +   .md\\\\:markdown hr + * {
+      -   .md\\\\:prose :where(hr + *) {
+      +   .md\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose h2 + * {
-      +   .md\\\\:markdown h2 + * {
+      -   .md\\\\:prose :where(h2 + *) {
+      +   .md\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose h3 + * {
-      +   .md\\\\:markdown h3 + * {
+      -   .md\\\\:prose :where(h3 + *) {
+      +   .md\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose h4 + * {
-      +   .md\\\\:markdown h4 + * {
+      -   .md\\\\:prose :where(h4 + *) {
+      +   .md\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose thead th:first-child {
-      +   .md\\\\:markdown thead th:first-child {
+      -   .md\\\\:prose :where(thead th:first-child) {
+      +   .md\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose thead th:last-child {
-      +   .md\\\\:markdown thead th:last-child {
+      -   .md\\\\:prose :where(thead th:last-child) {
+      +   .md\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose tbody td:first-child {
-      +   .md\\\\:markdown tbody td:first-child {
+      -   .md\\\\:prose :where(tbody td:first-child) {
+      +   .md\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose tbody td:last-child {
-      +   .md\\\\:markdown tbody td:last-child {
+      -   .md\\\\:prose :where(tbody td:last-child) {
+      +   .md\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose > :first-child {
-      +   .md\\\\:markdown > :first-child {
+      -   .md\\\\:prose :where(> :first-child) {
+      +   .md\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose > :last-child {
-      +   .md\\\\:markdown > :last-child {
+      -   .md\\\\:prose :where(> :last-child) {
+      +   .md\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -11027,218 +11027,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-sm p {
-      +   .md\\\\:markdown-sm p {
+      -   .md\\\\:prose-sm :where(p) {
+      +   .md\\\\:markdown-sm :where(p) {
 
       ---
 
-      -   .md\\\\:prose-sm [class~='lead'] {
-      +   .md\\\\:markdown-sm [class~='lead'] {
+      -   .md\\\\:prose-sm :where([class~='lead']) {
+      +   .md\\\\:markdown-sm :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-sm blockquote {
-      +   .md\\\\:markdown-sm blockquote {
+      -   .md\\\\:prose-sm :where(blockquote) {
+      +   .md\\\\:markdown-sm :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-sm h1 {
-      +   .md\\\\:markdown-sm h1 {
+      -   .md\\\\:prose-sm :where(h1) {
+      +   .md\\\\:markdown-sm :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-sm h2 {
-      +   .md\\\\:markdown-sm h2 {
+      -   .md\\\\:prose-sm :where(h2) {
+      +   .md\\\\:markdown-sm :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-sm h3 {
-      +   .md\\\\:markdown-sm h3 {
+      -   .md\\\\:prose-sm :where(h3) {
+      +   .md\\\\:markdown-sm :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-sm h4 {
-      +   .md\\\\:markdown-sm h4 {
+      -   .md\\\\:prose-sm :where(h4) {
+      +   .md\\\\:markdown-sm :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-sm img {
-      +   .md\\\\:markdown-sm img {
+      -   .md\\\\:prose-sm :where(img) {
+      +   .md\\\\:markdown-sm :where(img) {
 
       ---
 
-      -   .md\\\\:prose-sm video {
-      +   .md\\\\:markdown-sm video {
+      -   .md\\\\:prose-sm :where(video) {
+      +   .md\\\\:markdown-sm :where(video) {
 
       ---
 
-      -   .md\\\\:prose-sm figure {
-      +   .md\\\\:markdown-sm figure {
+      -   .md\\\\:prose-sm :where(figure) {
+      +   .md\\\\:markdown-sm :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-sm figure > * {
-      +   .md\\\\:markdown-sm figure > * {
+      -   .md\\\\:prose-sm :where(figure > *) {
+      +   .md\\\\:markdown-sm :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-sm figure figcaption {
-      +   .md\\\\:markdown-sm figure figcaption {
+      -   .md\\\\:prose-sm :where(figure figcaption) {
+      +   .md\\\\:markdown-sm :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-sm code {
-      +   .md\\\\:markdown-sm code {
+      -   .md\\\\:prose-sm :where(code) {
+      +   .md\\\\:markdown-sm :where(code) {
 
       ---
 
-      -   .md\\\\:prose-sm h2 code {
-      +   .md\\\\:markdown-sm h2 code {
+      -   .md\\\\:prose-sm :where(h2 code) {
+      +   .md\\\\:markdown-sm :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-sm h3 code {
-      +   .md\\\\:markdown-sm h3 code {
+      -   .md\\\\:prose-sm :where(h3 code) {
+      +   .md\\\\:markdown-sm :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-sm pre {
-      +   .md\\\\:markdown-sm pre {
+      -   .md\\\\:prose-sm :where(pre) {
+      +   .md\\\\:markdown-sm :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-sm ol {
-      +   .md\\\\:markdown-sm ol {
+      -   .md\\\\:prose-sm :where(ol) {
+      +   .md\\\\:markdown-sm :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-sm ul {
-      +   .md\\\\:markdown-sm ul {
+      -   .md\\\\:prose-sm :where(ul) {
+      +   .md\\\\:markdown-sm :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-sm li {
-      +   .md\\\\:markdown-sm li {
+      -   .md\\\\:prose-sm :where(li) {
+      +   .md\\\\:markdown-sm :where(li) {
 
       ---
 
-      -   .md\\\\:prose-sm ol > li {
-      +   .md\\\\:markdown-sm ol > li {
+      -   .md\\\\:prose-sm :where(ol > li) {
+      +   .md\\\\:markdown-sm :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-sm ol > li::before {
-      +   .md\\\\:markdown-sm ol > li::before {
+      -   .md\\\\:prose-sm :where(ol > li::before) {
+      +   .md\\\\:markdown-sm :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-sm ul > li {
-      +   .md\\\\:markdown-sm ul > li {
+      -   .md\\\\:prose-sm :where(ul > li) {
+      +   .md\\\\:markdown-sm :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-sm ul > li::before {
-      +   .md\\\\:markdown-sm ul > li::before {
+      -   .md\\\\:prose-sm :where(ul > li::before) {
+      +   .md\\\\:markdown-sm :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-sm > ul > li p {
-      +   .md\\\\:markdown-sm > ul > li p {
+      -   .md\\\\:prose-sm :where(> ul > li p) {
+      +   .md\\\\:markdown-sm :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-sm > ul > li > *:first-child {
-      +   .md\\\\:markdown-sm > ul > li > *:first-child {
+      -   .md\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > ul > li > *:last-child {
-      +   .md\\\\:markdown-sm > ul > li > *:last-child {
+      -   .md\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > ol > li > *:first-child {
-      +   .md\\\\:markdown-sm > ol > li > *:first-child {
+      -   .md\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > ol > li > *:last-child {
-      +   .md\\\\:markdown-sm > ol > li > *:last-child {
+      -   .md\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm ul ul, .md\\\\:prose-sm ul ol, .md\\\\:prose-sm ol ul, .md\\\\:prose-sm ol ol {
-      +   .md\\\\:markdown-sm ul ul, .md\\\\:markdown-sm ul ol, .md\\\\:markdown-sm ol ul, .md\\\\:markdown-sm ol ol {
+      -   .md\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-sm hr {
-      +   .md\\\\:markdown-sm hr {
+      -   .md\\\\:prose-sm :where(hr) {
+      +   .md\\\\:markdown-sm :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-sm hr + * {
-      +   .md\\\\:markdown-sm hr + * {
+      -   .md\\\\:prose-sm :where(hr + *) {
+      +   .md\\\\:markdown-sm :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-sm h2 + * {
-      +   .md\\\\:markdown-sm h2 + * {
+      -   .md\\\\:prose-sm :where(h2 + *) {
+      +   .md\\\\:markdown-sm :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-sm h3 + * {
-      +   .md\\\\:markdown-sm h3 + * {
+      -   .md\\\\:prose-sm :where(h3 + *) {
+      +   .md\\\\:markdown-sm :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-sm h4 + * {
-      +   .md\\\\:markdown-sm h4 + * {
+      -   .md\\\\:prose-sm :where(h4 + *) {
+      +   .md\\\\:markdown-sm :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-sm table {
-      +   .md\\\\:markdown-sm table {
+      -   .md\\\\:prose-sm :where(table) {
+      +   .md\\\\:markdown-sm :where(table) {
 
       ---
 
-      -   .md\\\\:prose-sm thead th {
-      +   .md\\\\:markdown-sm thead th {
+      -   .md\\\\:prose-sm :where(thead th) {
+      +   .md\\\\:markdown-sm :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-sm thead th:first-child {
-      +   .md\\\\:markdown-sm thead th:first-child {
+      -   .md\\\\:prose-sm :where(thead th:first-child) {
+      +   .md\\\\:markdown-sm :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm thead th:last-child {
-      +   .md\\\\:markdown-sm thead th:last-child {
+      -   .md\\\\:prose-sm :where(thead th:last-child) {
+      +   .md\\\\:markdown-sm :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm tbody td {
-      +   .md\\\\:markdown-sm tbody td {
+      -   .md\\\\:prose-sm :where(tbody td) {
+      +   .md\\\\:markdown-sm :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-sm tbody td:first-child {
-      +   .md\\\\:markdown-sm tbody td:first-child {
+      -   .md\\\\:prose-sm :where(tbody td:first-child) {
+      +   .md\\\\:markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm tbody td:last-child {
-      +   .md\\\\:markdown-sm tbody td:last-child {
+      -   .md\\\\:prose-sm :where(tbody td:last-child) {
+      +   .md\\\\:markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > :first-child {
-      +   .md\\\\:markdown-sm > :first-child {
+      -   .md\\\\:prose-sm :where(> :first-child) {
+      +   .md\\\\:markdown-sm :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > :last-child {
-      +   .md\\\\:markdown-sm > :last-child {
+      -   .md\\\\:prose-sm :where(> :last-child) {
+      +   .md\\\\:markdown-sm :where(> :last-child) {
 
       ---
 
@@ -11247,218 +11247,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-lg p {
-      +   .md\\\\:markdown-lg p {
+      -   .md\\\\:prose-lg :where(p) {
+      +   .md\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .md\\\\:prose-lg [class~='lead'] {
-      +   .md\\\\:markdown-lg [class~='lead'] {
+      -   .md\\\\:prose-lg :where([class~='lead']) {
+      +   .md\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-lg blockquote {
-      +   .md\\\\:markdown-lg blockquote {
+      -   .md\\\\:prose-lg :where(blockquote) {
+      +   .md\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-lg h1 {
-      +   .md\\\\:markdown-lg h1 {
+      -   .md\\\\:prose-lg :where(h1) {
+      +   .md\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 {
-      +   .md\\\\:markdown-lg h2 {
+      -   .md\\\\:prose-lg :where(h2) {
+      +   .md\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 {
-      +   .md\\\\:markdown-lg h3 {
+      -   .md\\\\:prose-lg :where(h3) {
+      +   .md\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-lg h4 {
-      +   .md\\\\:markdown-lg h4 {
+      -   .md\\\\:prose-lg :where(h4) {
+      +   .md\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-lg img {
-      +   .md\\\\:markdown-lg img {
+      -   .md\\\\:prose-lg :where(img) {
+      +   .md\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .md\\\\:prose-lg video {
-      +   .md\\\\:markdown-lg video {
+      -   .md\\\\:prose-lg :where(video) {
+      +   .md\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .md\\\\:prose-lg figure {
-      +   .md\\\\:markdown-lg figure {
+      -   .md\\\\:prose-lg :where(figure) {
+      +   .md\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-lg figure > * {
-      +   .md\\\\:markdown-lg figure > * {
+      -   .md\\\\:prose-lg :where(figure > *) {
+      +   .md\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-lg figure figcaption {
-      +   .md\\\\:markdown-lg figure figcaption {
+      -   .md\\\\:prose-lg :where(figure figcaption) {
+      +   .md\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-lg code {
-      +   .md\\\\:markdown-lg code {
+      -   .md\\\\:prose-lg :where(code) {
+      +   .md\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 code {
-      +   .md\\\\:markdown-lg h2 code {
+      -   .md\\\\:prose-lg :where(h2 code) {
+      +   .md\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 code {
-      +   .md\\\\:markdown-lg h3 code {
+      -   .md\\\\:prose-lg :where(h3 code) {
+      +   .md\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-lg pre {
-      +   .md\\\\:markdown-lg pre {
+      -   .md\\\\:prose-lg :where(pre) {
+      +   .md\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-lg ol {
-      +   .md\\\\:markdown-lg ol {
+      -   .md\\\\:prose-lg :where(ol) {
+      +   .md\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-lg ul {
-      +   .md\\\\:markdown-lg ul {
+      -   .md\\\\:prose-lg :where(ul) {
+      +   .md\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-lg li {
-      +   .md\\\\:markdown-lg li {
+      -   .md\\\\:prose-lg :where(li) {
+      +   .md\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .md\\\\:prose-lg ol > li {
-      +   .md\\\\:markdown-lg ol > li {
+      -   .md\\\\:prose-lg :where(ol > li) {
+      +   .md\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-lg ol > li::before {
-      +   .md\\\\:markdown-lg ol > li::before {
+      -   .md\\\\:prose-lg :where(ol > li::before) {
+      +   .md\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-lg ul > li {
-      +   .md\\\\:markdown-lg ul > li {
+      -   .md\\\\:prose-lg :where(ul > li) {
+      +   .md\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-lg ul > li::before {
-      +   .md\\\\:markdown-lg ul > li::before {
+      -   .md\\\\:prose-lg :where(ul > li::before) {
+      +   .md\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li p {
-      +   .md\\\\:markdown-lg > ul > li p {
+      -   .md\\\\:prose-lg :where(> ul > li p) {
+      +   .md\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li > *:first-child {
-      +   .md\\\\:markdown-lg > ul > li > *:first-child {
+      -   .md\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li > *:last-child {
-      +   .md\\\\:markdown-lg > ul > li > *:last-child {
+      -   .md\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ol > li > *:first-child {
-      +   .md\\\\:markdown-lg > ol > li > *:first-child {
+      -   .md\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ol > li > *:last-child {
-      +   .md\\\\:markdown-lg > ol > li > *:last-child {
+      -   .md\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg ul ul, .md\\\\:prose-lg ul ol, .md\\\\:prose-lg ol ul, .md\\\\:prose-lg ol ol {
-      +   .md\\\\:markdown-lg ul ul, .md\\\\:markdown-lg ul ol, .md\\\\:markdown-lg ol ul, .md\\\\:markdown-lg ol ol {
+      -   .md\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-lg hr {
-      +   .md\\\\:markdown-lg hr {
+      -   .md\\\\:prose-lg :where(hr) {
+      +   .md\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-lg hr + * {
-      +   .md\\\\:markdown-lg hr + * {
+      -   .md\\\\:prose-lg :where(hr + *) {
+      +   .md\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 + * {
-      +   .md\\\\:markdown-lg h2 + * {
+      -   .md\\\\:prose-lg :where(h2 + *) {
+      +   .md\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 + * {
-      +   .md\\\\:markdown-lg h3 + * {
+      -   .md\\\\:prose-lg :where(h3 + *) {
+      +   .md\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h4 + * {
-      +   .md\\\\:markdown-lg h4 + * {
+      -   .md\\\\:prose-lg :where(h4 + *) {
+      +   .md\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg table {
-      +   .md\\\\:markdown-lg table {
+      -   .md\\\\:prose-lg :where(table) {
+      +   .md\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th {
-      +   .md\\\\:markdown-lg thead th {
+      -   .md\\\\:prose-lg :where(thead th) {
+      +   .md\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th:first-child {
-      +   .md\\\\:markdown-lg thead th:first-child {
+      -   .md\\\\:prose-lg :where(thead th:first-child) {
+      +   .md\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th:last-child {
-      +   .md\\\\:markdown-lg thead th:last-child {
+      -   .md\\\\:prose-lg :where(thead th:last-child) {
+      +   .md\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td {
-      +   .md\\\\:markdown-lg tbody td {
+      -   .md\\\\:prose-lg :where(tbody td) {
+      +   .md\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td:first-child {
-      +   .md\\\\:markdown-lg tbody td:first-child {
+      -   .md\\\\:prose-lg :where(tbody td:first-child) {
+      +   .md\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td:last-child {
-      +   .md\\\\:markdown-lg tbody td:last-child {
+      -   .md\\\\:prose-lg :where(tbody td:last-child) {
+      +   .md\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > :first-child {
-      +   .md\\\\:markdown-lg > :first-child {
+      -   .md\\\\:prose-lg :where(> :first-child) {
+      +   .md\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > :last-child {
-      +   .md\\\\:markdown-lg > :last-child {
+      -   .md\\\\:prose-lg :where(> :last-child) {
+      +   .md\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -11467,218 +11467,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-xl p {
-      +   .md\\\\:markdown-xl p {
+      -   .md\\\\:prose-xl :where(p) {
+      +   .md\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .md\\\\:prose-xl [class~='lead'] {
-      +   .md\\\\:markdown-xl [class~='lead'] {
+      -   .md\\\\:prose-xl :where([class~='lead']) {
+      +   .md\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-xl blockquote {
-      +   .md\\\\:markdown-xl blockquote {
+      -   .md\\\\:prose-xl :where(blockquote) {
+      +   .md\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-xl h1 {
-      +   .md\\\\:markdown-xl h1 {
+      -   .md\\\\:prose-xl :where(h1) {
+      +   .md\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 {
-      +   .md\\\\:markdown-xl h2 {
+      -   .md\\\\:prose-xl :where(h2) {
+      +   .md\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 {
-      +   .md\\\\:markdown-xl h3 {
+      -   .md\\\\:prose-xl :where(h3) {
+      +   .md\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-xl h4 {
-      +   .md\\\\:markdown-xl h4 {
+      -   .md\\\\:prose-xl :where(h4) {
+      +   .md\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-xl img {
-      +   .md\\\\:markdown-xl img {
+      -   .md\\\\:prose-xl :where(img) {
+      +   .md\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .md\\\\:prose-xl video {
-      +   .md\\\\:markdown-xl video {
+      -   .md\\\\:prose-xl :where(video) {
+      +   .md\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .md\\\\:prose-xl figure {
-      +   .md\\\\:markdown-xl figure {
+      -   .md\\\\:prose-xl :where(figure) {
+      +   .md\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-xl figure > * {
-      +   .md\\\\:markdown-xl figure > * {
+      -   .md\\\\:prose-xl :where(figure > *) {
+      +   .md\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-xl figure figcaption {
-      +   .md\\\\:markdown-xl figure figcaption {
+      -   .md\\\\:prose-xl :where(figure figcaption) {
+      +   .md\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-xl code {
-      +   .md\\\\:markdown-xl code {
+      -   .md\\\\:prose-xl :where(code) {
+      +   .md\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 code {
-      +   .md\\\\:markdown-xl h2 code {
+      -   .md\\\\:prose-xl :where(h2 code) {
+      +   .md\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 code {
-      +   .md\\\\:markdown-xl h3 code {
+      -   .md\\\\:prose-xl :where(h3 code) {
+      +   .md\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-xl pre {
-      +   .md\\\\:markdown-xl pre {
+      -   .md\\\\:prose-xl :where(pre) {
+      +   .md\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-xl ol {
-      +   .md\\\\:markdown-xl ol {
+      -   .md\\\\:prose-xl :where(ol) {
+      +   .md\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-xl ul {
-      +   .md\\\\:markdown-xl ul {
+      -   .md\\\\:prose-xl :where(ul) {
+      +   .md\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-xl li {
-      +   .md\\\\:markdown-xl li {
+      -   .md\\\\:prose-xl :where(li) {
+      +   .md\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .md\\\\:prose-xl ol > li {
-      +   .md\\\\:markdown-xl ol > li {
+      -   .md\\\\:prose-xl :where(ol > li) {
+      +   .md\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-xl ol > li::before {
-      +   .md\\\\:markdown-xl ol > li::before {
+      -   .md\\\\:prose-xl :where(ol > li::before) {
+      +   .md\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-xl ul > li {
-      +   .md\\\\:markdown-xl ul > li {
+      -   .md\\\\:prose-xl :where(ul > li) {
+      +   .md\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-xl ul > li::before {
-      +   .md\\\\:markdown-xl ul > li::before {
+      -   .md\\\\:prose-xl :where(ul > li::before) {
+      +   .md\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li p {
-      +   .md\\\\:markdown-xl > ul > li p {
+      -   .md\\\\:prose-xl :where(> ul > li p) {
+      +   .md\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li > *:first-child {
-      +   .md\\\\:markdown-xl > ul > li > *:first-child {
+      -   .md\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li > *:last-child {
-      +   .md\\\\:markdown-xl > ul > li > *:last-child {
+      -   .md\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ol > li > *:first-child {
-      +   .md\\\\:markdown-xl > ol > li > *:first-child {
+      -   .md\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ol > li > *:last-child {
-      +   .md\\\\:markdown-xl > ol > li > *:last-child {
+      -   .md\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl ul ul, .md\\\\:prose-xl ul ol, .md\\\\:prose-xl ol ul, .md\\\\:prose-xl ol ol {
-      +   .md\\\\:markdown-xl ul ul, .md\\\\:markdown-xl ul ol, .md\\\\:markdown-xl ol ul, .md\\\\:markdown-xl ol ol {
+      -   .md\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-xl hr {
-      +   .md\\\\:markdown-xl hr {
+      -   .md\\\\:prose-xl :where(hr) {
+      +   .md\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-xl hr + * {
-      +   .md\\\\:markdown-xl hr + * {
+      -   .md\\\\:prose-xl :where(hr + *) {
+      +   .md\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 + * {
-      +   .md\\\\:markdown-xl h2 + * {
+      -   .md\\\\:prose-xl :where(h2 + *) {
+      +   .md\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 + * {
-      +   .md\\\\:markdown-xl h3 + * {
+      -   .md\\\\:prose-xl :where(h3 + *) {
+      +   .md\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h4 + * {
-      +   .md\\\\:markdown-xl h4 + * {
+      -   .md\\\\:prose-xl :where(h4 + *) {
+      +   .md\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl table {
-      +   .md\\\\:markdown-xl table {
+      -   .md\\\\:prose-xl :where(table) {
+      +   .md\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th {
-      +   .md\\\\:markdown-xl thead th {
+      -   .md\\\\:prose-xl :where(thead th) {
+      +   .md\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th:first-child {
-      +   .md\\\\:markdown-xl thead th:first-child {
+      -   .md\\\\:prose-xl :where(thead th:first-child) {
+      +   .md\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th:last-child {
-      +   .md\\\\:markdown-xl thead th:last-child {
+      -   .md\\\\:prose-xl :where(thead th:last-child) {
+      +   .md\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td {
-      +   .md\\\\:markdown-xl tbody td {
+      -   .md\\\\:prose-xl :where(tbody td) {
+      +   .md\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td:first-child {
-      +   .md\\\\:markdown-xl tbody td:first-child {
+      -   .md\\\\:prose-xl :where(tbody td:first-child) {
+      +   .md\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td:last-child {
-      +   .md\\\\:markdown-xl tbody td:last-child {
+      -   .md\\\\:prose-xl :where(tbody td:last-child) {
+      +   .md\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > :first-child {
-      +   .md\\\\:markdown-xl > :first-child {
+      -   .md\\\\:prose-xl :where(> :first-child) {
+      +   .md\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > :last-child {
-      +   .md\\\\:markdown-xl > :last-child {
+      -   .md\\\\:prose-xl :where(> :last-child) {
+      +   .md\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -11687,288 +11687,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-2xl p {
-      +   .md\\\\:markdown-2xl p {
+      -   .md\\\\:prose-2xl :where(p) {
+      +   .md\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .md\\\\:prose-2xl [class~='lead'] {
-      +   .md\\\\:markdown-2xl [class~='lead'] {
+      -   .md\\\\:prose-2xl :where([class~='lead']) {
+      +   .md\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-2xl blockquote {
-      +   .md\\\\:markdown-2xl blockquote {
+      -   .md\\\\:prose-2xl :where(blockquote) {
+      +   .md\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-2xl h1 {
-      +   .md\\\\:markdown-2xl h1 {
+      -   .md\\\\:prose-2xl :where(h1) {
+      +   .md\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 {
-      +   .md\\\\:markdown-2xl h2 {
+      -   .md\\\\:prose-2xl :where(h2) {
+      +   .md\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 {
-      +   .md\\\\:markdown-2xl h3 {
+      -   .md\\\\:prose-2xl :where(h3) {
+      +   .md\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-2xl h4 {
-      +   .md\\\\:markdown-2xl h4 {
+      -   .md\\\\:prose-2xl :where(h4) {
+      +   .md\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-2xl img {
-      +   .md\\\\:markdown-2xl img {
+      -   .md\\\\:prose-2xl :where(img) {
+      +   .md\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .md\\\\:prose-2xl video {
-      +   .md\\\\:markdown-2xl video {
+      -   .md\\\\:prose-2xl :where(video) {
+      +   .md\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure {
-      +   .md\\\\:markdown-2xl figure {
+      -   .md\\\\:prose-2xl :where(figure) {
+      +   .md\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure > * {
-      +   .md\\\\:markdown-2xl figure > * {
+      -   .md\\\\:prose-2xl :where(figure > *) {
+      +   .md\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure figcaption {
-      +   .md\\\\:markdown-2xl figure figcaption {
+      -   .md\\\\:prose-2xl :where(figure figcaption) {
+      +   .md\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-2xl code {
-      +   .md\\\\:markdown-2xl code {
+      -   .md\\\\:prose-2xl :where(code) {
+      +   .md\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 code {
-      +   .md\\\\:markdown-2xl h2 code {
+      -   .md\\\\:prose-2xl :where(h2 code) {
+      +   .md\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 code {
-      +   .md\\\\:markdown-2xl h3 code {
+      -   .md\\\\:prose-2xl :where(h3 code) {
+      +   .md\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-2xl pre {
-      +   .md\\\\:markdown-2xl pre {
+      -   .md\\\\:prose-2xl :where(pre) {
+      +   .md\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol {
-      +   .md\\\\:markdown-2xl ol {
+      -   .md\\\\:prose-2xl :where(ol) {
+      +   .md\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul {
-      +   .md\\\\:markdown-2xl ul {
+      -   .md\\\\:prose-2xl :where(ul) {
+      +   .md\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-2xl li {
-      +   .md\\\\:markdown-2xl li {
+      -   .md\\\\:prose-2xl :where(li) {
+      +   .md\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol > li {
-      +   .md\\\\:markdown-2xl ol > li {
+      -   .md\\\\:prose-2xl :where(ol > li) {
+      +   .md\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol > li::before {
-      +   .md\\\\:markdown-2xl ol > li::before {
+      -   .md\\\\:prose-2xl :where(ol > li::before) {
+      +   .md\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul > li {
-      +   .md\\\\:markdown-2xl ul > li {
+      -   .md\\\\:prose-2xl :where(ul > li) {
+      +   .md\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul > li::before {
-      +   .md\\\\:markdown-2xl ul > li::before {
+      -   .md\\\\:prose-2xl :where(ul > li::before) {
+      +   .md\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li p {
-      +   .md\\\\:markdown-2xl > ul > li p {
+      -   .md\\\\:prose-2xl :where(> ul > li p) {
+      +   .md\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li > *:first-child {
-      +   .md\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li > *:last-child {
-      +   .md\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ol > li > *:first-child {
-      +   .md\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ol > li > *:last-child {
-      +   .md\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul ul, .md\\\\:prose-2xl ul ol, .md\\\\:prose-2xl ol ul, .md\\\\:prose-2xl ol ol {
-      +   .md\\\\:markdown-2xl ul ul, .md\\\\:markdown-2xl ul ol, .md\\\\:markdown-2xl ol ul, .md\\\\:markdown-2xl ol ol {
+      -   .md\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-2xl hr {
-      +   .md\\\\:markdown-2xl hr {
+      -   .md\\\\:prose-2xl :where(hr) {
+      +   .md\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-2xl hr + * {
-      +   .md\\\\:markdown-2xl hr + * {
+      -   .md\\\\:prose-2xl :where(hr + *) {
+      +   .md\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 + * {
-      +   .md\\\\:markdown-2xl h2 + * {
+      -   .md\\\\:prose-2xl :where(h2 + *) {
+      +   .md\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 + * {
-      +   .md\\\\:markdown-2xl h3 + * {
+      -   .md\\\\:prose-2xl :where(h3 + *) {
+      +   .md\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h4 + * {
-      +   .md\\\\:markdown-2xl h4 + * {
+      -   .md\\\\:prose-2xl :where(h4 + *) {
+      +   .md\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl table {
-      +   .md\\\\:markdown-2xl table {
+      -   .md\\\\:prose-2xl :where(table) {
+      +   .md\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th {
-      +   .md\\\\:markdown-2xl thead th {
+      -   .md\\\\:prose-2xl :where(thead th) {
+      +   .md\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th:first-child {
-      +   .md\\\\:markdown-2xl thead th:first-child {
+      -   .md\\\\:prose-2xl :where(thead th:first-child) {
+      +   .md\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th:last-child {
-      +   .md\\\\:markdown-2xl thead th:last-child {
+      -   .md\\\\:prose-2xl :where(thead th:last-child) {
+      +   .md\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td {
-      +   .md\\\\:markdown-2xl tbody td {
+      -   .md\\\\:prose-2xl :where(tbody td) {
+      +   .md\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td:first-child {
-      +   .md\\\\:markdown-2xl tbody td:first-child {
+      -   .md\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .md\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td:last-child {
-      +   .md\\\\:markdown-2xl tbody td:last-child {
+      -   .md\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .md\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > :first-child {
-      +   .md\\\\:markdown-2xl > :first-child {
+      -   .md\\\\:prose-2xl :where(> :first-child) {
+      +   .md\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > :last-child {
-      +   .md\\\\:markdown-2xl > :last-child {
+      -   .md\\\\:prose-2xl :where(> :last-child) {
+      +   .md\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
-      -   .md\\\\:prose-red a {
-      +   .md\\\\:markdown-red a {
+      -   .md\\\\:prose-red :where(a) {
+      +   .md\\\\:markdown-red :where(a) {
 
       ---
 
-      -   .md\\\\:prose-red a code {
-      +   .md\\\\:markdown-red a code {
+      -   .md\\\\:prose-red :where(a code) {
+      +   .md\\\\:markdown-red :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-yellow a {
-      +   .md\\\\:markdown-yellow a {
+      -   .md\\\\:prose-yellow :where(a) {
+      +   .md\\\\:markdown-yellow :where(a) {
 
       ---
 
-      -   .md\\\\:prose-yellow a code {
-      +   .md\\\\:markdown-yellow a code {
+      -   .md\\\\:prose-yellow :where(a code) {
+      +   .md\\\\:markdown-yellow :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-green a {
-      +   .md\\\\:markdown-green a {
+      -   .md\\\\:prose-green :where(a) {
+      +   .md\\\\:markdown-green :where(a) {
 
       ---
 
-      -   .md\\\\:prose-green a code {
-      +   .md\\\\:markdown-green a code {
+      -   .md\\\\:prose-green :where(a code) {
+      +   .md\\\\:markdown-green :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-blue a {
-      +   .md\\\\:markdown-blue a {
+      -   .md\\\\:prose-blue :where(a) {
+      +   .md\\\\:markdown-blue :where(a) {
 
       ---
 
-      -   .md\\\\:prose-blue a code {
-      +   .md\\\\:markdown-blue a code {
+      -   .md\\\\:prose-blue :where(a code) {
+      +   .md\\\\:markdown-blue :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-indigo a {
-      +   .md\\\\:markdown-indigo a {
+      -   .md\\\\:prose-indigo :where(a) {
+      +   .md\\\\:markdown-indigo :where(a) {
 
       ---
 
-      -   .md\\\\:prose-indigo a code {
-      +   .md\\\\:markdown-indigo a code {
+      -   .md\\\\:prose-indigo :where(a code) {
+      +   .md\\\\:markdown-indigo :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-purple a {
-      +   .md\\\\:markdown-purple a {
+      -   .md\\\\:prose-purple :where(a) {
+      +   .md\\\\:markdown-purple :where(a) {
 
       ---
 
-      -   .md\\\\:prose-purple a code {
-      +   .md\\\\:markdown-purple a code {
+      -   .md\\\\:prose-purple :where(a code) {
+      +   .md\\\\:markdown-purple :where(a code) {
 
       ---
 
-      -   .md\\\\:prose-pink a {
-      +   .md\\\\:markdown-pink a {
+      -   .md\\\\:prose-pink :where(a) {
+      +   .md\\\\:markdown-pink :where(a) {
 
       ---
 
-      -   .md\\\\:prose-pink a code {
-      +   .md\\\\:markdown-pink a code {
+      -   .md\\\\:prose-pink :where(a code) {
+      +   .md\\\\:markdown-pink :where(a code) {
 
       ---
 
@@ -11977,218 +11977,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose [class~='lead'] {
-      +   .lg\\\\:markdown [class~='lead'] {
+      -   .lg\\\\:prose :where([class~='lead']) {
+      +   .lg\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose a {
-      +   .lg\\\\:markdown a {
+      -   .lg\\\\:prose :where(a) {
+      +   .lg\\\\:markdown :where(a) {
 
       ---
 
-      -   .lg\\\\:prose strong {
-      +   .lg\\\\:markdown strong {
+      -   .lg\\\\:prose :where(strong) {
+      +   .lg\\\\:markdown :where(strong) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='A'] {
-      +   .lg\\\\:markdown ol[type='A'] {
+      -   .lg\\\\:prose :where(ol[type='A']) {
+      +   .lg\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='a'] {
-      +   .lg\\\\:markdown ol[type='a'] {
+      -   .lg\\\\:prose :where(ol[type='a']) {
+      +   .lg\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='A' s] {
-      +   .lg\\\\:markdown ol[type='A' s] {
+      -   .lg\\\\:prose :where(ol[type='A' s]) {
+      +   .lg\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='a' s] {
-      +   .lg\\\\:markdown ol[type='a' s] {
+      -   .lg\\\\:prose :where(ol[type='a' s]) {
+      +   .lg\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='I'] {
-      +   .lg\\\\:markdown ol[type='I'] {
+      -   .lg\\\\:prose :where(ol[type='I']) {
+      +   .lg\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='i'] {
-      +   .lg\\\\:markdown ol[type='i'] {
+      -   .lg\\\\:prose :where(ol[type='i']) {
+      +   .lg\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='I' s] {
-      +   .lg\\\\:markdown ol[type='I' s] {
+      -   .lg\\\\:prose :where(ol[type='I' s]) {
+      +   .lg\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='i' s] {
-      +   .lg\\\\:markdown ol[type='i' s] {
+      -   .lg\\\\:prose :where(ol[type='i' s]) {
+      +   .lg\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='1'] {
-      +   .lg\\\\:markdown ol[type='1'] {
+      -   .lg\\\\:prose :where(ol[type='1']) {
+      +   .lg\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .lg\\\\:prose ol > li {
-      +   .lg\\\\:markdown ol > li {
+      -   .lg\\\\:prose :where(ol > li) {
+      +   .lg\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose ol > li::before {
-      +   .lg\\\\:markdown ol > li::before {
+      -   .lg\\\\:prose :where(ol > li::before) {
+      +   .lg\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose ul > li {
-      +   .lg\\\\:markdown ul > li {
+      -   .lg\\\\:prose :where(ul > li) {
+      +   .lg\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose ul > li::before {
-      +   .lg\\\\:markdown ul > li::before {
+      -   .lg\\\\:prose :where(ul > li::before) {
+      +   .lg\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose hr {
-      +   .lg\\\\:markdown hr {
+      -   .lg\\\\:prose :where(hr) {
+      +   .lg\\\\:markdown :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose blockquote {
-      +   .lg\\\\:markdown blockquote {
+      -   .lg\\\\:prose :where(blockquote) {
+      +   .lg\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose blockquote p:first-of-type::before {
-      +   .lg\\\\:markdown blockquote p:first-of-type::before {
+      -   .lg\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .lg\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .lg\\\\:prose blockquote p:last-of-type::after {
-      +   .lg\\\\:markdown blockquote p:last-of-type::after {
+      -   .lg\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .lg\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .lg\\\\:prose h1 {
-      +   .lg\\\\:markdown h1 {
+      -   .lg\\\\:prose :where(h1) {
+      +   .lg\\\\:markdown :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose h1 strong {
-      +   .lg\\\\:markdown h1 strong {
+      -   .lg\\\\:prose :where(h1 strong) {
+      +   .lg\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .lg\\\\:prose h2 {
-      +   .lg\\\\:markdown h2 {
+      -   .lg\\\\:prose :where(h2) {
+      +   .lg\\\\:markdown :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose h2 strong {
-      +   .lg\\\\:markdown h2 strong {
+      -   .lg\\\\:prose :where(h2 strong) {
+      +   .lg\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .lg\\\\:prose h3 {
-      +   .lg\\\\:markdown h3 {
+      -   .lg\\\\:prose :where(h3) {
+      +   .lg\\\\:markdown :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose h3 strong {
-      +   .lg\\\\:markdown h3 strong {
+      -   .lg\\\\:prose :where(h3 strong) {
+      +   .lg\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .lg\\\\:prose h4 {
-      +   .lg\\\\:markdown h4 {
+      -   .lg\\\\:prose :where(h4) {
+      +   .lg\\\\:markdown :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose h4 strong {
-      +   .lg\\\\:markdown h4 strong {
+      -   .lg\\\\:prose :where(h4 strong) {
+      +   .lg\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .lg\\\\:prose figure figcaption {
-      +   .lg\\\\:markdown figure figcaption {
+      -   .lg\\\\:prose :where(figure figcaption) {
+      +   .lg\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose code {
-      +   .lg\\\\:markdown code {
+      -   .lg\\\\:prose :where(code) {
+      +   .lg\\\\:markdown :where(code) {
 
       ---
 
-      -   .lg\\\\:prose code::before {
-      +   .lg\\\\:markdown code::before {
+      -   .lg\\\\:prose :where(code::before) {
+      +   .lg\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .lg\\\\:prose code::after {
-      +   .lg\\\\:markdown code::after {
+      -   .lg\\\\:prose :where(code::after) {
+      +   .lg\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .lg\\\\:prose a code {
-      +   .lg\\\\:markdown a code {
+      -   .lg\\\\:prose :where(a code) {
+      +   .lg\\\\:markdown :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose pre {
-      +   .lg\\\\:markdown pre {
+      -   .lg\\\\:prose :where(pre) {
+      +   .lg\\\\:markdown :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose pre code {
-      +   .lg\\\\:markdown pre code {
+      -   .lg\\\\:prose :where(pre code) {
+      +   .lg\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .lg\\\\:prose pre code::before {
-      +   .lg\\\\:markdown pre code::before {
+      -   .lg\\\\:prose :where(pre code::before) {
+      +   .lg\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .lg\\\\:prose pre code::after {
-      +   .lg\\\\:markdown pre code::after {
+      -   .lg\\\\:prose :where(pre code::after) {
+      +   .lg\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .lg\\\\:prose table {
-      +   .lg\\\\:markdown table {
+      -   .lg\\\\:prose :where(table) {
+      +   .lg\\\\:markdown :where(table) {
 
       ---
 
-      -   .lg\\\\:prose thead {
-      +   .lg\\\\:markdown thead {
+      -   .lg\\\\:prose :where(thead) {
+      +   .lg\\\\:markdown :where(thead) {
 
       ---
 
-      -   .lg\\\\:prose thead th {
-      +   .lg\\\\:markdown thead th {
+      -   .lg\\\\:prose :where(thead th) {
+      +   .lg\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose tbody tr {
-      +   .lg\\\\:markdown tbody tr {
+      -   .lg\\\\:prose :where(tbody tr) {
+      +   .lg\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .lg\\\\:prose tbody tr:last-child {
-      +   .lg\\\\:markdown tbody tr:last-child {
+      -   .lg\\\\:prose :where(tbody tr:last-child) {
+      +   .lg\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .lg\\\\:prose tbody td {
-      +   .lg\\\\:markdown tbody td {
+      -   .lg\\\\:prose :where(tbody td) {
+      +   .lg\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -12197,133 +12197,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose p {
-      +   .lg\\\\:markdown p {
+      -   .lg\\\\:prose :where(p) {
+      +   .lg\\\\:markdown :where(p) {
 
       ---
 
-      -   .lg\\\\:prose img {
-      +   .lg\\\\:markdown img {
+      -   .lg\\\\:prose :where(img) {
+      +   .lg\\\\:markdown :where(img) {
 
       ---
 
-      -   .lg\\\\:prose video {
-      +   .lg\\\\:markdown video {
+      -   .lg\\\\:prose :where(video) {
+      +   .lg\\\\:markdown :where(video) {
 
       ---
 
-      -   .lg\\\\:prose figure {
-      +   .lg\\\\:markdown figure {
+      -   .lg\\\\:prose :where(figure) {
+      +   .lg\\\\:markdown :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose figure > * {
-      +   .lg\\\\:markdown figure > * {
+      -   .lg\\\\:prose :where(figure > *) {
+      +   .lg\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose h2 code {
-      +   .lg\\\\:markdown h2 code {
+      -   .lg\\\\:prose :where(h2 code) {
+      +   .lg\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose h3 code {
-      +   .lg\\\\:markdown h3 code {
+      -   .lg\\\\:prose :where(h3 code) {
+      +   .lg\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose ol {
-      +   .lg\\\\:markdown ol {
+      -   .lg\\\\:prose :where(ol) {
+      +   .lg\\\\:markdown :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose ul {
-      +   .lg\\\\:markdown ul {
+      -   .lg\\\\:prose :where(ul) {
+      +   .lg\\\\:markdown :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose li {
-      +   .lg\\\\:markdown li {
+      -   .lg\\\\:prose :where(li) {
+      +   .lg\\\\:markdown :where(li) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li p {
-      +   .lg\\\\:markdown > ul > li p {
+      -   .lg\\\\:prose :where(> ul > li p) {
+      +   .lg\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li > *:first-child {
-      +   .lg\\\\:markdown > ul > li > *:first-child {
+      -   .lg\\\\:prose :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li > *:last-child {
-      +   .lg\\\\:markdown > ul > li > *:last-child {
+      -   .lg\\\\:prose :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose > ol > li > *:first-child {
-      +   .lg\\\\:markdown > ol > li > *:first-child {
+      -   .lg\\\\:prose :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose > ol > li > *:last-child {
-      +   .lg\\\\:markdown > ol > li > *:last-child {
+      -   .lg\\\\:prose :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose ul ul, .lg\\\\:prose ul ol, .lg\\\\:prose ol ul, .lg\\\\:prose ol ol {
-      +   .lg\\\\:markdown ul ul, .lg\\\\:markdown ul ol, .lg\\\\:markdown ol ul, .lg\\\\:markdown ol ol {
+      -   .lg\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose hr + * {
-      +   .lg\\\\:markdown hr + * {
+      -   .lg\\\\:prose :where(hr + *) {
+      +   .lg\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose h2 + * {
-      +   .lg\\\\:markdown h2 + * {
+      -   .lg\\\\:prose :where(h2 + *) {
+      +   .lg\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose h3 + * {
-      +   .lg\\\\:markdown h3 + * {
+      -   .lg\\\\:prose :where(h3 + *) {
+      +   .lg\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose h4 + * {
-      +   .lg\\\\:markdown h4 + * {
+      -   .lg\\\\:prose :where(h4 + *) {
+      +   .lg\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose thead th:first-child {
-      +   .lg\\\\:markdown thead th:first-child {
+      -   .lg\\\\:prose :where(thead th:first-child) {
+      +   .lg\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose thead th:last-child {
-      +   .lg\\\\:markdown thead th:last-child {
+      -   .lg\\\\:prose :where(thead th:last-child) {
+      +   .lg\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose tbody td:first-child {
-      +   .lg\\\\:markdown tbody td:first-child {
+      -   .lg\\\\:prose :where(tbody td:first-child) {
+      +   .lg\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose tbody td:last-child {
-      +   .lg\\\\:markdown tbody td:last-child {
+      -   .lg\\\\:prose :where(tbody td:last-child) {
+      +   .lg\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose > :first-child {
-      +   .lg\\\\:markdown > :first-child {
+      -   .lg\\\\:prose :where(> :first-child) {
+      +   .lg\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose > :last-child {
-      +   .lg\\\\:markdown > :last-child {
+      -   .lg\\\\:prose :where(> :last-child) {
+      +   .lg\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -12332,218 +12332,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-sm p {
-      +   .lg\\\\:markdown-sm p {
+      -   .lg\\\\:prose-sm :where(p) {
+      +   .lg\\\\:markdown-sm :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-sm [class~='lead'] {
-      +   .lg\\\\:markdown-sm [class~='lead'] {
+      -   .lg\\\\:prose-sm :where([class~='lead']) {
+      +   .lg\\\\:markdown-sm :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-sm blockquote {
-      +   .lg\\\\:markdown-sm blockquote {
+      -   .lg\\\\:prose-sm :where(blockquote) {
+      +   .lg\\\\:markdown-sm :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-sm h1 {
-      +   .lg\\\\:markdown-sm h1 {
+      -   .lg\\\\:prose-sm :where(h1) {
+      +   .lg\\\\:markdown-sm :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-sm h2 {
-      +   .lg\\\\:markdown-sm h2 {
+      -   .lg\\\\:prose-sm :where(h2) {
+      +   .lg\\\\:markdown-sm :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-sm h3 {
-      +   .lg\\\\:markdown-sm h3 {
+      -   .lg\\\\:prose-sm :where(h3) {
+      +   .lg\\\\:markdown-sm :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-sm h4 {
-      +   .lg\\\\:markdown-sm h4 {
+      -   .lg\\\\:prose-sm :where(h4) {
+      +   .lg\\\\:markdown-sm :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-sm img {
-      +   .lg\\\\:markdown-sm img {
+      -   .lg\\\\:prose-sm :where(img) {
+      +   .lg\\\\:markdown-sm :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-sm video {
-      +   .lg\\\\:markdown-sm video {
+      -   .lg\\\\:prose-sm :where(video) {
+      +   .lg\\\\:markdown-sm :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-sm figure {
-      +   .lg\\\\:markdown-sm figure {
+      -   .lg\\\\:prose-sm :where(figure) {
+      +   .lg\\\\:markdown-sm :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-sm figure > * {
-      +   .lg\\\\:markdown-sm figure > * {
+      -   .lg\\\\:prose-sm :where(figure > *) {
+      +   .lg\\\\:markdown-sm :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-sm figure figcaption {
-      +   .lg\\\\:markdown-sm figure figcaption {
+      -   .lg\\\\:prose-sm :where(figure figcaption) {
+      +   .lg\\\\:markdown-sm :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-sm code {
-      +   .lg\\\\:markdown-sm code {
+      -   .lg\\\\:prose-sm :where(code) {
+      +   .lg\\\\:markdown-sm :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-sm h2 code {
-      +   .lg\\\\:markdown-sm h2 code {
+      -   .lg\\\\:prose-sm :where(h2 code) {
+      +   .lg\\\\:markdown-sm :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-sm h3 code {
-      +   .lg\\\\:markdown-sm h3 code {
+      -   .lg\\\\:prose-sm :where(h3 code) {
+      +   .lg\\\\:markdown-sm :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-sm pre {
-      +   .lg\\\\:markdown-sm pre {
+      -   .lg\\\\:prose-sm :where(pre) {
+      +   .lg\\\\:markdown-sm :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-sm ol {
-      +   .lg\\\\:markdown-sm ol {
+      -   .lg\\\\:prose-sm :where(ol) {
+      +   .lg\\\\:markdown-sm :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-sm ul {
-      +   .lg\\\\:markdown-sm ul {
+      -   .lg\\\\:prose-sm :where(ul) {
+      +   .lg\\\\:markdown-sm :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-sm li {
-      +   .lg\\\\:markdown-sm li {
+      -   .lg\\\\:prose-sm :where(li) {
+      +   .lg\\\\:markdown-sm :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-sm ol > li {
-      +   .lg\\\\:markdown-sm ol > li {
+      -   .lg\\\\:prose-sm :where(ol > li) {
+      +   .lg\\\\:markdown-sm :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-sm ol > li::before {
-      +   .lg\\\\:markdown-sm ol > li::before {
+      -   .lg\\\\:prose-sm :where(ol > li::before) {
+      +   .lg\\\\:markdown-sm :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-sm ul > li {
-      +   .lg\\\\:markdown-sm ul > li {
+      -   .lg\\\\:prose-sm :where(ul > li) {
+      +   .lg\\\\:markdown-sm :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-sm ul > li::before {
-      +   .lg\\\\:markdown-sm ul > li::before {
+      -   .lg\\\\:prose-sm :where(ul > li::before) {
+      +   .lg\\\\:markdown-sm :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-sm > ul > li p {
-      +   .lg\\\\:markdown-sm > ul > li p {
+      -   .lg\\\\:prose-sm :where(> ul > li p) {
+      +   .lg\\\\:markdown-sm :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-sm > ul > li > *:first-child {
-      +   .lg\\\\:markdown-sm > ul > li > *:first-child {
+      -   .lg\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > ul > li > *:last-child {
-      +   .lg\\\\:markdown-sm > ul > li > *:last-child {
+      -   .lg\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > ol > li > *:first-child {
-      +   .lg\\\\:markdown-sm > ol > li > *:first-child {
+      -   .lg\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > ol > li > *:last-child {
-      +   .lg\\\\:markdown-sm > ol > li > *:last-child {
+      -   .lg\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm ul ul, .lg\\\\:prose-sm ul ol, .lg\\\\:prose-sm ol ul, .lg\\\\:prose-sm ol ol {
-      +   .lg\\\\:markdown-sm ul ul, .lg\\\\:markdown-sm ul ol, .lg\\\\:markdown-sm ol ul, .lg\\\\:markdown-sm ol ol {
+      -   .lg\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-sm hr {
-      +   .lg\\\\:markdown-sm hr {
+      -   .lg\\\\:prose-sm :where(hr) {
+      +   .lg\\\\:markdown-sm :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-sm hr + * {
-      +   .lg\\\\:markdown-sm hr + * {
+      -   .lg\\\\:prose-sm :where(hr + *) {
+      +   .lg\\\\:markdown-sm :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h2 + * {
-      +   .lg\\\\:markdown-sm h2 + * {
+      -   .lg\\\\:prose-sm :where(h2 + *) {
+      +   .lg\\\\:markdown-sm :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h3 + * {
-      +   .lg\\\\:markdown-sm h3 + * {
+      -   .lg\\\\:prose-sm :where(h3 + *) {
+      +   .lg\\\\:markdown-sm :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h4 + * {
-      +   .lg\\\\:markdown-sm h4 + * {
+      -   .lg\\\\:prose-sm :where(h4 + *) {
+      +   .lg\\\\:markdown-sm :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm table {
-      +   .lg\\\\:markdown-sm table {
+      -   .lg\\\\:prose-sm :where(table) {
+      +   .lg\\\\:markdown-sm :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-sm thead th {
-      +   .lg\\\\:markdown-sm thead th {
+      -   .lg\\\\:prose-sm :where(thead th) {
+      +   .lg\\\\:markdown-sm :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-sm thead th:first-child {
-      +   .lg\\\\:markdown-sm thead th:first-child {
+      -   .lg\\\\:prose-sm :where(thead th:first-child) {
+      +   .lg\\\\:markdown-sm :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm thead th:last-child {
-      +   .lg\\\\:markdown-sm thead th:last-child {
+      -   .lg\\\\:prose-sm :where(thead th:last-child) {
+      +   .lg\\\\:markdown-sm :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm tbody td {
-      +   .lg\\\\:markdown-sm tbody td {
+      -   .lg\\\\:prose-sm :where(tbody td) {
+      +   .lg\\\\:markdown-sm :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-sm tbody td:first-child {
-      +   .lg\\\\:markdown-sm tbody td:first-child {
+      -   .lg\\\\:prose-sm :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm tbody td:last-child {
-      +   .lg\\\\:markdown-sm tbody td:last-child {
+      -   .lg\\\\:prose-sm :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > :first-child {
-      +   .lg\\\\:markdown-sm > :first-child {
+      -   .lg\\\\:prose-sm :where(> :first-child) {
+      +   .lg\\\\:markdown-sm :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > :last-child {
-      +   .lg\\\\:markdown-sm > :last-child {
+      -   .lg\\\\:prose-sm :where(> :last-child) {
+      +   .lg\\\\:markdown-sm :where(> :last-child) {
 
       ---
 
@@ -12552,218 +12552,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-lg p {
-      +   .lg\\\\:markdown-lg p {
+      -   .lg\\\\:prose-lg :where(p) {
+      +   .lg\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-lg [class~='lead'] {
-      +   .lg\\\\:markdown-lg [class~='lead'] {
+      -   .lg\\\\:prose-lg :where([class~='lead']) {
+      +   .lg\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-lg blockquote {
-      +   .lg\\\\:markdown-lg blockquote {
+      -   .lg\\\\:prose-lg :where(blockquote) {
+      +   .lg\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-lg h1 {
-      +   .lg\\\\:markdown-lg h1 {
+      -   .lg\\\\:prose-lg :where(h1) {
+      +   .lg\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 {
-      +   .lg\\\\:markdown-lg h2 {
+      -   .lg\\\\:prose-lg :where(h2) {
+      +   .lg\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 {
-      +   .lg\\\\:markdown-lg h3 {
+      -   .lg\\\\:prose-lg :where(h3) {
+      +   .lg\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-lg h4 {
-      +   .lg\\\\:markdown-lg h4 {
+      -   .lg\\\\:prose-lg :where(h4) {
+      +   .lg\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-lg img {
-      +   .lg\\\\:markdown-lg img {
+      -   .lg\\\\:prose-lg :where(img) {
+      +   .lg\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-lg video {
-      +   .lg\\\\:markdown-lg video {
+      -   .lg\\\\:prose-lg :where(video) {
+      +   .lg\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure {
-      +   .lg\\\\:markdown-lg figure {
+      -   .lg\\\\:prose-lg :where(figure) {
+      +   .lg\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure > * {
-      +   .lg\\\\:markdown-lg figure > * {
+      -   .lg\\\\:prose-lg :where(figure > *) {
+      +   .lg\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure figcaption {
-      +   .lg\\\\:markdown-lg figure figcaption {
+      -   .lg\\\\:prose-lg :where(figure figcaption) {
+      +   .lg\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-lg code {
-      +   .lg\\\\:markdown-lg code {
+      -   .lg\\\\:prose-lg :where(code) {
+      +   .lg\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 code {
-      +   .lg\\\\:markdown-lg h2 code {
+      -   .lg\\\\:prose-lg :where(h2 code) {
+      +   .lg\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 code {
-      +   .lg\\\\:markdown-lg h3 code {
+      -   .lg\\\\:prose-lg :where(h3 code) {
+      +   .lg\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-lg pre {
-      +   .lg\\\\:markdown-lg pre {
+      -   .lg\\\\:prose-lg :where(pre) {
+      +   .lg\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol {
-      +   .lg\\\\:markdown-lg ol {
+      -   .lg\\\\:prose-lg :where(ol) {
+      +   .lg\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul {
-      +   .lg\\\\:markdown-lg ul {
+      -   .lg\\\\:prose-lg :where(ul) {
+      +   .lg\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-lg li {
-      +   .lg\\\\:markdown-lg li {
+      -   .lg\\\\:prose-lg :where(li) {
+      +   .lg\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol > li {
-      +   .lg\\\\:markdown-lg ol > li {
+      -   .lg\\\\:prose-lg :where(ol > li) {
+      +   .lg\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol > li::before {
-      +   .lg\\\\:markdown-lg ol > li::before {
+      -   .lg\\\\:prose-lg :where(ol > li::before) {
+      +   .lg\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul > li {
-      +   .lg\\\\:markdown-lg ul > li {
+      -   .lg\\\\:prose-lg :where(ul > li) {
+      +   .lg\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul > li::before {
-      +   .lg\\\\:markdown-lg ul > li::before {
+      -   .lg\\\\:prose-lg :where(ul > li::before) {
+      +   .lg\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li p {
-      +   .lg\\\\:markdown-lg > ul > li p {
+      -   .lg\\\\:prose-lg :where(> ul > li p) {
+      +   .lg\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li > *:first-child {
-      +   .lg\\\\:markdown-lg > ul > li > *:first-child {
+      -   .lg\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li > *:last-child {
-      +   .lg\\\\:markdown-lg > ul > li > *:last-child {
+      -   .lg\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ol > li > *:first-child {
-      +   .lg\\\\:markdown-lg > ol > li > *:first-child {
+      -   .lg\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ol > li > *:last-child {
-      +   .lg\\\\:markdown-lg > ol > li > *:last-child {
+      -   .lg\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul ul, .lg\\\\:prose-lg ul ol, .lg\\\\:prose-lg ol ul, .lg\\\\:prose-lg ol ol {
-      +   .lg\\\\:markdown-lg ul ul, .lg\\\\:markdown-lg ul ol, .lg\\\\:markdown-lg ol ul, .lg\\\\:markdown-lg ol ol {
+      -   .lg\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-lg hr {
-      +   .lg\\\\:markdown-lg hr {
+      -   .lg\\\\:prose-lg :where(hr) {
+      +   .lg\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-lg hr + * {
-      +   .lg\\\\:markdown-lg hr + * {
+      -   .lg\\\\:prose-lg :where(hr + *) {
+      +   .lg\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 + * {
-      +   .lg\\\\:markdown-lg h2 + * {
+      -   .lg\\\\:prose-lg :where(h2 + *) {
+      +   .lg\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 + * {
-      +   .lg\\\\:markdown-lg h3 + * {
+      -   .lg\\\\:prose-lg :where(h3 + *) {
+      +   .lg\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h4 + * {
-      +   .lg\\\\:markdown-lg h4 + * {
+      -   .lg\\\\:prose-lg :where(h4 + *) {
+      +   .lg\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg table {
-      +   .lg\\\\:markdown-lg table {
+      -   .lg\\\\:prose-lg :where(table) {
+      +   .lg\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th {
-      +   .lg\\\\:markdown-lg thead th {
+      -   .lg\\\\:prose-lg :where(thead th) {
+      +   .lg\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th:first-child {
-      +   .lg\\\\:markdown-lg thead th:first-child {
+      -   .lg\\\\:prose-lg :where(thead th:first-child) {
+      +   .lg\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th:last-child {
-      +   .lg\\\\:markdown-lg thead th:last-child {
+      -   .lg\\\\:prose-lg :where(thead th:last-child) {
+      +   .lg\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td {
-      +   .lg\\\\:markdown-lg tbody td {
+      -   .lg\\\\:prose-lg :where(tbody td) {
+      +   .lg\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td:first-child {
-      +   .lg\\\\:markdown-lg tbody td:first-child {
+      -   .lg\\\\:prose-lg :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td:last-child {
-      +   .lg\\\\:markdown-lg tbody td:last-child {
+      -   .lg\\\\:prose-lg :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > :first-child {
-      +   .lg\\\\:markdown-lg > :first-child {
+      -   .lg\\\\:prose-lg :where(> :first-child) {
+      +   .lg\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > :last-child {
-      +   .lg\\\\:markdown-lg > :last-child {
+      -   .lg\\\\:prose-lg :where(> :last-child) {
+      +   .lg\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -12772,218 +12772,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-xl p {
-      +   .lg\\\\:markdown-xl p {
+      -   .lg\\\\:prose-xl :where(p) {
+      +   .lg\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-xl [class~='lead'] {
-      +   .lg\\\\:markdown-xl [class~='lead'] {
+      -   .lg\\\\:prose-xl :where([class~='lead']) {
+      +   .lg\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-xl blockquote {
-      +   .lg\\\\:markdown-xl blockquote {
+      -   .lg\\\\:prose-xl :where(blockquote) {
+      +   .lg\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-xl h1 {
-      +   .lg\\\\:markdown-xl h1 {
+      -   .lg\\\\:prose-xl :where(h1) {
+      +   .lg\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 {
-      +   .lg\\\\:markdown-xl h2 {
+      -   .lg\\\\:prose-xl :where(h2) {
+      +   .lg\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 {
-      +   .lg\\\\:markdown-xl h3 {
+      -   .lg\\\\:prose-xl :where(h3) {
+      +   .lg\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-xl h4 {
-      +   .lg\\\\:markdown-xl h4 {
+      -   .lg\\\\:prose-xl :where(h4) {
+      +   .lg\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-xl img {
-      +   .lg\\\\:markdown-xl img {
+      -   .lg\\\\:prose-xl :where(img) {
+      +   .lg\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-xl video {
-      +   .lg\\\\:markdown-xl video {
+      -   .lg\\\\:prose-xl :where(video) {
+      +   .lg\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure {
-      +   .lg\\\\:markdown-xl figure {
+      -   .lg\\\\:prose-xl :where(figure) {
+      +   .lg\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure > * {
-      +   .lg\\\\:markdown-xl figure > * {
+      -   .lg\\\\:prose-xl :where(figure > *) {
+      +   .lg\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure figcaption {
-      +   .lg\\\\:markdown-xl figure figcaption {
+      -   .lg\\\\:prose-xl :where(figure figcaption) {
+      +   .lg\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-xl code {
-      +   .lg\\\\:markdown-xl code {
+      -   .lg\\\\:prose-xl :where(code) {
+      +   .lg\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 code {
-      +   .lg\\\\:markdown-xl h2 code {
+      -   .lg\\\\:prose-xl :where(h2 code) {
+      +   .lg\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 code {
-      +   .lg\\\\:markdown-xl h3 code {
+      -   .lg\\\\:prose-xl :where(h3 code) {
+      +   .lg\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-xl pre {
-      +   .lg\\\\:markdown-xl pre {
+      -   .lg\\\\:prose-xl :where(pre) {
+      +   .lg\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol {
-      +   .lg\\\\:markdown-xl ol {
+      -   .lg\\\\:prose-xl :where(ol) {
+      +   .lg\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul {
-      +   .lg\\\\:markdown-xl ul {
+      -   .lg\\\\:prose-xl :where(ul) {
+      +   .lg\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-xl li {
-      +   .lg\\\\:markdown-xl li {
+      -   .lg\\\\:prose-xl :where(li) {
+      +   .lg\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol > li {
-      +   .lg\\\\:markdown-xl ol > li {
+      -   .lg\\\\:prose-xl :where(ol > li) {
+      +   .lg\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol > li::before {
-      +   .lg\\\\:markdown-xl ol > li::before {
+      -   .lg\\\\:prose-xl :where(ol > li::before) {
+      +   .lg\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul > li {
-      +   .lg\\\\:markdown-xl ul > li {
+      -   .lg\\\\:prose-xl :where(ul > li) {
+      +   .lg\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul > li::before {
-      +   .lg\\\\:markdown-xl ul > li::before {
+      -   .lg\\\\:prose-xl :where(ul > li::before) {
+      +   .lg\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li p {
-      +   .lg\\\\:markdown-xl > ul > li p {
+      -   .lg\\\\:prose-xl :where(> ul > li p) {
+      +   .lg\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li > *:first-child {
-      +   .lg\\\\:markdown-xl > ul > li > *:first-child {
+      -   .lg\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li > *:last-child {
-      +   .lg\\\\:markdown-xl > ul > li > *:last-child {
+      -   .lg\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ol > li > *:first-child {
-      +   .lg\\\\:markdown-xl > ol > li > *:first-child {
+      -   .lg\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ol > li > *:last-child {
-      +   .lg\\\\:markdown-xl > ol > li > *:last-child {
+      -   .lg\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul ul, .lg\\\\:prose-xl ul ol, .lg\\\\:prose-xl ol ul, .lg\\\\:prose-xl ol ol {
-      +   .lg\\\\:markdown-xl ul ul, .lg\\\\:markdown-xl ul ol, .lg\\\\:markdown-xl ol ul, .lg\\\\:markdown-xl ol ol {
+      -   .lg\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-xl hr {
-      +   .lg\\\\:markdown-xl hr {
+      -   .lg\\\\:prose-xl :where(hr) {
+      +   .lg\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-xl hr + * {
-      +   .lg\\\\:markdown-xl hr + * {
+      -   .lg\\\\:prose-xl :where(hr + *) {
+      +   .lg\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 + * {
-      +   .lg\\\\:markdown-xl h2 + * {
+      -   .lg\\\\:prose-xl :where(h2 + *) {
+      +   .lg\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 + * {
-      +   .lg\\\\:markdown-xl h3 + * {
+      -   .lg\\\\:prose-xl :where(h3 + *) {
+      +   .lg\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h4 + * {
-      +   .lg\\\\:markdown-xl h4 + * {
+      -   .lg\\\\:prose-xl :where(h4 + *) {
+      +   .lg\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl table {
-      +   .lg\\\\:markdown-xl table {
+      -   .lg\\\\:prose-xl :where(table) {
+      +   .lg\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th {
-      +   .lg\\\\:markdown-xl thead th {
+      -   .lg\\\\:prose-xl :where(thead th) {
+      +   .lg\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th:first-child {
-      +   .lg\\\\:markdown-xl thead th:first-child {
+      -   .lg\\\\:prose-xl :where(thead th:first-child) {
+      +   .lg\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th:last-child {
-      +   .lg\\\\:markdown-xl thead th:last-child {
+      -   .lg\\\\:prose-xl :where(thead th:last-child) {
+      +   .lg\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td {
-      +   .lg\\\\:markdown-xl tbody td {
+      -   .lg\\\\:prose-xl :where(tbody td) {
+      +   .lg\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td:first-child {
-      +   .lg\\\\:markdown-xl tbody td:first-child {
+      -   .lg\\\\:prose-xl :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td:last-child {
-      +   .lg\\\\:markdown-xl tbody td:last-child {
+      -   .lg\\\\:prose-xl :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > :first-child {
-      +   .lg\\\\:markdown-xl > :first-child {
+      -   .lg\\\\:prose-xl :where(> :first-child) {
+      +   .lg\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > :last-child {
-      +   .lg\\\\:markdown-xl > :last-child {
+      -   .lg\\\\:prose-xl :where(> :last-child) {
+      +   .lg\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -12992,288 +12992,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-2xl p {
-      +   .lg\\\\:markdown-2xl p {
+      -   .lg\\\\:prose-2xl :where(p) {
+      +   .lg\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-2xl [class~='lead'] {
-      +   .lg\\\\:markdown-2xl [class~='lead'] {
+      -   .lg\\\\:prose-2xl :where([class~='lead']) {
+      +   .lg\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-2xl blockquote {
-      +   .lg\\\\:markdown-2xl blockquote {
+      -   .lg\\\\:prose-2xl :where(blockquote) {
+      +   .lg\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h1 {
-      +   .lg\\\\:markdown-2xl h1 {
+      -   .lg\\\\:prose-2xl :where(h1) {
+      +   .lg\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 {
-      +   .lg\\\\:markdown-2xl h2 {
+      -   .lg\\\\:prose-2xl :where(h2) {
+      +   .lg\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 {
-      +   .lg\\\\:markdown-2xl h3 {
+      -   .lg\\\\:prose-2xl :where(h3) {
+      +   .lg\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h4 {
-      +   .lg\\\\:markdown-2xl h4 {
+      -   .lg\\\\:prose-2xl :where(h4) {
+      +   .lg\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-2xl img {
-      +   .lg\\\\:markdown-2xl img {
+      -   .lg\\\\:prose-2xl :where(img) {
+      +   .lg\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-2xl video {
-      +   .lg\\\\:markdown-2xl video {
+      -   .lg\\\\:prose-2xl :where(video) {
+      +   .lg\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure {
-      +   .lg\\\\:markdown-2xl figure {
+      -   .lg\\\\:prose-2xl :where(figure) {
+      +   .lg\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure > * {
-      +   .lg\\\\:markdown-2xl figure > * {
+      -   .lg\\\\:prose-2xl :where(figure > *) {
+      +   .lg\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure figcaption {
-      +   .lg\\\\:markdown-2xl figure figcaption {
+      -   .lg\\\\:prose-2xl :where(figure figcaption) {
+      +   .lg\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-2xl code {
-      +   .lg\\\\:markdown-2xl code {
+      -   .lg\\\\:prose-2xl :where(code) {
+      +   .lg\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 code {
-      +   .lg\\\\:markdown-2xl h2 code {
+      -   .lg\\\\:prose-2xl :where(h2 code) {
+      +   .lg\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 code {
-      +   .lg\\\\:markdown-2xl h3 code {
+      -   .lg\\\\:prose-2xl :where(h3 code) {
+      +   .lg\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl pre {
-      +   .lg\\\\:markdown-2xl pre {
+      -   .lg\\\\:prose-2xl :where(pre) {
+      +   .lg\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol {
-      +   .lg\\\\:markdown-2xl ol {
+      -   .lg\\\\:prose-2xl :where(ol) {
+      +   .lg\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul {
-      +   .lg\\\\:markdown-2xl ul {
+      -   .lg\\\\:prose-2xl :where(ul) {
+      +   .lg\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-2xl li {
-      +   .lg\\\\:markdown-2xl li {
+      -   .lg\\\\:prose-2xl :where(li) {
+      +   .lg\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol > li {
-      +   .lg\\\\:markdown-2xl ol > li {
+      -   .lg\\\\:prose-2xl :where(ol > li) {
+      +   .lg\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol > li::before {
-      +   .lg\\\\:markdown-2xl ol > li::before {
+      -   .lg\\\\:prose-2xl :where(ol > li::before) {
+      +   .lg\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul > li {
-      +   .lg\\\\:markdown-2xl ul > li {
+      -   .lg\\\\:prose-2xl :where(ul > li) {
+      +   .lg\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul > li::before {
-      +   .lg\\\\:markdown-2xl ul > li::before {
+      -   .lg\\\\:prose-2xl :where(ul > li::before) {
+      +   .lg\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li p {
-      +   .lg\\\\:markdown-2xl > ul > li p {
+      -   .lg\\\\:prose-2xl :where(> ul > li p) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li > *:first-child {
-      +   .lg\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li > *:last-child {
-      +   .lg\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ol > li > *:first-child {
-      +   .lg\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ol > li > *:last-child {
-      +   .lg\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul ul, .lg\\\\:prose-2xl ul ol, .lg\\\\:prose-2xl ol ul, .lg\\\\:prose-2xl ol ol {
-      +   .lg\\\\:markdown-2xl ul ul, .lg\\\\:markdown-2xl ul ol, .lg\\\\:markdown-2xl ol ul, .lg\\\\:markdown-2xl ol ol {
+      -   .lg\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-2xl hr {
-      +   .lg\\\\:markdown-2xl hr {
+      -   .lg\\\\:prose-2xl :where(hr) {
+      +   .lg\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-2xl hr + * {
-      +   .lg\\\\:markdown-2xl hr + * {
+      -   .lg\\\\:prose-2xl :where(hr + *) {
+      +   .lg\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 + * {
-      +   .lg\\\\:markdown-2xl h2 + * {
+      -   .lg\\\\:prose-2xl :where(h2 + *) {
+      +   .lg\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 + * {
-      +   .lg\\\\:markdown-2xl h3 + * {
+      -   .lg\\\\:prose-2xl :where(h3 + *) {
+      +   .lg\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h4 + * {
-      +   .lg\\\\:markdown-2xl h4 + * {
+      -   .lg\\\\:prose-2xl :where(h4 + *) {
+      +   .lg\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl table {
-      +   .lg\\\\:markdown-2xl table {
+      -   .lg\\\\:prose-2xl :where(table) {
+      +   .lg\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th {
-      +   .lg\\\\:markdown-2xl thead th {
+      -   .lg\\\\:prose-2xl :where(thead th) {
+      +   .lg\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th:first-child {
-      +   .lg\\\\:markdown-2xl thead th:first-child {
+      -   .lg\\\\:prose-2xl :where(thead th:first-child) {
+      +   .lg\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th:last-child {
-      +   .lg\\\\:markdown-2xl thead th:last-child {
+      -   .lg\\\\:prose-2xl :where(thead th:last-child) {
+      +   .lg\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td {
-      +   .lg\\\\:markdown-2xl tbody td {
+      -   .lg\\\\:prose-2xl :where(tbody td) {
+      +   .lg\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td:first-child {
-      +   .lg\\\\:markdown-2xl tbody td:first-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td:last-child {
-      +   .lg\\\\:markdown-2xl tbody td:last-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > :first-child {
-      +   .lg\\\\:markdown-2xl > :first-child {
+      -   .lg\\\\:prose-2xl :where(> :first-child) {
+      +   .lg\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > :last-child {
-      +   .lg\\\\:markdown-2xl > :last-child {
+      -   .lg\\\\:prose-2xl :where(> :last-child) {
+      +   .lg\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
-      -   .lg\\\\:prose-red a {
-      +   .lg\\\\:markdown-red a {
+      -   .lg\\\\:prose-red :where(a) {
+      +   .lg\\\\:markdown-red :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-red a code {
-      +   .lg\\\\:markdown-red a code {
+      -   .lg\\\\:prose-red :where(a code) {
+      +   .lg\\\\:markdown-red :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-yellow a {
-      +   .lg\\\\:markdown-yellow a {
+      -   .lg\\\\:prose-yellow :where(a) {
+      +   .lg\\\\:markdown-yellow :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-yellow a code {
-      +   .lg\\\\:markdown-yellow a code {
+      -   .lg\\\\:prose-yellow :where(a code) {
+      +   .lg\\\\:markdown-yellow :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-green a {
-      +   .lg\\\\:markdown-green a {
+      -   .lg\\\\:prose-green :where(a) {
+      +   .lg\\\\:markdown-green :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-green a code {
-      +   .lg\\\\:markdown-green a code {
+      -   .lg\\\\:prose-green :where(a code) {
+      +   .lg\\\\:markdown-green :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-blue a {
-      +   .lg\\\\:markdown-blue a {
+      -   .lg\\\\:prose-blue :where(a) {
+      +   .lg\\\\:markdown-blue :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-blue a code {
-      +   .lg\\\\:markdown-blue a code {
+      -   .lg\\\\:prose-blue :where(a code) {
+      +   .lg\\\\:markdown-blue :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-indigo a {
-      +   .lg\\\\:markdown-indigo a {
+      -   .lg\\\\:prose-indigo :where(a) {
+      +   .lg\\\\:markdown-indigo :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-indigo a code {
-      +   .lg\\\\:markdown-indigo a code {
+      -   .lg\\\\:prose-indigo :where(a code) {
+      +   .lg\\\\:markdown-indigo :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-purple a {
-      +   .lg\\\\:markdown-purple a {
+      -   .lg\\\\:prose-purple :where(a) {
+      +   .lg\\\\:markdown-purple :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-purple a code {
-      +   .lg\\\\:markdown-purple a code {
+      -   .lg\\\\:prose-purple :where(a code) {
+      +   .lg\\\\:markdown-purple :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose-pink a {
-      +   .lg\\\\:markdown-pink a {
+      -   .lg\\\\:prose-pink :where(a) {
+      +   .lg\\\\:markdown-pink :where(a) {
 
       ---
 
-      -   .lg\\\\:prose-pink a code {
-      +   .lg\\\\:markdown-pink a code {
+      -   .lg\\\\:prose-pink :where(a code) {
+      +   .lg\\\\:markdown-pink :where(a code) {
 
       ---
 
@@ -13282,218 +13282,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose [class~='lead'] {
-      +   .xl\\\\:markdown [class~='lead'] {
+      -   .xl\\\\:prose :where([class~='lead']) {
+      +   .xl\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose a {
-      +   .xl\\\\:markdown a {
+      -   .xl\\\\:prose :where(a) {
+      +   .xl\\\\:markdown :where(a) {
 
       ---
 
-      -   .xl\\\\:prose strong {
-      +   .xl\\\\:markdown strong {
+      -   .xl\\\\:prose :where(strong) {
+      +   .xl\\\\:markdown :where(strong) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='A'] {
-      +   .xl\\\\:markdown ol[type='A'] {
+      -   .xl\\\\:prose :where(ol[type='A']) {
+      +   .xl\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='a'] {
-      +   .xl\\\\:markdown ol[type='a'] {
+      -   .xl\\\\:prose :where(ol[type='a']) {
+      +   .xl\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='A' s] {
-      +   .xl\\\\:markdown ol[type='A' s] {
+      -   .xl\\\\:prose :where(ol[type='A' s]) {
+      +   .xl\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='a' s] {
-      +   .xl\\\\:markdown ol[type='a' s] {
+      -   .xl\\\\:prose :where(ol[type='a' s]) {
+      +   .xl\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='I'] {
-      +   .xl\\\\:markdown ol[type='I'] {
+      -   .xl\\\\:prose :where(ol[type='I']) {
+      +   .xl\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='i'] {
-      +   .xl\\\\:markdown ol[type='i'] {
+      -   .xl\\\\:prose :where(ol[type='i']) {
+      +   .xl\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='I' s] {
-      +   .xl\\\\:markdown ol[type='I' s] {
+      -   .xl\\\\:prose :where(ol[type='I' s]) {
+      +   .xl\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='i' s] {
-      +   .xl\\\\:markdown ol[type='i' s] {
+      -   .xl\\\\:prose :where(ol[type='i' s]) {
+      +   .xl\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='1'] {
-      +   .xl\\\\:markdown ol[type='1'] {
+      -   .xl\\\\:prose :where(ol[type='1']) {
+      +   .xl\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .xl\\\\:prose ol > li {
-      +   .xl\\\\:markdown ol > li {
+      -   .xl\\\\:prose :where(ol > li) {
+      +   .xl\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose ol > li::before {
-      +   .xl\\\\:markdown ol > li::before {
+      -   .xl\\\\:prose :where(ol > li::before) {
+      +   .xl\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose ul > li {
-      +   .xl\\\\:markdown ul > li {
+      -   .xl\\\\:prose :where(ul > li) {
+      +   .xl\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose ul > li::before {
-      +   .xl\\\\:markdown ul > li::before {
+      -   .xl\\\\:prose :where(ul > li::before) {
+      +   .xl\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose hr {
-      +   .xl\\\\:markdown hr {
+      -   .xl\\\\:prose :where(hr) {
+      +   .xl\\\\:markdown :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose blockquote {
-      +   .xl\\\\:markdown blockquote {
+      -   .xl\\\\:prose :where(blockquote) {
+      +   .xl\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose blockquote p:first-of-type::before {
-      +   .xl\\\\:markdown blockquote p:first-of-type::before {
+      -   .xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .xl\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .xl\\\\:prose blockquote p:last-of-type::after {
-      +   .xl\\\\:markdown blockquote p:last-of-type::after {
+      -   .xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .xl\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .xl\\\\:prose h1 {
-      +   .xl\\\\:markdown h1 {
+      -   .xl\\\\:prose :where(h1) {
+      +   .xl\\\\:markdown :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose h1 strong {
-      +   .xl\\\\:markdown h1 strong {
+      -   .xl\\\\:prose :where(h1 strong) {
+      +   .xl\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .xl\\\\:prose h2 {
-      +   .xl\\\\:markdown h2 {
+      -   .xl\\\\:prose :where(h2) {
+      +   .xl\\\\:markdown :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose h2 strong {
-      +   .xl\\\\:markdown h2 strong {
+      -   .xl\\\\:prose :where(h2 strong) {
+      +   .xl\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .xl\\\\:prose h3 {
-      +   .xl\\\\:markdown h3 {
+      -   .xl\\\\:prose :where(h3) {
+      +   .xl\\\\:markdown :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose h3 strong {
-      +   .xl\\\\:markdown h3 strong {
+      -   .xl\\\\:prose :where(h3 strong) {
+      +   .xl\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .xl\\\\:prose h4 {
-      +   .xl\\\\:markdown h4 {
+      -   .xl\\\\:prose :where(h4) {
+      +   .xl\\\\:markdown :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose h4 strong {
-      +   .xl\\\\:markdown h4 strong {
+      -   .xl\\\\:prose :where(h4 strong) {
+      +   .xl\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .xl\\\\:prose figure figcaption {
-      +   .xl\\\\:markdown figure figcaption {
+      -   .xl\\\\:prose :where(figure figcaption) {
+      +   .xl\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose code {
-      +   .xl\\\\:markdown code {
+      -   .xl\\\\:prose :where(code) {
+      +   .xl\\\\:markdown :where(code) {
 
       ---
 
-      -   .xl\\\\:prose code::before {
-      +   .xl\\\\:markdown code::before {
+      -   .xl\\\\:prose :where(code::before) {
+      +   .xl\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .xl\\\\:prose code::after {
-      +   .xl\\\\:markdown code::after {
+      -   .xl\\\\:prose :where(code::after) {
+      +   .xl\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .xl\\\\:prose a code {
-      +   .xl\\\\:markdown a code {
+      -   .xl\\\\:prose :where(a code) {
+      +   .xl\\\\:markdown :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose pre {
-      +   .xl\\\\:markdown pre {
+      -   .xl\\\\:prose :where(pre) {
+      +   .xl\\\\:markdown :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose pre code {
-      +   .xl\\\\:markdown pre code {
+      -   .xl\\\\:prose :where(pre code) {
+      +   .xl\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .xl\\\\:prose pre code::before {
-      +   .xl\\\\:markdown pre code::before {
+      -   .xl\\\\:prose :where(pre code::before) {
+      +   .xl\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .xl\\\\:prose pre code::after {
-      +   .xl\\\\:markdown pre code::after {
+      -   .xl\\\\:prose :where(pre code::after) {
+      +   .xl\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .xl\\\\:prose table {
-      +   .xl\\\\:markdown table {
+      -   .xl\\\\:prose :where(table) {
+      +   .xl\\\\:markdown :where(table) {
 
       ---
 
-      -   .xl\\\\:prose thead {
-      +   .xl\\\\:markdown thead {
+      -   .xl\\\\:prose :where(thead) {
+      +   .xl\\\\:markdown :where(thead) {
 
       ---
 
-      -   .xl\\\\:prose thead th {
-      +   .xl\\\\:markdown thead th {
+      -   .xl\\\\:prose :where(thead th) {
+      +   .xl\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose tbody tr {
-      +   .xl\\\\:markdown tbody tr {
+      -   .xl\\\\:prose :where(tbody tr) {
+      +   .xl\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .xl\\\\:prose tbody tr:last-child {
-      +   .xl\\\\:markdown tbody tr:last-child {
+      -   .xl\\\\:prose :where(tbody tr:last-child) {
+      +   .xl\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td {
-      +   .xl\\\\:markdown tbody td {
+      -   .xl\\\\:prose :where(tbody td) {
+      +   .xl\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -13502,133 +13502,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose p {
-      +   .xl\\\\:markdown p {
+      -   .xl\\\\:prose :where(p) {
+      +   .xl\\\\:markdown :where(p) {
 
       ---
 
-      -   .xl\\\\:prose img {
-      +   .xl\\\\:markdown img {
+      -   .xl\\\\:prose :where(img) {
+      +   .xl\\\\:markdown :where(img) {
 
       ---
 
-      -   .xl\\\\:prose video {
-      +   .xl\\\\:markdown video {
+      -   .xl\\\\:prose :where(video) {
+      +   .xl\\\\:markdown :where(video) {
 
       ---
 
-      -   .xl\\\\:prose figure {
-      +   .xl\\\\:markdown figure {
+      -   .xl\\\\:prose :where(figure) {
+      +   .xl\\\\:markdown :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose figure > * {
-      +   .xl\\\\:markdown figure > * {
+      -   .xl\\\\:prose :where(figure > *) {
+      +   .xl\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose h2 code {
-      +   .xl\\\\:markdown h2 code {
+      -   .xl\\\\:prose :where(h2 code) {
+      +   .xl\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose h3 code {
-      +   .xl\\\\:markdown h3 code {
+      -   .xl\\\\:prose :where(h3 code) {
+      +   .xl\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose ol {
-      +   .xl\\\\:markdown ol {
+      -   .xl\\\\:prose :where(ol) {
+      +   .xl\\\\:markdown :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose ul {
-      +   .xl\\\\:markdown ul {
+      -   .xl\\\\:prose :where(ul) {
+      +   .xl\\\\:markdown :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose li {
-      +   .xl\\\\:markdown li {
+      -   .xl\\\\:prose :where(li) {
+      +   .xl\\\\:markdown :where(li) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li p {
-      +   .xl\\\\:markdown > ul > li p {
+      -   .xl\\\\:prose :where(> ul > li p) {
+      +   .xl\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li > *:first-child {
-      +   .xl\\\\:markdown > ul > li > *:first-child {
+      -   .xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li > *:last-child {
-      +   .xl\\\\:markdown > ul > li > *:last-child {
+      -   .xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose > ol > li > *:first-child {
-      +   .xl\\\\:markdown > ol > li > *:first-child {
+      -   .xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose > ol > li > *:last-child {
-      +   .xl\\\\:markdown > ol > li > *:last-child {
+      -   .xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose ul ul, .xl\\\\:prose ul ol, .xl\\\\:prose ol ul, .xl\\\\:prose ol ol {
-      +   .xl\\\\:markdown ul ul, .xl\\\\:markdown ul ol, .xl\\\\:markdown ol ul, .xl\\\\:markdown ol ol {
+      -   .xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose hr + * {
-      +   .xl\\\\:markdown hr + * {
+      -   .xl\\\\:prose :where(hr + *) {
+      +   .xl\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose h2 + * {
-      +   .xl\\\\:markdown h2 + * {
+      -   .xl\\\\:prose :where(h2 + *) {
+      +   .xl\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose h3 + * {
-      +   .xl\\\\:markdown h3 + * {
+      -   .xl\\\\:prose :where(h3 + *) {
+      +   .xl\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose h4 + * {
-      +   .xl\\\\:markdown h4 + * {
+      -   .xl\\\\:prose :where(h4 + *) {
+      +   .xl\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose thead th:first-child {
-      +   .xl\\\\:markdown thead th:first-child {
+      -   .xl\\\\:prose :where(thead th:first-child) {
+      +   .xl\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose thead th:last-child {
-      +   .xl\\\\:markdown thead th:last-child {
+      -   .xl\\\\:prose :where(thead th:last-child) {
+      +   .xl\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td:first-child {
-      +   .xl\\\\:markdown tbody td:first-child {
+      -   .xl\\\\:prose :where(tbody td:first-child) {
+      +   .xl\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td:last-child {
-      +   .xl\\\\:markdown tbody td:last-child {
+      -   .xl\\\\:prose :where(tbody td:last-child) {
+      +   .xl\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose > :first-child {
-      +   .xl\\\\:markdown > :first-child {
+      -   .xl\\\\:prose :where(> :first-child) {
+      +   .xl\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose > :last-child {
-      +   .xl\\\\:markdown > :last-child {
+      -   .xl\\\\:prose :where(> :last-child) {
+      +   .xl\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -13637,218 +13637,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-sm p {
-      +   .xl\\\\:markdown-sm p {
+      -   .xl\\\\:prose-sm :where(p) {
+      +   .xl\\\\:markdown-sm :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-sm [class~='lead'] {
-      +   .xl\\\\:markdown-sm [class~='lead'] {
+      -   .xl\\\\:prose-sm :where([class~='lead']) {
+      +   .xl\\\\:markdown-sm :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-sm blockquote {
-      +   .xl\\\\:markdown-sm blockquote {
+      -   .xl\\\\:prose-sm :where(blockquote) {
+      +   .xl\\\\:markdown-sm :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-sm h1 {
-      +   .xl\\\\:markdown-sm h1 {
+      -   .xl\\\\:prose-sm :where(h1) {
+      +   .xl\\\\:markdown-sm :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-sm h2 {
-      +   .xl\\\\:markdown-sm h2 {
+      -   .xl\\\\:prose-sm :where(h2) {
+      +   .xl\\\\:markdown-sm :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-sm h3 {
-      +   .xl\\\\:markdown-sm h3 {
+      -   .xl\\\\:prose-sm :where(h3) {
+      +   .xl\\\\:markdown-sm :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-sm h4 {
-      +   .xl\\\\:markdown-sm h4 {
+      -   .xl\\\\:prose-sm :where(h4) {
+      +   .xl\\\\:markdown-sm :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-sm img {
-      +   .xl\\\\:markdown-sm img {
+      -   .xl\\\\:prose-sm :where(img) {
+      +   .xl\\\\:markdown-sm :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-sm video {
-      +   .xl\\\\:markdown-sm video {
+      -   .xl\\\\:prose-sm :where(video) {
+      +   .xl\\\\:markdown-sm :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-sm figure {
-      +   .xl\\\\:markdown-sm figure {
+      -   .xl\\\\:prose-sm :where(figure) {
+      +   .xl\\\\:markdown-sm :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-sm figure > * {
-      +   .xl\\\\:markdown-sm figure > * {
+      -   .xl\\\\:prose-sm :where(figure > *) {
+      +   .xl\\\\:markdown-sm :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-sm figure figcaption {
-      +   .xl\\\\:markdown-sm figure figcaption {
+      -   .xl\\\\:prose-sm :where(figure figcaption) {
+      +   .xl\\\\:markdown-sm :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-sm code {
-      +   .xl\\\\:markdown-sm code {
+      -   .xl\\\\:prose-sm :where(code) {
+      +   .xl\\\\:markdown-sm :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-sm h2 code {
-      +   .xl\\\\:markdown-sm h2 code {
+      -   .xl\\\\:prose-sm :where(h2 code) {
+      +   .xl\\\\:markdown-sm :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-sm h3 code {
-      +   .xl\\\\:markdown-sm h3 code {
+      -   .xl\\\\:prose-sm :where(h3 code) {
+      +   .xl\\\\:markdown-sm :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-sm pre {
-      +   .xl\\\\:markdown-sm pre {
+      -   .xl\\\\:prose-sm :where(pre) {
+      +   .xl\\\\:markdown-sm :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-sm ol {
-      +   .xl\\\\:markdown-sm ol {
+      -   .xl\\\\:prose-sm :where(ol) {
+      +   .xl\\\\:markdown-sm :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-sm ul {
-      +   .xl\\\\:markdown-sm ul {
+      -   .xl\\\\:prose-sm :where(ul) {
+      +   .xl\\\\:markdown-sm :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-sm li {
-      +   .xl\\\\:markdown-sm li {
+      -   .xl\\\\:prose-sm :where(li) {
+      +   .xl\\\\:markdown-sm :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-sm ol > li {
-      +   .xl\\\\:markdown-sm ol > li {
+      -   .xl\\\\:prose-sm :where(ol > li) {
+      +   .xl\\\\:markdown-sm :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-sm ol > li::before {
-      +   .xl\\\\:markdown-sm ol > li::before {
+      -   .xl\\\\:prose-sm :where(ol > li::before) {
+      +   .xl\\\\:markdown-sm :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-sm ul > li {
-      +   .xl\\\\:markdown-sm ul > li {
+      -   .xl\\\\:prose-sm :where(ul > li) {
+      +   .xl\\\\:markdown-sm :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-sm ul > li::before {
-      +   .xl\\\\:markdown-sm ul > li::before {
+      -   .xl\\\\:prose-sm :where(ul > li::before) {
+      +   .xl\\\\:markdown-sm :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-sm > ul > li p {
-      +   .xl\\\\:markdown-sm > ul > li p {
+      -   .xl\\\\:prose-sm :where(> ul > li p) {
+      +   .xl\\\\:markdown-sm :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-sm > ul > li > *:first-child {
-      +   .xl\\\\:markdown-sm > ul > li > *:first-child {
+      -   .xl\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm > ul > li > *:last-child {
-      +   .xl\\\\:markdown-sm > ul > li > *:last-child {
+      -   .xl\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm > ol > li > *:first-child {
-      +   .xl\\\\:markdown-sm > ol > li > *:first-child {
+      -   .xl\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm > ol > li > *:last-child {
-      +   .xl\\\\:markdown-sm > ol > li > *:last-child {
+      -   .xl\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm ul ul, .xl\\\\:prose-sm ul ol, .xl\\\\:prose-sm ol ul, .xl\\\\:prose-sm ol ol {
-      +   .xl\\\\:markdown-sm ul ul, .xl\\\\:markdown-sm ul ol, .xl\\\\:markdown-sm ol ul, .xl\\\\:markdown-sm ol ol {
+      -   .xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-sm hr {
-      +   .xl\\\\:markdown-sm hr {
+      -   .xl\\\\:prose-sm :where(hr) {
+      +   .xl\\\\:markdown-sm :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-sm hr + * {
-      +   .xl\\\\:markdown-sm hr + * {
+      -   .xl\\\\:prose-sm :where(hr + *) {
+      +   .xl\\\\:markdown-sm :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-sm h2 + * {
-      +   .xl\\\\:markdown-sm h2 + * {
+      -   .xl\\\\:prose-sm :where(h2 + *) {
+      +   .xl\\\\:markdown-sm :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-sm h3 + * {
-      +   .xl\\\\:markdown-sm h3 + * {
+      -   .xl\\\\:prose-sm :where(h3 + *) {
+      +   .xl\\\\:markdown-sm :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-sm h4 + * {
-      +   .xl\\\\:markdown-sm h4 + * {
+      -   .xl\\\\:prose-sm :where(h4 + *) {
+      +   .xl\\\\:markdown-sm :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-sm table {
-      +   .xl\\\\:markdown-sm table {
+      -   .xl\\\\:prose-sm :where(table) {
+      +   .xl\\\\:markdown-sm :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-sm thead th {
-      +   .xl\\\\:markdown-sm thead th {
+      -   .xl\\\\:prose-sm :where(thead th) {
+      +   .xl\\\\:markdown-sm :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-sm thead th:first-child {
-      +   .xl\\\\:markdown-sm thead th:first-child {
+      -   .xl\\\\:prose-sm :where(thead th:first-child) {
+      +   .xl\\\\:markdown-sm :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm thead th:last-child {
-      +   .xl\\\\:markdown-sm thead th:last-child {
+      -   .xl\\\\:prose-sm :where(thead th:last-child) {
+      +   .xl\\\\:markdown-sm :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm tbody td {
-      +   .xl\\\\:markdown-sm tbody td {
+      -   .xl\\\\:prose-sm :where(tbody td) {
+      +   .xl\\\\:markdown-sm :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-sm tbody td:first-child {
-      +   .xl\\\\:markdown-sm tbody td:first-child {
+      -   .xl\\\\:prose-sm :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm tbody td:last-child {
-      +   .xl\\\\:markdown-sm tbody td:last-child {
+      -   .xl\\\\:prose-sm :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm > :first-child {
-      +   .xl\\\\:markdown-sm > :first-child {
+      -   .xl\\\\:prose-sm :where(> :first-child) {
+      +   .xl\\\\:markdown-sm :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-sm > :last-child {
-      +   .xl\\\\:markdown-sm > :last-child {
+      -   .xl\\\\:prose-sm :where(> :last-child) {
+      +   .xl\\\\:markdown-sm :where(> :last-child) {
 
       ---
 
@@ -13857,218 +13857,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-lg p {
-      +   .xl\\\\:markdown-lg p {
+      -   .xl\\\\:prose-lg :where(p) {
+      +   .xl\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-lg [class~='lead'] {
-      +   .xl\\\\:markdown-lg [class~='lead'] {
+      -   .xl\\\\:prose-lg :where([class~='lead']) {
+      +   .xl\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-lg blockquote {
-      +   .xl\\\\:markdown-lg blockquote {
+      -   .xl\\\\:prose-lg :where(blockquote) {
+      +   .xl\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-lg h1 {
-      +   .xl\\\\:markdown-lg h1 {
+      -   .xl\\\\:prose-lg :where(h1) {
+      +   .xl\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 {
-      +   .xl\\\\:markdown-lg h2 {
+      -   .xl\\\\:prose-lg :where(h2) {
+      +   .xl\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 {
-      +   .xl\\\\:markdown-lg h3 {
+      -   .xl\\\\:prose-lg :where(h3) {
+      +   .xl\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-lg h4 {
-      +   .xl\\\\:markdown-lg h4 {
+      -   .xl\\\\:prose-lg :where(h4) {
+      +   .xl\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-lg img {
-      +   .xl\\\\:markdown-lg img {
+      -   .xl\\\\:prose-lg :where(img) {
+      +   .xl\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-lg video {
-      +   .xl\\\\:markdown-lg video {
+      -   .xl\\\\:prose-lg :where(video) {
+      +   .xl\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure {
-      +   .xl\\\\:markdown-lg figure {
+      -   .xl\\\\:prose-lg :where(figure) {
+      +   .xl\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure > * {
-      +   .xl\\\\:markdown-lg figure > * {
+      -   .xl\\\\:prose-lg :where(figure > *) {
+      +   .xl\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure figcaption {
-      +   .xl\\\\:markdown-lg figure figcaption {
+      -   .xl\\\\:prose-lg :where(figure figcaption) {
+      +   .xl\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-lg code {
-      +   .xl\\\\:markdown-lg code {
+      -   .xl\\\\:prose-lg :where(code) {
+      +   .xl\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 code {
-      +   .xl\\\\:markdown-lg h2 code {
+      -   .xl\\\\:prose-lg :where(h2 code) {
+      +   .xl\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 code {
-      +   .xl\\\\:markdown-lg h3 code {
+      -   .xl\\\\:prose-lg :where(h3 code) {
+      +   .xl\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-lg pre {
-      +   .xl\\\\:markdown-lg pre {
+      -   .xl\\\\:prose-lg :where(pre) {
+      +   .xl\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol {
-      +   .xl\\\\:markdown-lg ol {
+      -   .xl\\\\:prose-lg :where(ol) {
+      +   .xl\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul {
-      +   .xl\\\\:markdown-lg ul {
+      -   .xl\\\\:prose-lg :where(ul) {
+      +   .xl\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-lg li {
-      +   .xl\\\\:markdown-lg li {
+      -   .xl\\\\:prose-lg :where(li) {
+      +   .xl\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol > li {
-      +   .xl\\\\:markdown-lg ol > li {
+      -   .xl\\\\:prose-lg :where(ol > li) {
+      +   .xl\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol > li::before {
-      +   .xl\\\\:markdown-lg ol > li::before {
+      -   .xl\\\\:prose-lg :where(ol > li::before) {
+      +   .xl\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul > li {
-      +   .xl\\\\:markdown-lg ul > li {
+      -   .xl\\\\:prose-lg :where(ul > li) {
+      +   .xl\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul > li::before {
-      +   .xl\\\\:markdown-lg ul > li::before {
+      -   .xl\\\\:prose-lg :where(ul > li::before) {
+      +   .xl\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li p {
-      +   .xl\\\\:markdown-lg > ul > li p {
+      -   .xl\\\\:prose-lg :where(> ul > li p) {
+      +   .xl\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li > *:first-child {
-      +   .xl\\\\:markdown-lg > ul > li > *:first-child {
+      -   .xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li > *:last-child {
-      +   .xl\\\\:markdown-lg > ul > li > *:last-child {
+      -   .xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ol > li > *:first-child {
-      +   .xl\\\\:markdown-lg > ol > li > *:first-child {
+      -   .xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ol > li > *:last-child {
-      +   .xl\\\\:markdown-lg > ol > li > *:last-child {
+      -   .xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul ul, .xl\\\\:prose-lg ul ol, .xl\\\\:prose-lg ol ul, .xl\\\\:prose-lg ol ol {
-      +   .xl\\\\:markdown-lg ul ul, .xl\\\\:markdown-lg ul ol, .xl\\\\:markdown-lg ol ul, .xl\\\\:markdown-lg ol ol {
+      -   .xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-lg hr {
-      +   .xl\\\\:markdown-lg hr {
+      -   .xl\\\\:prose-lg :where(hr) {
+      +   .xl\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-lg hr + * {
-      +   .xl\\\\:markdown-lg hr + * {
+      -   .xl\\\\:prose-lg :where(hr + *) {
+      +   .xl\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 + * {
-      +   .xl\\\\:markdown-lg h2 + * {
+      -   .xl\\\\:prose-lg :where(h2 + *) {
+      +   .xl\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 + * {
-      +   .xl\\\\:markdown-lg h3 + * {
+      -   .xl\\\\:prose-lg :where(h3 + *) {
+      +   .xl\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h4 + * {
-      +   .xl\\\\:markdown-lg h4 + * {
+      -   .xl\\\\:prose-lg :where(h4 + *) {
+      +   .xl\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg table {
-      +   .xl\\\\:markdown-lg table {
+      -   .xl\\\\:prose-lg :where(table) {
+      +   .xl\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th {
-      +   .xl\\\\:markdown-lg thead th {
+      -   .xl\\\\:prose-lg :where(thead th) {
+      +   .xl\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th:first-child {
-      +   .xl\\\\:markdown-lg thead th:first-child {
+      -   .xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .xl\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th:last-child {
-      +   .xl\\\\:markdown-lg thead th:last-child {
+      -   .xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .xl\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td {
-      +   .xl\\\\:markdown-lg tbody td {
+      -   .xl\\\\:prose-lg :where(tbody td) {
+      +   .xl\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td:first-child {
-      +   .xl\\\\:markdown-lg tbody td:first-child {
+      -   .xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td:last-child {
-      +   .xl\\\\:markdown-lg tbody td:last-child {
+      -   .xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > :first-child {
-      +   .xl\\\\:markdown-lg > :first-child {
+      -   .xl\\\\:prose-lg :where(> :first-child) {
+      +   .xl\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > :last-child {
-      +   .xl\\\\:markdown-lg > :last-child {
+      -   .xl\\\\:prose-lg :where(> :last-child) {
+      +   .xl\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -14077,218 +14077,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-xl p {
-      +   .xl\\\\:markdown-xl p {
+      -   .xl\\\\:prose-xl :where(p) {
+      +   .xl\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-xl [class~='lead'] {
-      +   .xl\\\\:markdown-xl [class~='lead'] {
+      -   .xl\\\\:prose-xl :where([class~='lead']) {
+      +   .xl\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-xl blockquote {
-      +   .xl\\\\:markdown-xl blockquote {
+      -   .xl\\\\:prose-xl :where(blockquote) {
+      +   .xl\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-xl h1 {
-      +   .xl\\\\:markdown-xl h1 {
+      -   .xl\\\\:prose-xl :where(h1) {
+      +   .xl\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 {
-      +   .xl\\\\:markdown-xl h2 {
+      -   .xl\\\\:prose-xl :where(h2) {
+      +   .xl\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 {
-      +   .xl\\\\:markdown-xl h3 {
+      -   .xl\\\\:prose-xl :where(h3) {
+      +   .xl\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-xl h4 {
-      +   .xl\\\\:markdown-xl h4 {
+      -   .xl\\\\:prose-xl :where(h4) {
+      +   .xl\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-xl img {
-      +   .xl\\\\:markdown-xl img {
+      -   .xl\\\\:prose-xl :where(img) {
+      +   .xl\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-xl video {
-      +   .xl\\\\:markdown-xl video {
+      -   .xl\\\\:prose-xl :where(video) {
+      +   .xl\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure {
-      +   .xl\\\\:markdown-xl figure {
+      -   .xl\\\\:prose-xl :where(figure) {
+      +   .xl\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure > * {
-      +   .xl\\\\:markdown-xl figure > * {
+      -   .xl\\\\:prose-xl :where(figure > *) {
+      +   .xl\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure figcaption {
-      +   .xl\\\\:markdown-xl figure figcaption {
+      -   .xl\\\\:prose-xl :where(figure figcaption) {
+      +   .xl\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-xl code {
-      +   .xl\\\\:markdown-xl code {
+      -   .xl\\\\:prose-xl :where(code) {
+      +   .xl\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 code {
-      +   .xl\\\\:markdown-xl h2 code {
+      -   .xl\\\\:prose-xl :where(h2 code) {
+      +   .xl\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 code {
-      +   .xl\\\\:markdown-xl h3 code {
+      -   .xl\\\\:prose-xl :where(h3 code) {
+      +   .xl\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-xl pre {
-      +   .xl\\\\:markdown-xl pre {
+      -   .xl\\\\:prose-xl :where(pre) {
+      +   .xl\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol {
-      +   .xl\\\\:markdown-xl ol {
+      -   .xl\\\\:prose-xl :where(ol) {
+      +   .xl\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul {
-      +   .xl\\\\:markdown-xl ul {
+      -   .xl\\\\:prose-xl :where(ul) {
+      +   .xl\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-xl li {
-      +   .xl\\\\:markdown-xl li {
+      -   .xl\\\\:prose-xl :where(li) {
+      +   .xl\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol > li {
-      +   .xl\\\\:markdown-xl ol > li {
+      -   .xl\\\\:prose-xl :where(ol > li) {
+      +   .xl\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol > li::before {
-      +   .xl\\\\:markdown-xl ol > li::before {
+      -   .xl\\\\:prose-xl :where(ol > li::before) {
+      +   .xl\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul > li {
-      +   .xl\\\\:markdown-xl ul > li {
+      -   .xl\\\\:prose-xl :where(ul > li) {
+      +   .xl\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul > li::before {
-      +   .xl\\\\:markdown-xl ul > li::before {
+      -   .xl\\\\:prose-xl :where(ul > li::before) {
+      +   .xl\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li p {
-      +   .xl\\\\:markdown-xl > ul > li p {
+      -   .xl\\\\:prose-xl :where(> ul > li p) {
+      +   .xl\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li > *:first-child {
-      +   .xl\\\\:markdown-xl > ul > li > *:first-child {
+      -   .xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li > *:last-child {
-      +   .xl\\\\:markdown-xl > ul > li > *:last-child {
+      -   .xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ol > li > *:first-child {
-      +   .xl\\\\:markdown-xl > ol > li > *:first-child {
+      -   .xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ol > li > *:last-child {
-      +   .xl\\\\:markdown-xl > ol > li > *:last-child {
+      -   .xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul ul, .xl\\\\:prose-xl ul ol, .xl\\\\:prose-xl ol ul, .xl\\\\:prose-xl ol ol {
-      +   .xl\\\\:markdown-xl ul ul, .xl\\\\:markdown-xl ul ol, .xl\\\\:markdown-xl ol ul, .xl\\\\:markdown-xl ol ol {
+      -   .xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-xl hr {
-      +   .xl\\\\:markdown-xl hr {
+      -   .xl\\\\:prose-xl :where(hr) {
+      +   .xl\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-xl hr + * {
-      +   .xl\\\\:markdown-xl hr + * {
+      -   .xl\\\\:prose-xl :where(hr + *) {
+      +   .xl\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 + * {
-      +   .xl\\\\:markdown-xl h2 + * {
+      -   .xl\\\\:prose-xl :where(h2 + *) {
+      +   .xl\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 + * {
-      +   .xl\\\\:markdown-xl h3 + * {
+      -   .xl\\\\:prose-xl :where(h3 + *) {
+      +   .xl\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h4 + * {
-      +   .xl\\\\:markdown-xl h4 + * {
+      -   .xl\\\\:prose-xl :where(h4 + *) {
+      +   .xl\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl table {
-      +   .xl\\\\:markdown-xl table {
+      -   .xl\\\\:prose-xl :where(table) {
+      +   .xl\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th {
-      +   .xl\\\\:markdown-xl thead th {
+      -   .xl\\\\:prose-xl :where(thead th) {
+      +   .xl\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th:first-child {
-      +   .xl\\\\:markdown-xl thead th:first-child {
+      -   .xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .xl\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th:last-child {
-      +   .xl\\\\:markdown-xl thead th:last-child {
+      -   .xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .xl\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td {
-      +   .xl\\\\:markdown-xl tbody td {
+      -   .xl\\\\:prose-xl :where(tbody td) {
+      +   .xl\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td:first-child {
-      +   .xl\\\\:markdown-xl tbody td:first-child {
+      -   .xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td:last-child {
-      +   .xl\\\\:markdown-xl tbody td:last-child {
+      -   .xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > :first-child {
-      +   .xl\\\\:markdown-xl > :first-child {
+      -   .xl\\\\:prose-xl :where(> :first-child) {
+      +   .xl\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > :last-child {
-      +   .xl\\\\:markdown-xl > :last-child {
+      -   .xl\\\\:prose-xl :where(> :last-child) {
+      +   .xl\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -14297,288 +14297,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-2xl p {
-      +   .xl\\\\:markdown-2xl p {
+      -   .xl\\\\:prose-2xl :where(p) {
+      +   .xl\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-2xl [class~='lead'] {
-      +   .xl\\\\:markdown-2xl [class~='lead'] {
+      -   .xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .xl\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-2xl blockquote {
-      +   .xl\\\\:markdown-2xl blockquote {
+      -   .xl\\\\:prose-2xl :where(blockquote) {
+      +   .xl\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h1 {
-      +   .xl\\\\:markdown-2xl h1 {
+      -   .xl\\\\:prose-2xl :where(h1) {
+      +   .xl\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 {
-      +   .xl\\\\:markdown-2xl h2 {
+      -   .xl\\\\:prose-2xl :where(h2) {
+      +   .xl\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 {
-      +   .xl\\\\:markdown-2xl h3 {
+      -   .xl\\\\:prose-2xl :where(h3) {
+      +   .xl\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h4 {
-      +   .xl\\\\:markdown-2xl h4 {
+      -   .xl\\\\:prose-2xl :where(h4) {
+      +   .xl\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-2xl img {
-      +   .xl\\\\:markdown-2xl img {
+      -   .xl\\\\:prose-2xl :where(img) {
+      +   .xl\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-2xl video {
-      +   .xl\\\\:markdown-2xl video {
+      -   .xl\\\\:prose-2xl :where(video) {
+      +   .xl\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure {
-      +   .xl\\\\:markdown-2xl figure {
+      -   .xl\\\\:prose-2xl :where(figure) {
+      +   .xl\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure > * {
-      +   .xl\\\\:markdown-2xl figure > * {
+      -   .xl\\\\:prose-2xl :where(figure > *) {
+      +   .xl\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure figcaption {
-      +   .xl\\\\:markdown-2xl figure figcaption {
+      -   .xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .xl\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-2xl code {
-      +   .xl\\\\:markdown-2xl code {
+      -   .xl\\\\:prose-2xl :where(code) {
+      +   .xl\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 code {
-      +   .xl\\\\:markdown-2xl h2 code {
+      -   .xl\\\\:prose-2xl :where(h2 code) {
+      +   .xl\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 code {
-      +   .xl\\\\:markdown-2xl h3 code {
+      -   .xl\\\\:prose-2xl :where(h3 code) {
+      +   .xl\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl pre {
-      +   .xl\\\\:markdown-2xl pre {
+      -   .xl\\\\:prose-2xl :where(pre) {
+      +   .xl\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol {
-      +   .xl\\\\:markdown-2xl ol {
+      -   .xl\\\\:prose-2xl :where(ol) {
+      +   .xl\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul {
-      +   .xl\\\\:markdown-2xl ul {
+      -   .xl\\\\:prose-2xl :where(ul) {
+      +   .xl\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-2xl li {
-      +   .xl\\\\:markdown-2xl li {
+      -   .xl\\\\:prose-2xl :where(li) {
+      +   .xl\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol > li {
-      +   .xl\\\\:markdown-2xl ol > li {
+      -   .xl\\\\:prose-2xl :where(ol > li) {
+      +   .xl\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol > li::before {
-      +   .xl\\\\:markdown-2xl ol > li::before {
+      -   .xl\\\\:prose-2xl :where(ol > li::before) {
+      +   .xl\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul > li {
-      +   .xl\\\\:markdown-2xl ul > li {
+      -   .xl\\\\:prose-2xl :where(ul > li) {
+      +   .xl\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul > li::before {
-      +   .xl\\\\:markdown-2xl ul > li::before {
+      -   .xl\\\\:prose-2xl :where(ul > li::before) {
+      +   .xl\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li p {
-      +   .xl\\\\:markdown-2xl > ul > li p {
+      -   .xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li > *:first-child {
-      +   .xl\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li > *:last-child {
-      +   .xl\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ol > li > *:first-child {
-      +   .xl\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ol > li > *:last-child {
-      +   .xl\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul ul, .xl\\\\:prose-2xl ul ol, .xl\\\\:prose-2xl ol ul, .xl\\\\:prose-2xl ol ol {
-      +   .xl\\\\:markdown-2xl ul ul, .xl\\\\:markdown-2xl ul ol, .xl\\\\:markdown-2xl ol ul, .xl\\\\:markdown-2xl ol ol {
+      -   .xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-2xl hr {
-      +   .xl\\\\:markdown-2xl hr {
+      -   .xl\\\\:prose-2xl :where(hr) {
+      +   .xl\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-2xl hr + * {
-      +   .xl\\\\:markdown-2xl hr + * {
+      -   .xl\\\\:prose-2xl :where(hr + *) {
+      +   .xl\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 + * {
-      +   .xl\\\\:markdown-2xl h2 + * {
+      -   .xl\\\\:prose-2xl :where(h2 + *) {
+      +   .xl\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 + * {
-      +   .xl\\\\:markdown-2xl h3 + * {
+      -   .xl\\\\:prose-2xl :where(h3 + *) {
+      +   .xl\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h4 + * {
-      +   .xl\\\\:markdown-2xl h4 + * {
+      -   .xl\\\\:prose-2xl :where(h4 + *) {
+      +   .xl\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl table {
-      +   .xl\\\\:markdown-2xl table {
+      -   .xl\\\\:prose-2xl :where(table) {
+      +   .xl\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th {
-      +   .xl\\\\:markdown-2xl thead th {
+      -   .xl\\\\:prose-2xl :where(thead th) {
+      +   .xl\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th:first-child {
-      +   .xl\\\\:markdown-2xl thead th:first-child {
+      -   .xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .xl\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th:last-child {
-      +   .xl\\\\:markdown-2xl thead th:last-child {
+      -   .xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .xl\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td {
-      +   .xl\\\\:markdown-2xl tbody td {
+      -   .xl\\\\:prose-2xl :where(tbody td) {
+      +   .xl\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td:first-child {
-      +   .xl\\\\:markdown-2xl tbody td:first-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td:last-child {
-      +   .xl\\\\:markdown-2xl tbody td:last-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > :first-child {
-      +   .xl\\\\:markdown-2xl > :first-child {
+      -   .xl\\\\:prose-2xl :where(> :first-child) {
+      +   .xl\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > :last-child {
-      +   .xl\\\\:markdown-2xl > :last-child {
+      -   .xl\\\\:prose-2xl :where(> :last-child) {
+      +   .xl\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
-      -   .xl\\\\:prose-red a {
-      +   .xl\\\\:markdown-red a {
+      -   .xl\\\\:prose-red :where(a) {
+      +   .xl\\\\:markdown-red :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-red a code {
-      +   .xl\\\\:markdown-red a code {
+      -   .xl\\\\:prose-red :where(a code) {
+      +   .xl\\\\:markdown-red :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-yellow a {
-      +   .xl\\\\:markdown-yellow a {
+      -   .xl\\\\:prose-yellow :where(a) {
+      +   .xl\\\\:markdown-yellow :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-yellow a code {
-      +   .xl\\\\:markdown-yellow a code {
+      -   .xl\\\\:prose-yellow :where(a code) {
+      +   .xl\\\\:markdown-yellow :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-green a {
-      +   .xl\\\\:markdown-green a {
+      -   .xl\\\\:prose-green :where(a) {
+      +   .xl\\\\:markdown-green :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-green a code {
-      +   .xl\\\\:markdown-green a code {
+      -   .xl\\\\:prose-green :where(a code) {
+      +   .xl\\\\:markdown-green :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-blue a {
-      +   .xl\\\\:markdown-blue a {
+      -   .xl\\\\:prose-blue :where(a) {
+      +   .xl\\\\:markdown-blue :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-blue a code {
-      +   .xl\\\\:markdown-blue a code {
+      -   .xl\\\\:prose-blue :where(a code) {
+      +   .xl\\\\:markdown-blue :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-indigo a {
-      +   .xl\\\\:markdown-indigo a {
+      -   .xl\\\\:prose-indigo :where(a) {
+      +   .xl\\\\:markdown-indigo :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-indigo a code {
-      +   .xl\\\\:markdown-indigo a code {
+      -   .xl\\\\:prose-indigo :where(a code) {
+      +   .xl\\\\:markdown-indigo :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-purple a {
-      +   .xl\\\\:markdown-purple a {
+      -   .xl\\\\:prose-purple :where(a) {
+      +   .xl\\\\:markdown-purple :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-purple a code {
-      +   .xl\\\\:markdown-purple a code {
+      -   .xl\\\\:prose-purple :where(a code) {
+      +   .xl\\\\:markdown-purple :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose-pink a {
-      +   .xl\\\\:markdown-pink a {
+      -   .xl\\\\:prose-pink :where(a) {
+      +   .xl\\\\:markdown-pink :where(a) {
 
       ---
 
-      -   .xl\\\\:prose-pink a code {
-      +   .xl\\\\:markdown-pink a code {
+      -   .xl\\\\:prose-pink :where(a code) {
+      +   .xl\\\\:markdown-pink :where(a code) {
 
       ---
 
@@ -14587,218 +14587,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown [class~='lead'] {
+      -   .\\\\32xl\\\\:prose :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose a {
-      +   .\\\\32xl\\\\:markdown a {
+      -   .\\\\32xl\\\\:prose :where(a) {
+      +   .\\\\32xl\\\\:markdown :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose strong {
-      +   .\\\\32xl\\\\:markdown strong {
+      -   .\\\\32xl\\\\:prose :where(strong) {
+      +   .\\\\32xl\\\\:markdown :where(strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='A'] {
-      +   .\\\\32xl\\\\:markdown ol[type='A'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='A']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='a'] {
-      +   .\\\\32xl\\\\:markdown ol[type='a'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='a']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='A' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='A' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='A' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='a' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='a' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='a' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='I'] {
-      +   .\\\\32xl\\\\:markdown ol[type='I'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='I']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='i'] {
-      +   .\\\\32xl\\\\:markdown ol[type='i'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='i']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='I' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='I' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='I' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='i' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='i' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='i' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='1'] {
-      +   .\\\\32xl\\\\:markdown ol[type='1'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='1']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol > li {
-      +   .\\\\32xl\\\\:markdown ol > li {
+      -   .\\\\32xl\\\\:prose :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol > li::before {
-      +   .\\\\32xl\\\\:markdown ol > li::before {
+      -   .\\\\32xl\\\\:prose :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul > li {
-      +   .\\\\32xl\\\\:markdown ul > li {
+      -   .\\\\32xl\\\\:prose :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul > li::before {
-      +   .\\\\32xl\\\\:markdown ul > li::before {
+      -   .\\\\32xl\\\\:prose :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose hr {
-      +   .\\\\32xl\\\\:markdown hr {
+      -   .\\\\32xl\\\\:prose :where(hr) {
+      +   .\\\\32xl\\\\:markdown :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote {
-      +   .\\\\32xl\\\\:markdown blockquote {
+      -   .\\\\32xl\\\\:prose :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote p:first-of-type::before {
-      +   .\\\\32xl\\\\:markdown blockquote p:first-of-type::before {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote p:last-of-type::after {
-      +   .\\\\32xl\\\\:markdown blockquote p:last-of-type::after {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h1 {
-      +   .\\\\32xl\\\\:markdown h1 {
+      -   .\\\\32xl\\\\:prose :where(h1) {
+      +   .\\\\32xl\\\\:markdown :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h1 strong {
-      +   .\\\\32xl\\\\:markdown h1 strong {
+      -   .\\\\32xl\\\\:prose :where(h1 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 {
-      +   .\\\\32xl\\\\:markdown h2 {
+      -   .\\\\32xl\\\\:prose :where(h2) {
+      +   .\\\\32xl\\\\:markdown :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 strong {
-      +   .\\\\32xl\\\\:markdown h2 strong {
+      -   .\\\\32xl\\\\:prose :where(h2 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 {
-      +   .\\\\32xl\\\\:markdown h3 {
+      -   .\\\\32xl\\\\:prose :where(h3) {
+      +   .\\\\32xl\\\\:markdown :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 strong {
-      +   .\\\\32xl\\\\:markdown h3 strong {
+      -   .\\\\32xl\\\\:prose :where(h3 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 {
-      +   .\\\\32xl\\\\:markdown h4 {
+      -   .\\\\32xl\\\\:prose :where(h4) {
+      +   .\\\\32xl\\\\:markdown :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 strong {
-      +   .\\\\32xl\\\\:markdown h4 strong {
+      -   .\\\\32xl\\\\:prose :where(h4 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure figcaption {
-      +   .\\\\32xl\\\\:markdown figure figcaption {
+      -   .\\\\32xl\\\\:prose :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code {
-      +   .\\\\32xl\\\\:markdown code {
+      -   .\\\\32xl\\\\:prose :where(code) {
+      +   .\\\\32xl\\\\:markdown :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code::before {
-      +   .\\\\32xl\\\\:markdown code::before {
+      -   .\\\\32xl\\\\:prose :where(code::before) {
+      +   .\\\\32xl\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code::after {
-      +   .\\\\32xl\\\\:markdown code::after {
+      -   .\\\\32xl\\\\:prose :where(code::after) {
+      +   .\\\\32xl\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose a code {
-      +   .\\\\32xl\\\\:markdown a code {
+      -   .\\\\32xl\\\\:prose :where(a code) {
+      +   .\\\\32xl\\\\:markdown :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre {
-      +   .\\\\32xl\\\\:markdown pre {
+      -   .\\\\32xl\\\\:prose :where(pre) {
+      +   .\\\\32xl\\\\:markdown :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code {
-      +   .\\\\32xl\\\\:markdown pre code {
+      -   .\\\\32xl\\\\:prose :where(pre code) {
+      +   .\\\\32xl\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code::before {
-      +   .\\\\32xl\\\\:markdown pre code::before {
+      -   .\\\\32xl\\\\:prose :where(pre code::before) {
+      +   .\\\\32xl\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code::after {
-      +   .\\\\32xl\\\\:markdown pre code::after {
+      -   .\\\\32xl\\\\:prose :where(pre code::after) {
+      +   .\\\\32xl\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose table {
-      +   .\\\\32xl\\\\:markdown table {
+      -   .\\\\32xl\\\\:prose :where(table) {
+      +   .\\\\32xl\\\\:markdown :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead {
-      +   .\\\\32xl\\\\:markdown thead {
+      -   .\\\\32xl\\\\:prose :where(thead) {
+      +   .\\\\32xl\\\\:markdown :where(thead) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th {
-      +   .\\\\32xl\\\\:markdown thead th {
+      -   .\\\\32xl\\\\:prose :where(thead th) {
+      +   .\\\\32xl\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody tr {
-      +   .\\\\32xl\\\\:markdown tbody tr {
+      -   .\\\\32xl\\\\:prose :where(tbody tr) {
+      +   .\\\\32xl\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody tr:last-child {
-      +   .\\\\32xl\\\\:markdown tbody tr:last-child {
+      -   .\\\\32xl\\\\:prose :where(tbody tr:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td {
-      +   .\\\\32xl\\\\:markdown tbody td {
+      -   .\\\\32xl\\\\:prose :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -14807,133 +14807,133 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose p {
-      +   .\\\\32xl\\\\:markdown p {
+      -   .\\\\32xl\\\\:prose :where(p) {
+      +   .\\\\32xl\\\\:markdown :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose img {
-      +   .\\\\32xl\\\\:markdown img {
+      -   .\\\\32xl\\\\:prose :where(img) {
+      +   .\\\\32xl\\\\:markdown :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose video {
-      +   .\\\\32xl\\\\:markdown video {
+      -   .\\\\32xl\\\\:prose :where(video) {
+      +   .\\\\32xl\\\\:markdown :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure {
-      +   .\\\\32xl\\\\:markdown figure {
+      -   .\\\\32xl\\\\:prose :where(figure) {
+      +   .\\\\32xl\\\\:markdown :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure > * {
-      +   .\\\\32xl\\\\:markdown figure > * {
+      -   .\\\\32xl\\\\:prose :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 code {
-      +   .\\\\32xl\\\\:markdown h2 code {
+      -   .\\\\32xl\\\\:prose :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 code {
-      +   .\\\\32xl\\\\:markdown h3 code {
+      -   .\\\\32xl\\\\:prose :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol {
-      +   .\\\\32xl\\\\:markdown ol {
+      -   .\\\\32xl\\\\:prose :where(ol) {
+      +   .\\\\32xl\\\\:markdown :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul {
-      +   .\\\\32xl\\\\:markdown ul {
+      -   .\\\\32xl\\\\:prose :where(ul) {
+      +   .\\\\32xl\\\\:markdown :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose li {
-      +   .\\\\32xl\\\\:markdown li {
+      -   .\\\\32xl\\\\:prose :where(li) {
+      +   .\\\\32xl\\\\:markdown :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li p {
-      +   .\\\\32xl\\\\:markdown > ul > li p {
+      -   .\\\\32xl\\\\:prose :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul ul, .\\\\32xl\\\\:prose ul ol, .\\\\32xl\\\\:prose ol ul, .\\\\32xl\\\\:prose ol ol {
-      +   .\\\\32xl\\\\:markdown ul ul, .\\\\32xl\\\\:markdown ul ol, .\\\\32xl\\\\:markdown ol ul, .\\\\32xl\\\\:markdown ol ol {
+      -   .\\\\32xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose hr + * {
-      +   .\\\\32xl\\\\:markdown hr + * {
+      -   .\\\\32xl\\\\:prose :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 + * {
-      +   .\\\\32xl\\\\:markdown h2 + * {
+      -   .\\\\32xl\\\\:prose :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 + * {
-      +   .\\\\32xl\\\\:markdown h3 + * {
+      -   .\\\\32xl\\\\:prose :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 + * {
-      +   .\\\\32xl\\\\:markdown h4 + * {
+      -   .\\\\32xl\\\\:prose :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th:first-child {
-      +   .\\\\32xl\\\\:markdown thead th:first-child {
+      -   .\\\\32xl\\\\:prose :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th:last-child {
-      +   .\\\\32xl\\\\:markdown thead th:last-child {
+      -   .\\\\32xl\\\\:prose :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown tbody td:first-child {
+      -   .\\\\32xl\\\\:prose :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown tbody td:last-child {
+      -   .\\\\32xl\\\\:prose :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > :first-child {
-      +   .\\\\32xl\\\\:markdown > :first-child {
+      -   .\\\\32xl\\\\:prose :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > :last-child {
-      +   .\\\\32xl\\\\:markdown > :last-child {
+      -   .\\\\32xl\\\\:prose :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -14942,218 +14942,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm p {
-      +   .\\\\32xl\\\\:markdown-sm p {
+      -   .\\\\32xl\\\\:prose-sm :where(p) {
+      +   .\\\\32xl\\\\:markdown-sm :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-sm [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-sm :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-sm :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm blockquote {
-      +   .\\\\32xl\\\\:markdown-sm blockquote {
+      -   .\\\\32xl\\\\:prose-sm :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-sm :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h1 {
-      +   .\\\\32xl\\\\:markdown-sm h1 {
+      -   .\\\\32xl\\\\:prose-sm :where(h1) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h2 {
-      +   .\\\\32xl\\\\:markdown-sm h2 {
+      -   .\\\\32xl\\\\:prose-sm :where(h2) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h3 {
-      +   .\\\\32xl\\\\:markdown-sm h3 {
+      -   .\\\\32xl\\\\:prose-sm :where(h3) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h4 {
-      +   .\\\\32xl\\\\:markdown-sm h4 {
+      -   .\\\\32xl\\\\:prose-sm :where(h4) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm img {
-      +   .\\\\32xl\\\\:markdown-sm img {
+      -   .\\\\32xl\\\\:prose-sm :where(img) {
+      +   .\\\\32xl\\\\:markdown-sm :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm video {
-      +   .\\\\32xl\\\\:markdown-sm video {
+      -   .\\\\32xl\\\\:prose-sm :where(video) {
+      +   .\\\\32xl\\\\:markdown-sm :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm figure {
-      +   .\\\\32xl\\\\:markdown-sm figure {
+      -   .\\\\32xl\\\\:prose-sm :where(figure) {
+      +   .\\\\32xl\\\\:markdown-sm :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm figure > * {
-      +   .\\\\32xl\\\\:markdown-sm figure > * {
+      -   .\\\\32xl\\\\:prose-sm :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-sm :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm figure figcaption {
-      +   .\\\\32xl\\\\:markdown-sm figure figcaption {
+      -   .\\\\32xl\\\\:prose-sm :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-sm :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm code {
-      +   .\\\\32xl\\\\:markdown-sm code {
+      -   .\\\\32xl\\\\:prose-sm :where(code) {
+      +   .\\\\32xl\\\\:markdown-sm :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h2 code {
-      +   .\\\\32xl\\\\:markdown-sm h2 code {
+      -   .\\\\32xl\\\\:prose-sm :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h3 code {
-      +   .\\\\32xl\\\\:markdown-sm h3 code {
+      -   .\\\\32xl\\\\:prose-sm :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm pre {
-      +   .\\\\32xl\\\\:markdown-sm pre {
+      -   .\\\\32xl\\\\:prose-sm :where(pre) {
+      +   .\\\\32xl\\\\:markdown-sm :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ol {
-      +   .\\\\32xl\\\\:markdown-sm ol {
+      -   .\\\\32xl\\\\:prose-sm :where(ol) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ul {
-      +   .\\\\32xl\\\\:markdown-sm ul {
+      -   .\\\\32xl\\\\:prose-sm :where(ul) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm li {
-      +   .\\\\32xl\\\\:markdown-sm li {
+      -   .\\\\32xl\\\\:prose-sm :where(li) {
+      +   .\\\\32xl\\\\:markdown-sm :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ol > li {
-      +   .\\\\32xl\\\\:markdown-sm ol > li {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ol > li::before {
-      +   .\\\\32xl\\\\:markdown-sm ol > li::before {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ul > li {
-      +   .\\\\32xl\\\\:markdown-sm ul > li {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ul > li::before {
-      +   .\\\\32xl\\\\:markdown-sm ul > li::before {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > ul > li p {
-      +   .\\\\32xl\\\\:markdown-sm > ul > li p {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-sm > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-sm > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-sm > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-sm > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm ul ul, .\\\\32xl\\\\:prose-sm ul ol, .\\\\32xl\\\\:prose-sm ol ul, .\\\\32xl\\\\:prose-sm ol ol {
-      +   .\\\\32xl\\\\:markdown-sm ul ul, .\\\\32xl\\\\:markdown-sm ul ol, .\\\\32xl\\\\:markdown-sm ol ul, .\\\\32xl\\\\:markdown-sm ol ol {
+      -   .\\\\32xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-sm :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm hr {
-      +   .\\\\32xl\\\\:markdown-sm hr {
+      -   .\\\\32xl\\\\:prose-sm :where(hr) {
+      +   .\\\\32xl\\\\:markdown-sm :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm hr + * {
-      +   .\\\\32xl\\\\:markdown-sm hr + * {
+      -   .\\\\32xl\\\\:prose-sm :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-sm :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h2 + * {
-      +   .\\\\32xl\\\\:markdown-sm h2 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h3 + * {
-      +   .\\\\32xl\\\\:markdown-sm h3 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm h4 + * {
-      +   .\\\\32xl\\\\:markdown-sm h4 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-sm :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm table {
-      +   .\\\\32xl\\\\:markdown-sm table {
+      -   .\\\\32xl\\\\:prose-sm :where(table) {
+      +   .\\\\32xl\\\\:markdown-sm :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm thead th {
-      +   .\\\\32xl\\\\:markdown-sm thead th {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-sm :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-sm thead th:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-sm thead th:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm tbody td {
-      +   .\\\\32xl\\\\:markdown-sm tbody td {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-sm :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-sm tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-sm tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > :first-child {
-      +   .\\\\32xl\\\\:markdown-sm > :first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm > :last-child {
-      +   .\\\\32xl\\\\:markdown-sm > :last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-sm :where(> :last-child) {
 
       ---
 
@@ -15162,218 +15162,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg p {
-      +   .\\\\32xl\\\\:markdown-lg p {
+      -   .\\\\32xl\\\\:prose-lg :where(p) {
+      +   .\\\\32xl\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-lg [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-lg :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg blockquote {
-      +   .\\\\32xl\\\\:markdown-lg blockquote {
+      -   .\\\\32xl\\\\:prose-lg :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h1 {
-      +   .\\\\32xl\\\\:markdown-lg h1 {
+      -   .\\\\32xl\\\\:prose-lg :where(h1) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 {
-      +   .\\\\32xl\\\\:markdown-lg h2 {
+      -   .\\\\32xl\\\\:prose-lg :where(h2) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 {
-      +   .\\\\32xl\\\\:markdown-lg h3 {
+      -   .\\\\32xl\\\\:prose-lg :where(h3) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h4 {
-      +   .\\\\32xl\\\\:markdown-lg h4 {
+      -   .\\\\32xl\\\\:prose-lg :where(h4) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg img {
-      +   .\\\\32xl\\\\:markdown-lg img {
+      -   .\\\\32xl\\\\:prose-lg :where(img) {
+      +   .\\\\32xl\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg video {
-      +   .\\\\32xl\\\\:markdown-lg video {
+      -   .\\\\32xl\\\\:prose-lg :where(video) {
+      +   .\\\\32xl\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure {
-      +   .\\\\32xl\\\\:markdown-lg figure {
+      -   .\\\\32xl\\\\:prose-lg :where(figure) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure > * {
-      +   .\\\\32xl\\\\:markdown-lg figure > * {
+      -   .\\\\32xl\\\\:prose-lg :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure figcaption {
-      +   .\\\\32xl\\\\:markdown-lg figure figcaption {
+      -   .\\\\32xl\\\\:prose-lg :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg code {
-      +   .\\\\32xl\\\\:markdown-lg code {
+      -   .\\\\32xl\\\\:prose-lg :where(code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 code {
-      +   .\\\\32xl\\\\:markdown-lg h2 code {
+      -   .\\\\32xl\\\\:prose-lg :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 code {
-      +   .\\\\32xl\\\\:markdown-lg h3 code {
+      -   .\\\\32xl\\\\:prose-lg :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg pre {
-      +   .\\\\32xl\\\\:markdown-lg pre {
+      -   .\\\\32xl\\\\:prose-lg :where(pre) {
+      +   .\\\\32xl\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol {
-      +   .\\\\32xl\\\\:markdown-lg ol {
+      -   .\\\\32xl\\\\:prose-lg :where(ol) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul {
-      +   .\\\\32xl\\\\:markdown-lg ul {
+      -   .\\\\32xl\\\\:prose-lg :where(ul) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg li {
-      +   .\\\\32xl\\\\:markdown-lg li {
+      -   .\\\\32xl\\\\:prose-lg :where(li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol > li {
-      +   .\\\\32xl\\\\:markdown-lg ol > li {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol > li::before {
-      +   .\\\\32xl\\\\:markdown-lg ol > li::before {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul > li {
-      +   .\\\\32xl\\\\:markdown-lg ul > li {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul > li::before {
-      +   .\\\\32xl\\\\:markdown-lg ul > li::before {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li p {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li p {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-lg > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-lg > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul ul, .\\\\32xl\\\\:prose-lg ul ol, .\\\\32xl\\\\:prose-lg ol ul, .\\\\32xl\\\\:prose-lg ol ol {
-      +   .\\\\32xl\\\\:markdown-lg ul ul, .\\\\32xl\\\\:markdown-lg ul ol, .\\\\32xl\\\\:markdown-lg ol ul, .\\\\32xl\\\\:markdown-lg ol ol {
+      -   .\\\\32xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg hr {
-      +   .\\\\32xl\\\\:markdown-lg hr {
+      -   .\\\\32xl\\\\:prose-lg :where(hr) {
+      +   .\\\\32xl\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg hr + * {
-      +   .\\\\32xl\\\\:markdown-lg hr + * {
+      -   .\\\\32xl\\\\:prose-lg :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 + * {
-      +   .\\\\32xl\\\\:markdown-lg h2 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 + * {
-      +   .\\\\32xl\\\\:markdown-lg h3 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h4 + * {
-      +   .\\\\32xl\\\\:markdown-lg h4 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg table {
-      +   .\\\\32xl\\\\:markdown-lg table {
+      -   .\\\\32xl\\\\:prose-lg :where(table) {
+      +   .\\\\32xl\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th {
-      +   .\\\\32xl\\\\:markdown-lg thead th {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-lg thead th:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-lg thead th:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td {
-      +   .\\\\32xl\\\\:markdown-lg tbody td {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-lg tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-lg tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > :first-child {
-      +   .\\\\32xl\\\\:markdown-lg > :first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > :last-child {
-      +   .\\\\32xl\\\\:markdown-lg > :last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -15382,218 +15382,218 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl p {
-      +   .\\\\32xl\\\\:markdown-xl p {
+      -   .\\\\32xl\\\\:prose-xl :where(p) {
+      +   .\\\\32xl\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-xl [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl blockquote {
-      +   .\\\\32xl\\\\:markdown-xl blockquote {
+      -   .\\\\32xl\\\\:prose-xl :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h1 {
-      +   .\\\\32xl\\\\:markdown-xl h1 {
+      -   .\\\\32xl\\\\:prose-xl :where(h1) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 {
-      +   .\\\\32xl\\\\:markdown-xl h2 {
+      -   .\\\\32xl\\\\:prose-xl :where(h2) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 {
-      +   .\\\\32xl\\\\:markdown-xl h3 {
+      -   .\\\\32xl\\\\:prose-xl :where(h3) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h4 {
-      +   .\\\\32xl\\\\:markdown-xl h4 {
+      -   .\\\\32xl\\\\:prose-xl :where(h4) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl img {
-      +   .\\\\32xl\\\\:markdown-xl img {
+      -   .\\\\32xl\\\\:prose-xl :where(img) {
+      +   .\\\\32xl\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl video {
-      +   .\\\\32xl\\\\:markdown-xl video {
+      -   .\\\\32xl\\\\:prose-xl :where(video) {
+      +   .\\\\32xl\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure {
-      +   .\\\\32xl\\\\:markdown-xl figure {
+      -   .\\\\32xl\\\\:prose-xl :where(figure) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure > * {
-      +   .\\\\32xl\\\\:markdown-xl figure > * {
+      -   .\\\\32xl\\\\:prose-xl :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure figcaption {
-      +   .\\\\32xl\\\\:markdown-xl figure figcaption {
+      -   .\\\\32xl\\\\:prose-xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl code {
-      +   .\\\\32xl\\\\:markdown-xl code {
+      -   .\\\\32xl\\\\:prose-xl :where(code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 code {
-      +   .\\\\32xl\\\\:markdown-xl h2 code {
+      -   .\\\\32xl\\\\:prose-xl :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 code {
-      +   .\\\\32xl\\\\:markdown-xl h3 code {
+      -   .\\\\32xl\\\\:prose-xl :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl pre {
-      +   .\\\\32xl\\\\:markdown-xl pre {
+      -   .\\\\32xl\\\\:prose-xl :where(pre) {
+      +   .\\\\32xl\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol {
-      +   .\\\\32xl\\\\:markdown-xl ol {
+      -   .\\\\32xl\\\\:prose-xl :where(ol) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul {
-      +   .\\\\32xl\\\\:markdown-xl ul {
+      -   .\\\\32xl\\\\:prose-xl :where(ul) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl li {
-      +   .\\\\32xl\\\\:markdown-xl li {
+      -   .\\\\32xl\\\\:prose-xl :where(li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol > li {
-      +   .\\\\32xl\\\\:markdown-xl ol > li {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol > li::before {
-      +   .\\\\32xl\\\\:markdown-xl ol > li::before {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul > li {
-      +   .\\\\32xl\\\\:markdown-xl ul > li {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul > li::before {
-      +   .\\\\32xl\\\\:markdown-xl ul > li::before {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li p {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li p {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-xl > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-xl > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul ul, .\\\\32xl\\\\:prose-xl ul ol, .\\\\32xl\\\\:prose-xl ol ul, .\\\\32xl\\\\:prose-xl ol ol {
-      +   .\\\\32xl\\\\:markdown-xl ul ul, .\\\\32xl\\\\:markdown-xl ul ol, .\\\\32xl\\\\:markdown-xl ol ul, .\\\\32xl\\\\:markdown-xl ol ol {
+      -   .\\\\32xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl hr {
-      +   .\\\\32xl\\\\:markdown-xl hr {
+      -   .\\\\32xl\\\\:prose-xl :where(hr) {
+      +   .\\\\32xl\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl hr + * {
-      +   .\\\\32xl\\\\:markdown-xl hr + * {
+      -   .\\\\32xl\\\\:prose-xl :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 + * {
-      +   .\\\\32xl\\\\:markdown-xl h2 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 + * {
-      +   .\\\\32xl\\\\:markdown-xl h3 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h4 + * {
-      +   .\\\\32xl\\\\:markdown-xl h4 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl table {
-      +   .\\\\32xl\\\\:markdown-xl table {
+      -   .\\\\32xl\\\\:prose-xl :where(table) {
+      +   .\\\\32xl\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th {
-      +   .\\\\32xl\\\\:markdown-xl thead th {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-xl thead th:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-xl thead th:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td {
-      +   .\\\\32xl\\\\:markdown-xl tbody td {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-xl tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-xl tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > :first-child {
-      +   .\\\\32xl\\\\:markdown-xl > :first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > :last-child {
-      +   .\\\\32xl\\\\:markdown-xl > :last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -15602,288 +15602,288 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl p {
-      +   .\\\\32xl\\\\:markdown-2xl p {
+      -   .\\\\32xl\\\\:prose-2xl :where(p) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-2xl [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl blockquote {
-      +   .\\\\32xl\\\\:markdown-2xl blockquote {
+      -   .\\\\32xl\\\\:prose-2xl :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h1 {
-      +   .\\\\32xl\\\\:markdown-2xl h1 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h1) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 {
-      +   .\\\\32xl\\\\:markdown-2xl h2 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 {
-      +   .\\\\32xl\\\\:markdown-2xl h3 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h4 {
-      +   .\\\\32xl\\\\:markdown-2xl h4 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl img {
-      +   .\\\\32xl\\\\:markdown-2xl img {
+      -   .\\\\32xl\\\\:prose-2xl :where(img) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl video {
-      +   .\\\\32xl\\\\:markdown-2xl video {
+      -   .\\\\32xl\\\\:prose-2xl :where(video) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure {
-      +   .\\\\32xl\\\\:markdown-2xl figure {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure > * {
-      +   .\\\\32xl\\\\:markdown-2xl figure > * {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure figcaption {
-      +   .\\\\32xl\\\\:markdown-2xl figure figcaption {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl code {
-      +   .\\\\32xl\\\\:markdown-2xl code {
+      -   .\\\\32xl\\\\:prose-2xl :where(code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 code {
-      +   .\\\\32xl\\\\:markdown-2xl h2 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 code {
-      +   .\\\\32xl\\\\:markdown-2xl h3 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl pre {
-      +   .\\\\32xl\\\\:markdown-2xl pre {
+      -   .\\\\32xl\\\\:prose-2xl :where(pre) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol {
-      +   .\\\\32xl\\\\:markdown-2xl ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul {
-      +   .\\\\32xl\\\\:markdown-2xl ul {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl li {
-      +   .\\\\32xl\\\\:markdown-2xl li {
+      -   .\\\\32xl\\\\:prose-2xl :where(li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol > li {
-      +   .\\\\32xl\\\\:markdown-2xl ol > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol > li::before {
-      +   .\\\\32xl\\\\:markdown-2xl ol > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul > li {
-      +   .\\\\32xl\\\\:markdown-2xl ul > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul > li::before {
-      +   .\\\\32xl\\\\:markdown-2xl ul > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li p {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li p {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul ul, .\\\\32xl\\\\:prose-2xl ul ol, .\\\\32xl\\\\:prose-2xl ol ul, .\\\\32xl\\\\:prose-2xl ol ol {
-      +   .\\\\32xl\\\\:markdown-2xl ul ul, .\\\\32xl\\\\:markdown-2xl ul ol, .\\\\32xl\\\\:markdown-2xl ol ul, .\\\\32xl\\\\:markdown-2xl ol ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl hr {
-      +   .\\\\32xl\\\\:markdown-2xl hr {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl hr + * {
-      +   .\\\\32xl\\\\:markdown-2xl hr + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h2 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h3 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h4 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h4 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl table {
-      +   .\\\\32xl\\\\:markdown-2xl table {
+      -   .\\\\32xl\\\\:prose-2xl :where(table) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th {
-      +   .\\\\32xl\\\\:markdown-2xl thead th {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl thead th:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl thead th:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > :first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > :first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > :last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > :last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-red a {
-      +   .\\\\32xl\\\\:markdown-red a {
+      -   .\\\\32xl\\\\:prose-red :where(a) {
+      +   .\\\\32xl\\\\:markdown-red :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-red a code {
-      +   .\\\\32xl\\\\:markdown-red a code {
+      -   .\\\\32xl\\\\:prose-red :where(a code) {
+      +   .\\\\32xl\\\\:markdown-red :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-yellow a {
-      +   .\\\\32xl\\\\:markdown-yellow a {
+      -   .\\\\32xl\\\\:prose-yellow :where(a) {
+      +   .\\\\32xl\\\\:markdown-yellow :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-yellow a code {
-      +   .\\\\32xl\\\\:markdown-yellow a code {
+      -   .\\\\32xl\\\\:prose-yellow :where(a code) {
+      +   .\\\\32xl\\\\:markdown-yellow :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-green a {
-      +   .\\\\32xl\\\\:markdown-green a {
+      -   .\\\\32xl\\\\:prose-green :where(a) {
+      +   .\\\\32xl\\\\:markdown-green :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-green a code {
-      +   .\\\\32xl\\\\:markdown-green a code {
+      -   .\\\\32xl\\\\:prose-green :where(a code) {
+      +   .\\\\32xl\\\\:markdown-green :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-blue a {
-      +   .\\\\32xl\\\\:markdown-blue a {
+      -   .\\\\32xl\\\\:prose-blue :where(a) {
+      +   .\\\\32xl\\\\:markdown-blue :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-blue a code {
-      +   .\\\\32xl\\\\:markdown-blue a code {
+      -   .\\\\32xl\\\\:prose-blue :where(a code) {
+      +   .\\\\32xl\\\\:markdown-blue :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-indigo a {
-      +   .\\\\32xl\\\\:markdown-indigo a {
+      -   .\\\\32xl\\\\:prose-indigo :where(a) {
+      +   .\\\\32xl\\\\:markdown-indigo :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-indigo a code {
-      +   .\\\\32xl\\\\:markdown-indigo a code {
+      -   .\\\\32xl\\\\:prose-indigo :where(a code) {
+      +   .\\\\32xl\\\\:markdown-indigo :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-purple a {
-      +   .\\\\32xl\\\\:markdown-purple a {
+      -   .\\\\32xl\\\\:prose-purple :where(a) {
+      +   .\\\\32xl\\\\:markdown-purple :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-purple a code {
-      +   .\\\\32xl\\\\:markdown-purple a code {
+      -   .\\\\32xl\\\\:prose-purple :where(a code) {
+      +   .\\\\32xl\\\\:markdown-purple :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-pink a {
-      +   .\\\\32xl\\\\:markdown-pink a {
+      -   .\\\\32xl\\\\:prose-pink :where(a) {
+      +   .\\\\32xl\\\\:markdown-pink :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-pink a code {
-      +   .\\\\32xl\\\\:markdown-pink a code {
+      -   .\\\\32xl\\\\:prose-pink :where(a code) {
+      +   .\\\\32xl\\\\:markdown-pink :where(a code) {
 
     "
   `)
@@ -15894,94 +15894,94 @@ it('should be possible to change the default modifiers', async () => {
     "
 
       - .prose-2xl {
-      -   font-size: 1.5rem;
-      -   line-height: 1.6666667;
+      -   :where(font-size): 1.5rem;
+      -   :where(line-height): 1.6666667;
       - }
       -
-      - .prose-2xl p {
+      - .prose-2xl :where(p) {
       -   margin-top: 1.3333333em;
       -   margin-bottom: 1.3333333em;
       - }
       -
-      - .prose-2xl [class~='lead'] {
+      - .prose-2xl :where([class~='lead']) {
       -   font-size: 1.25em;
       -   line-height: 1.4666667;
       -   margin-top: 1.0666667em;
       -   margin-bottom: 1.0666667em;
       - }
       -
-      - .prose-2xl blockquote {
+      - .prose-2xl :where(blockquote) {
       -   margin-top: 1.7777778em;
       -   margin-bottom: 1.7777778em;
       -   padding-left: 1.1111111em;
       - }
       -
-      - .prose-2xl h1 {
+      - .prose-2xl :where(h1) {
       -   font-size: 2.6666667em;
       -   margin-top: 0;
       -   margin-bottom: 0.875em;
       -   line-height: 1;
       - }
       -
-      - .prose-2xl h2 {
+      - .prose-2xl :where(h2) {
       -   font-size: 2em;
       -   margin-top: 1.5em;
       -   margin-bottom: 0.8333333em;
       -   line-height: 1.0833333;
       - }
       -
-      - .prose-2xl h3 {
+      - .prose-2xl :where(h3) {
       -   font-size: 1.5em;
       -   margin-top: 1.5555556em;
       -   margin-bottom: 0.6666667em;
       -   line-height: 1.2222222;
       - }
       -
-      - .prose-2xl h4 {
+      - .prose-2xl :where(h4) {
       -   margin-top: 1.6666667em;
       -   margin-bottom: 0.6666667em;
       -   line-height: 1.5;
       - }
       -
-      - .prose-2xl img {
+      - .prose-2xl :where(img) {
       -   margin-top: 2em;
       -   margin-bottom: 2em;
       - }
       -
-      - .prose-2xl video {
+      - .prose-2xl :where(video) {
       -   margin-top: 2em;
       -   margin-bottom: 2em;
       - }
       -
-      - .prose-2xl figure {
+      - .prose-2xl :where(figure) {
       -   margin-top: 2em;
       -   margin-bottom: 2em;
       - }
       -
-      - .prose-2xl figure > * {
+      - .prose-2xl :where(figure > *) {
       -   margin-top: 0;
       -   margin-bottom: 0;
       - }
       -
-      - .prose-2xl figure figcaption {
+      - .prose-2xl :where(figure figcaption) {
       -   font-size: 0.8333333em;
       -   line-height: 1.6;
       -   margin-top: 1em;
       - }
       -
-      - .prose-2xl code {
+      - .prose-2xl :where(code) {
       -   font-size: 0.8333333em;
       - }
       -
-      - .prose-2xl h2 code {
+      - .prose-2xl :where(h2 code) {
       -   font-size: 0.875em;
       - }
       -
-      - .prose-2xl h3 code {
+      - .prose-2xl :where(h3 code) {
       -   font-size: 0.8888889em;
       - }
       -
-      - .prose-2xl pre {
+      - .prose-2xl :where(pre) {
       -   font-size: 0.8333333em;
       -   line-height: 1.8;
       -   margin-top: 2em;
@@ -15993,182 +15993,182 @@ it('should be possible to change the default modifiers', async () => {
       -   padding-left: 1.6em;
       - }
       -
-      - .prose-2xl ol {
+      - .prose-2xl :where(ol) {
       -   margin-top: 1.3333333em;
       -   margin-bottom: 1.3333333em;
       - }
       -
-      - .prose-2xl ul {
+      - .prose-2xl :where(ul) {
       -   margin-top: 1.3333333em;
       -   margin-bottom: 1.3333333em;
       - }
       -
-      - .prose-2xl li {
+      - .prose-2xl :where(li) {
       -   margin-top: 0.5em;
       -   margin-bottom: 0.5em;
       - }
       -
-      - .prose-2xl ol > li {
+      - .prose-2xl :where(ol > li) {
       -   padding-left: 1.6666667em;
       - }
       -
-      - .prose-2xl ol > li::before {
+      - .prose-2xl :where(ol > li::before) {
       -   left: 0;
       - }
       -
-      - .prose-2xl ul > li {
+      - .prose-2xl :where(ul > li) {
       -   padding-left: 1.6666667em;
       - }
       -
-      - .prose-2xl ul > li::before {
+      - .prose-2xl :where(ul > li::before) {
       -   width: 0.3333333em;
       -   height: 0.3333333em;
       -   top: calc(0.8333333em - 0.1666667em);
       -   left: 0.25em;
       - }
       -
-      - .prose-2xl > ul > li p {
+      - .prose-2xl :where(> ul > li p) {
       -   margin-top: 0.8333333em;
       -   margin-bottom: 0.8333333em;
       - }
       -
-      - .prose-2xl > ul > li > *:first-child {
+      - .prose-2xl :where(> ul > li > *:first-child) {
       -   margin-top: 1.3333333em;
       - }
       -
-      - .prose-2xl > ul > li > *:last-child {
+      - .prose-2xl :where(> ul > li > *:last-child) {
       -   margin-bottom: 1.3333333em;
       - }
       -
-      - .prose-2xl > ol > li > *:first-child {
+      - .prose-2xl :where(> ol > li > *:first-child) {
       -   margin-top: 1.3333333em;
       - }
       -
-      - .prose-2xl > ol > li > *:last-child {
+      - .prose-2xl :where(> ol > li > *:last-child) {
       -   margin-bottom: 1.3333333em;
       - }
       -
-      - .prose-2xl ul ul, .prose-2xl ul ol, .prose-2xl ol ul, .prose-2xl ol ol {
+      - .prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -   margin-top: 0.6666667em;
       -   margin-bottom: 0.6666667em;
       - }
       -
-      - .prose-2xl hr {
+      - .prose-2xl :where(hr) {
       -   margin-top: 3em;
       -   margin-bottom: 3em;
       - }
       -
-      - .prose-2xl hr + * {
+      - .prose-2xl :where(hr + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose-2xl h2 + * {
+      - .prose-2xl :where(h2 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose-2xl h3 + * {
+      - .prose-2xl :where(h3 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose-2xl h4 + * {
+      - .prose-2xl :where(h4 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose-2xl table {
+      - .prose-2xl :where(table) {
       -   font-size: 0.8333333em;
       -   line-height: 1.4;
       - }
       -
-      - .prose-2xl thead th {
+      - .prose-2xl :where(thead th) {
       -   padding-right: 0.6em;
       -   padding-bottom: 0.8em;
       -   padding-left: 0.6em;
       - }
       -
-      - .prose-2xl thead th:first-child {
+      - .prose-2xl :where(thead th:first-child) {
       -   padding-left: 0;
       - }
       -
-      - .prose-2xl thead th:last-child {
+      - .prose-2xl :where(thead th:last-child) {
       -   padding-right: 0;
       - }
       -
-      - .prose-2xl tbody td {
+      - .prose-2xl :where(tbody td) {
       -   padding-top: 0.8em;
       -   padding-right: 0.6em;
       -   padding-bottom: 0.8em;
       -   padding-left: 0.6em;
       - }
       -
-      - .prose-2xl tbody td:first-child {
+      - .prose-2xl :where(tbody td:first-child) {
       -   padding-left: 0;
       - }
       -
-      - .prose-2xl tbody td:last-child {
+      - .prose-2xl :where(tbody td:last-child) {
       -   padding-right: 0;
       - }
       -
-      - .prose-2xl > :first-child {
+      - .prose-2xl :where(> :first-child) {
       -   margin-top: 0;
       - }
       -
-      - .prose-2xl > :last-child {
+      - .prose-2xl :where(> :last-child) {
       -   margin-bottom: 0;
       - }
       -
-      - .prose-red a {
+      - .prose-red :where(a) {
       -   color: #dc2626;
       - }
       -
-      - .prose-red a code {
+      - .prose-red :where(a code) {
       -   color: #dc2626;
       - }
       -
-      - .prose-yellow a {
+      - .prose-yellow :where(a) {
       -   color: #d97706;
       - }
       -
-      - .prose-yellow a code {
+      - .prose-yellow :where(a code) {
       -   color: #d97706;
       - }
       -
-      - .prose-green a {
+      - .prose-green :where(a) {
       -   color: #059669;
       - }
       -
-      - .prose-green a code {
+      - .prose-green :where(a code) {
       -   color: #059669;
       - }
       -
-      - .prose-blue a {
+      - .prose-blue :where(a) {
       -   color: #2563eb;
       - }
       -
-      - .prose-blue a code {
+      - .prose-blue :where(a code) {
       -   color: #2563eb;
       - }
       -
-      - .prose-indigo a {
+      - .prose-indigo :where(a) {
       -   color: #4f46e5;
       - }
       -
-      - .prose-indigo a code {
+      - .prose-indigo :where(a code) {
       -   color: #4f46e5;
       - }
       -
-      - .prose-purple a {
+      - .prose-purple :where(a) {
       -   color: #7c3aed;
       - }
       -
-      - .prose-purple a code {
+      - .prose-purple :where(a code) {
       -   color: #7c3aed;
       - }
       -
-      - .prose-pink a {
+      - .prose-pink :where(a) {
       -   color: #db2777;
       - }
       -
-      - .prose-pink a code {
+      - .prose-pink :where(a code) {
       -   color: #db2777;
       - }
       -
@@ -16179,96 +16179,96 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .sm\\\\:prose-2xl {
-      -     font-size: 1.5rem;
-      -     line-height: 1.6666667;
+      -     :where(font-size): 1.5rem;
+      -     :where(line-height): 1.6666667;
       -   }
       -
-      -   .sm\\\\:prose-2xl p {
+      -   .sm\\\\:prose-2xl :where(p) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl [class~='lead'] {
+      -   .sm\\\\:prose-2xl :where([class~='lead']) {
       -     font-size: 1.25em;
       -     line-height: 1.4666667;
       -     margin-top: 1.0666667em;
       -     margin-bottom: 1.0666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl blockquote {
+      -   .sm\\\\:prose-2xl :where(blockquote) {
       -     margin-top: 1.7777778em;
       -     margin-bottom: 1.7777778em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .sm\\\\:prose-2xl h1 {
+      -   .sm\\\\:prose-2xl :where(h1) {
       -     font-size: 2.6666667em;
       -     margin-top: 0;
       -     margin-bottom: 0.875em;
       -     line-height: 1;
       -   }
       -
-      -   .sm\\\\:prose-2xl h2 {
+      -   .sm\\\\:prose-2xl :where(h2) {
       -     font-size: 2em;
       -     margin-top: 1.5em;
       -     margin-bottom: 0.8333333em;
       -     line-height: 1.0833333;
       -   }
       -
-      -   .sm\\\\:prose-2xl h3 {
+      -   .sm\\\\:prose-2xl :where(h3) {
       -     font-size: 1.5em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.2222222;
       -   }
       -
-      -   .sm\\\\:prose-2xl h4 {
+      -   .sm\\\\:prose-2xl :where(h4) {
       -     margin-top: 1.6666667em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.5;
       -   }
       -
-      -   .sm\\\\:prose-2xl img {
+      -   .sm\\\\:prose-2xl :where(img) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .sm\\\\:prose-2xl video {
+      -   .sm\\\\:prose-2xl :where(video) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .sm\\\\:prose-2xl figure {
+      -   .sm\\\\:prose-2xl :where(figure) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .sm\\\\:prose-2xl figure > * {
+      -   .sm\\\\:prose-2xl :where(figure > *) {
       -     margin-top: 0;
 
       ---
 
       -   }
       -
-      -   .sm\\\\:prose-2xl figure figcaption {
+      -   .sm\\\\:prose-2xl :where(figure figcaption) {
       -     font-size: 0.8333333em;
       -     line-height: 1.6;
       -     margin-top: 1em;
       -   }
       -
-      -   .sm\\\\:prose-2xl code {
+      -   .sm\\\\:prose-2xl :where(code) {
       -     font-size: 0.8333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl h2 code {
+      -   .sm\\\\:prose-2xl :where(h2 code) {
       -     font-size: 0.875em;
       -   }
       -
-      -   .sm\\\\:prose-2xl h3 code {
+      -   .sm\\\\:prose-2xl :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .sm\\\\:prose-2xl pre {
+      -   .sm\\\\:prose-2xl :where(pre) {
       -     font-size: 0.8333333em;
       -     line-height: 1.8;
       -     margin-top: 2em;
@@ -16280,184 +16280,184 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ol {
+      -   .sm\\\\:prose-2xl :where(ol) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ul {
+      -   .sm\\\\:prose-2xl :where(ul) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl li {
+      -   .sm\\\\:prose-2xl :where(li) {
       -     margin-top: 0.5em;
       -     margin-bottom: 0.5em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ol > li {
+      -   .sm\\\\:prose-2xl :where(ol > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ol > li::before {
+      -   .sm\\\\:prose-2xl :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl ul > li {
+      -   .sm\\\\:prose-2xl :where(ul > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ul > li::before {
+      -   .sm\\\\:prose-2xl :where(ul > li::before) {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
       -     left: 0.25em;
       -   }
       -
-      -   .sm\\\\:prose-2xl > ul > li p {
+      -   .sm\\\\:prose-2xl :where(> ul > li p) {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
 
       ---
 
       -
-      -   .sm\\\\:prose-2xl > ul > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl > ul > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl > ol > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl > ol > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .sm\\\\:prose-2xl ul ul, .sm\\\\:prose-2xl ul ol, .sm\\\\:prose-2xl ol ul, .sm\\\\:prose-2xl ol ol {
+      -   .sm\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.6666667em;
       -     margin-bottom: 0.6666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl hr {
+      -   .sm\\\\:prose-2xl :where(hr) {
       -     margin-top: 3em;
       -     margin-bottom: 3em;
       -   }
       -
-      -   .sm\\\\:prose-2xl hr + * {
+      -   .sm\\\\:prose-2xl :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl h2 + * {
+      -   .sm\\\\:prose-2xl :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl h3 + * {
+      -   .sm\\\\:prose-2xl :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl h4 + * {
+      -   .sm\\\\:prose-2xl :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl table {
+      -   .sm\\\\:prose-2xl :where(table) {
       -     font-size: 0.8333333em;
       -     line-height: 1.4;
       -   }
       -
-      -   .sm\\\\:prose-2xl thead th {
+      -   .sm\\\\:prose-2xl :where(thead th) {
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .sm\\\\:prose-2xl thead th:first-child {
+      -   .sm\\\\:prose-2xl :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl thead th:last-child {
+      -   .sm\\\\:prose-2xl :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl tbody td {
+      -   .sm\\\\:prose-2xl :where(tbody td) {
       -     padding-top: 0.8em;
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .sm\\\\:prose-2xl tbody td:first-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl tbody td:last-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl > :first-child {
+      -   .sm\\\\:prose-2xl :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-2xl > :last-child {
+      -   .sm\\\\:prose-2xl :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
-      -   .sm\\\\:prose-red a {
+      -   .sm\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .sm\\\\:prose-red a code {
+      -   .sm\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .sm\\\\:prose-yellow a {
+      -   .sm\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .sm\\\\:prose-yellow a code {
+      -   .sm\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .sm\\\\:prose-green a {
+      -   .sm\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .sm\\\\:prose-green a code {
+      -   .sm\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .sm\\\\:prose-blue a {
+      -   .sm\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .sm\\\\:prose-blue a code {
+      -   .sm\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .sm\\\\:prose-indigo a {
+      -   .sm\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .sm\\\\:prose-indigo a code {
+      -   .sm\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .sm\\\\:prose-purple a {
+      -   .sm\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .sm\\\\:prose-purple a code {
+      -   .sm\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .sm\\\\:prose-pink a {
+      -   .sm\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .sm\\\\:prose-pink a code {
+      -   .sm\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -16467,94 +16467,94 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .md\\\\:prose-2xl {
-      -     font-size: 1.5rem;
-      -     line-height: 1.6666667;
+      -     :where(font-size): 1.5rem;
+      -     :where(line-height): 1.6666667;
       -   }
       -
-      -   .md\\\\:prose-2xl p {
+      -   .md\\\\:prose-2xl :where(p) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl [class~='lead'] {
+      -   .md\\\\:prose-2xl :where([class~='lead']) {
       -     font-size: 1.25em;
       -     line-height: 1.4666667;
       -     margin-top: 1.0666667em;
       -     margin-bottom: 1.0666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl blockquote {
+      -   .md\\\\:prose-2xl :where(blockquote) {
       -     margin-top: 1.7777778em;
       -     margin-bottom: 1.7777778em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .md\\\\:prose-2xl h1 {
+      -   .md\\\\:prose-2xl :where(h1) {
       -     font-size: 2.6666667em;
       -     margin-top: 0;
       -     margin-bottom: 0.875em;
       -     line-height: 1;
       -   }
       -
-      -   .md\\\\:prose-2xl h2 {
+      -   .md\\\\:prose-2xl :where(h2) {
       -     font-size: 2em;
       -     margin-top: 1.5em;
       -     margin-bottom: 0.8333333em;
       -     line-height: 1.0833333;
       -   }
       -
-      -   .md\\\\:prose-2xl h3 {
+      -   .md\\\\:prose-2xl :where(h3) {
       -     font-size: 1.5em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.2222222;
       -   }
       -
-      -   .md\\\\:prose-2xl h4 {
+      -   .md\\\\:prose-2xl :where(h4) {
       -     margin-top: 1.6666667em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.5;
       -   }
       -
-      -   .md\\\\:prose-2xl img {
+      -   .md\\\\:prose-2xl :where(img) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .md\\\\:prose-2xl video {
+      -   .md\\\\:prose-2xl :where(video) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .md\\\\:prose-2xl figure {
+      -   .md\\\\:prose-2xl :where(figure) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .md\\\\:prose-2xl figure > * {
+      -   .md\\\\:prose-2xl :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl figure figcaption {
+      -   .md\\\\:prose-2xl :where(figure figcaption) {
       -     font-size: 0.8333333em;
       -     line-height: 1.6;
       -     margin-top: 1em;
       -   }
       -
-      -   .md\\\\:prose-2xl code {
+      -   .md\\\\:prose-2xl :where(code) {
       -     font-size: 0.8333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl h2 code {
+      -   .md\\\\:prose-2xl :where(h2 code) {
       -     font-size: 0.875em;
       -   }
       -
-      -   .md\\\\:prose-2xl h3 code {
+      -   .md\\\\:prose-2xl :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .md\\\\:prose-2xl pre {
+      -   .md\\\\:prose-2xl :where(pre) {
       -     font-size: 0.8333333em;
       -     line-height: 1.8;
       -     margin-top: 2em;
@@ -16566,184 +16566,184 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6em;
       -   }
       -
-      -   .md\\\\:prose-2xl ol {
+      -   .md\\\\:prose-2xl :where(ol) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl ul {
+      -   .md\\\\:prose-2xl :where(ul) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl li {
+      -   .md\\\\:prose-2xl :where(li) {
       -     margin-top: 0.5em;
       -     margin-bottom: 0.5em;
       -   }
       -
-      -   .md\\\\:prose-2xl ol > li {
+      -   .md\\\\:prose-2xl :where(ol > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl ol > li::before {
+      -   .md\\\\:prose-2xl :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl ul > li {
+      -   .md\\\\:prose-2xl :where(ul > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl ul > li::before {
+      -   .md\\\\:prose-2xl :where(ul > li::before) {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
       -     left: 0.25em;
       -   }
       -
-      -   .md\\\\:prose-2xl > ul > li p {
+      -   .md\\\\:prose-2xl :where(> ul > li p) {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl > ul > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl > ul > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl > ol > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl > ol > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .md\\\\:prose-2xl ul ul, .md\\\\:prose-2xl ul ol, .md\\\\:prose-2xl ol ul, .md\\\\:prose-2xl ol ol {
+      -   .md\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.6666667em;
       -     margin-bottom: 0.6666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl hr {
+      -   .md\\\\:prose-2xl :where(hr) {
       -     margin-top: 3em;
       -     margin-bottom: 3em;
       -   }
       -
-      -   .md\\\\:prose-2xl hr + * {
+      -   .md\\\\:prose-2xl :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl h2 + * {
+      -   .md\\\\:prose-2xl :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl h3 + * {
+      -   .md\\\\:prose-2xl :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl h4 + * {
+      -   .md\\\\:prose-2xl :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl table {
+      -   .md\\\\:prose-2xl :where(table) {
       -     font-size: 0.8333333em;
       -     line-height: 1.4;
       -   }
       -
-      -   .md\\\\:prose-2xl thead th {
+      -   .md\\\\:prose-2xl :where(thead th) {
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .md\\\\:prose-2xl thead th:first-child {
+      -   .md\\\\:prose-2xl :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl thead th:last-child {
+      -   .md\\\\:prose-2xl :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl tbody td {
+      -   .md\\\\:prose-2xl :where(tbody td) {
       -     padding-top: 0.8em;
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .md\\\\:prose-2xl tbody td:first-child {
+      -   .md\\\\:prose-2xl :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl tbody td:last-child {
+      -   .md\\\\:prose-2xl :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl > :first-child {
+      -   .md\\\\:prose-2xl :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-2xl > :last-child {
+      -   .md\\\\:prose-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .md\\\\:prose-red a {
+      -   .md\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .md\\\\:prose-red a code {
+      -   .md\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .md\\\\:prose-yellow a {
+      -   .md\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .md\\\\:prose-yellow a code {
+      -   .md\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .md\\\\:prose-green a {
+      -   .md\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .md\\\\:prose-green a code {
+      -   .md\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .md\\\\:prose-blue a {
+      -   .md\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .md\\\\:prose-blue a code {
+      -   .md\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .md\\\\:prose-indigo a {
+      -   .md\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .md\\\\:prose-indigo a code {
+      -   .md\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .md\\\\:prose-purple a {
+      -   .md\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .md\\\\:prose-purple a code {
+      -   .md\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .md\\\\:prose-pink a {
+      -   .md\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .md\\\\:prose-pink a code {
+      -   .md\\\\:prose-pink :where(a code) {
       -     color: #db2777;
 
       ---
@@ -16752,94 +16752,94 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .lg\\\\:prose-2xl {
-      -     font-size: 1.5rem;
-      -     line-height: 1.6666667;
+      -     :where(font-size): 1.5rem;
+      -     :where(line-height): 1.6666667;
       -   }
       -
-      -   .lg\\\\:prose-2xl p {
+      -   .lg\\\\:prose-2xl :where(p) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl [class~='lead'] {
+      -   .lg\\\\:prose-2xl :where([class~='lead']) {
       -     font-size: 1.25em;
       -     line-height: 1.4666667;
       -     margin-top: 1.0666667em;
       -     margin-bottom: 1.0666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl blockquote {
+      -   .lg\\\\:prose-2xl :where(blockquote) {
       -     margin-top: 1.7777778em;
       -     margin-bottom: 1.7777778em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .lg\\\\:prose-2xl h1 {
+      -   .lg\\\\:prose-2xl :where(h1) {
       -     font-size: 2.6666667em;
       -     margin-top: 0;
       -     margin-bottom: 0.875em;
       -     line-height: 1;
       -   }
       -
-      -   .lg\\\\:prose-2xl h2 {
+      -   .lg\\\\:prose-2xl :where(h2) {
       -     font-size: 2em;
       -     margin-top: 1.5em;
       -     margin-bottom: 0.8333333em;
       -     line-height: 1.0833333;
       -   }
       -
-      -   .lg\\\\:prose-2xl h3 {
+      -   .lg\\\\:prose-2xl :where(h3) {
       -     font-size: 1.5em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.2222222;
       -   }
       -
-      -   .lg\\\\:prose-2xl h4 {
+      -   .lg\\\\:prose-2xl :where(h4) {
       -     margin-top: 1.6666667em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.5;
       -   }
       -
-      -   .lg\\\\:prose-2xl img {
+      -   .lg\\\\:prose-2xl :where(img) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .lg\\\\:prose-2xl video {
+      -   .lg\\\\:prose-2xl :where(video) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .lg\\\\:prose-2xl figure {
+      -   .lg\\\\:prose-2xl :where(figure) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .lg\\\\:prose-2xl figure > * {
+      -   .lg\\\\:prose-2xl :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl figure figcaption {
+      -   .lg\\\\:prose-2xl :where(figure figcaption) {
       -     font-size: 0.8333333em;
       -     line-height: 1.6;
       -     margin-top: 1em;
       -   }
       -
-      -   .lg\\\\:prose-2xl code {
+      -   .lg\\\\:prose-2xl :where(code) {
       -     font-size: 0.8333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl h2 code {
+      -   .lg\\\\:prose-2xl :where(h2 code) {
       -     font-size: 0.875em;
       -   }
       -
-      -   .lg\\\\:prose-2xl h3 code {
+      -   .lg\\\\:prose-2xl :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .lg\\\\:prose-2xl pre {
+      -   .lg\\\\:prose-2xl :where(pre) {
       -     font-size: 0.8333333em;
       -     line-height: 1.8;
       -     margin-top: 2em;
@@ -16851,186 +16851,186 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ol {
+      -   .lg\\\\:prose-2xl :where(ol) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ul {
+      -   .lg\\\\:prose-2xl :where(ul) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl li {
+      -   .lg\\\\:prose-2xl :where(li) {
       -     margin-top: 0.5em;
       -     margin-bottom: 0.5em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ol > li {
+      -   .lg\\\\:prose-2xl :where(ol > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ol > li::before {
+      -   .lg\\\\:prose-2xl :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl ul > li {
+      -   .lg\\\\:prose-2xl :where(ul > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ul > li::before {
+      -   .lg\\\\:prose-2xl :where(ul > li::before) {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
       -     left: 0.25em;
       -   }
       -
-      -   .lg\\\\:prose-2xl > ul > li p {
+      -   .lg\\\\:prose-2xl :where(> ul > li p) {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl > ul > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl > ul > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl > ol > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl > ol > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .lg\\\\:prose-2xl ul ul, .lg\\\\:prose-2xl ul ol, .lg\\\\:prose-2xl ol ul, .lg\\\\:prose-2xl ol ol {
+      -   .lg\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.6666667em;
       -     margin-bottom: 0.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl hr {
+      -   .lg\\\\:prose-2xl :where(hr) {
       -     margin-top: 3em;
       -     margin-bottom: 3em;
       -   }
       -
-      -   .lg\\\\:prose-2xl hr + * {
+      -   .lg\\\\:prose-2xl :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl h2 + * {
+      -   .lg\\\\:prose-2xl :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl h3 + * {
+      -   .lg\\\\:prose-2xl :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl h4 + * {
+      -   .lg\\\\:prose-2xl :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl table {
+      -   .lg\\\\:prose-2xl :where(table) {
       -     font-size: 0.8333333em;
       -     line-height: 1.4;
       -   }
       -
-      -   .lg\\\\:prose-2xl thead th {
+      -   .lg\\\\:prose-2xl :where(thead th) {
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .lg\\\\:prose-2xl thead th:first-child {
+      -   .lg\\\\:prose-2xl :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl thead th:last-child {
+      -   .lg\\\\:prose-2xl :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl tbody td {
+      -   .lg\\\\:prose-2xl :where(tbody td) {
       -     padding-top: 0.8em;
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .lg\\\\:prose-2xl tbody td:first-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl tbody td:last-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl > :first-child {
+      -   .lg\\\\:prose-2xl :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose-2xl > :last-child {
+      -   .lg\\\\:prose-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .lg\\\\:prose-red a {
+      -   .lg\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .lg\\\\:prose-red a code {
+      -   .lg\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .lg\\\\:prose-yellow a {
+      -   .lg\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .lg\\\\:prose-yellow a code {
+      -   .lg\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .lg\\\\:prose-green a {
+      -   .lg\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .lg\\\\:prose-green a code {
+      -   .lg\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .lg\\\\:prose-blue a {
+      -   .lg\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .lg\\\\:prose-blue a code {
+      -   .lg\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .lg\\\\:prose-indigo a {
+      -   .lg\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .lg\\\\:prose-indigo a code {
+      -   .lg\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .lg\\\\:prose-purple a {
+      -   .lg\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .lg\\\\:prose-purple a code {
+      -   .lg\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
 
       ---
 
       -
-      -   .lg\\\\:prose-pink a {
+      -   .lg\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .lg\\\\:prose-pink a code {
+      -   .lg\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -17040,94 +17040,94 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .xl\\\\:prose-2xl {
-      -     font-size: 1.5rem;
-      -     line-height: 1.6666667;
+      -     :where(font-size): 1.5rem;
+      -     :where(line-height): 1.6666667;
       -   }
       -
-      -   .xl\\\\:prose-2xl p {
+      -   .xl\\\\:prose-2xl :where(p) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl [class~='lead'] {
+      -   .xl\\\\:prose-2xl :where([class~='lead']) {
       -     font-size: 1.25em;
       -     line-height: 1.4666667;
       -     margin-top: 1.0666667em;
       -     margin-bottom: 1.0666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl blockquote {
+      -   .xl\\\\:prose-2xl :where(blockquote) {
       -     margin-top: 1.7777778em;
       -     margin-bottom: 1.7777778em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .xl\\\\:prose-2xl h1 {
+      -   .xl\\\\:prose-2xl :where(h1) {
       -     font-size: 2.6666667em;
       -     margin-top: 0;
       -     margin-bottom: 0.875em;
       -     line-height: 1;
       -   }
       -
-      -   .xl\\\\:prose-2xl h2 {
+      -   .xl\\\\:prose-2xl :where(h2) {
       -     font-size: 2em;
       -     margin-top: 1.5em;
       -     margin-bottom: 0.8333333em;
       -     line-height: 1.0833333;
       -   }
       -
-      -   .xl\\\\:prose-2xl h3 {
+      -   .xl\\\\:prose-2xl :where(h3) {
       -     font-size: 1.5em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.2222222;
       -   }
       -
-      -   .xl\\\\:prose-2xl h4 {
+      -   .xl\\\\:prose-2xl :where(h4) {
       -     margin-top: 1.6666667em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.5;
       -   }
       -
-      -   .xl\\\\:prose-2xl img {
+      -   .xl\\\\:prose-2xl :where(img) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .xl\\\\:prose-2xl video {
+      -   .xl\\\\:prose-2xl :where(video) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .xl\\\\:prose-2xl figure {
+      -   .xl\\\\:prose-2xl :where(figure) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .xl\\\\:prose-2xl figure > * {
+      -   .xl\\\\:prose-2xl :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl figure figcaption {
+      -   .xl\\\\:prose-2xl :where(figure figcaption) {
       -     font-size: 0.8333333em;
       -     line-height: 1.6;
       -     margin-top: 1em;
       -   }
       -
-      -   .xl\\\\:prose-2xl code {
+      -   .xl\\\\:prose-2xl :where(code) {
       -     font-size: 0.8333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl h2 code {
+      -   .xl\\\\:prose-2xl :where(h2 code) {
       -     font-size: 0.875em;
       -   }
       -
-      -   .xl\\\\:prose-2xl h3 code {
+      -   .xl\\\\:prose-2xl :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .xl\\\\:prose-2xl pre {
+      -   .xl\\\\:prose-2xl :where(pre) {
       -     font-size: 0.8333333em;
       -     line-height: 1.8;
       -     margin-top: 2em;
@@ -17139,186 +17139,186 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ol {
+      -   .xl\\\\:prose-2xl :where(ol) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ul {
+      -   .xl\\\\:prose-2xl :where(ul) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl li {
+      -   .xl\\\\:prose-2xl :where(li) {
       -     margin-top: 0.5em;
       -     margin-bottom: 0.5em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ol > li {
+      -   .xl\\\\:prose-2xl :where(ol > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ol > li::before {
+      -   .xl\\\\:prose-2xl :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl ul > li {
+      -   .xl\\\\:prose-2xl :where(ul > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ul > li::before {
+      -   .xl\\\\:prose-2xl :where(ul > li::before) {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
       -     left: 0.25em;
       -   }
       -
-      -   .xl\\\\:prose-2xl > ul > li p {
+      -   .xl\\\\:prose-2xl :where(> ul > li p) {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl > ul > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl > ul > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl > ol > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl > ol > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .xl\\\\:prose-2xl ul ul, .xl\\\\:prose-2xl ul ol, .xl\\\\:prose-2xl ol ul, .xl\\\\:prose-2xl ol ol {
+      -   .xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.6666667em;
       -     margin-bottom: 0.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl hr {
+      -   .xl\\\\:prose-2xl :where(hr) {
       -     margin-top: 3em;
       -     margin-bottom: 3em;
       -   }
       -
-      -   .xl\\\\:prose-2xl hr + * {
+      -   .xl\\\\:prose-2xl :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl h2 + * {
+      -   .xl\\\\:prose-2xl :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl h3 + * {
+      -   .xl\\\\:prose-2xl :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl h4 + * {
+      -   .xl\\\\:prose-2xl :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl table {
+      -   .xl\\\\:prose-2xl :where(table) {
       -     font-size: 0.8333333em;
       -     line-height: 1.4;
       -   }
       -
-      -   .xl\\\\:prose-2xl thead th {
+      -   .xl\\\\:prose-2xl :where(thead th) {
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .xl\\\\:prose-2xl thead th:first-child {
+      -   .xl\\\\:prose-2xl :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl thead th:last-child {
+      -   .xl\\\\:prose-2xl :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl tbody td {
+      -   .xl\\\\:prose-2xl :where(tbody td) {
       -     padding-top: 0.8em;
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .xl\\\\:prose-2xl tbody td:first-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl tbody td:last-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl > :first-child {
+      -   .xl\\\\:prose-2xl :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-2xl > :last-child {
+      -   .xl\\\\:prose-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .xl\\\\:prose-red a {
+      -   .xl\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .xl\\\\:prose-red a code {
+      -   .xl\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .xl\\\\:prose-yellow a {
+      -   .xl\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .xl\\\\:prose-yellow a code {
+      -   .xl\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .xl\\\\:prose-green a {
+      -   .xl\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .xl\\\\:prose-green a code {
+      -   .xl\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .xl\\\\:prose-blue a {
+      -   .xl\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .xl\\\\:prose-blue a code {
+      -   .xl\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .xl\\\\:prose-indigo a {
+      -   .xl\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .xl\\\\:prose-indigo a code {
+      -   .xl\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .xl\\\\:prose-purple a {
+      -   .xl\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .xl\\\\:prose-purple a code {
+      -   .xl\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
 
       ---
 
       -
-      -   .xl\\\\:prose-pink a {
+      -   .xl\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .xl\\\\:prose-pink a code {
+      -   .xl\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -17328,96 +17328,96 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl {
-      -     font-size: 1.5rem;
-      -     line-height: 1.6666667;
+      -     :where(font-size): 1.5rem;
+      -     :where(line-height): 1.6666667;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl p {
+      -   .\\\\32xl\\\\:prose-2xl :where(p) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-2xl :where([class~='lead']) {
       -     font-size: 1.25em;
       -     line-height: 1.4666667;
       -     margin-top: 1.0666667em;
       -     margin-bottom: 1.0666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl blockquote {
+      -   .\\\\32xl\\\\:prose-2xl :where(blockquote) {
       -     margin-top: 1.7777778em;
       -     margin-bottom: 1.7777778em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h1 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h1) {
       -     font-size: 2.6666667em;
       -     margin-top: 0;
       -     margin-bottom: 0.875em;
       -     line-height: 1;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h2 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2) {
       -     font-size: 2em;
       -     margin-top: 1.5em;
       -     margin-bottom: 0.8333333em;
       -     line-height: 1.0833333;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h3 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3) {
       -     font-size: 1.5em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.2222222;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h4 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4) {
       -     margin-top: 1.6666667em;
       -     margin-bottom: 0.6666667em;
       -     line-height: 1.5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl img {
+      -   .\\\\32xl\\\\:prose-2xl :where(img) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl video {
+      -   .\\\\32xl\\\\:prose-2xl :where(video) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl figure {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure) {
       -     margin-top: 2em;
       -     margin-bottom: 2em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl figure > * {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure > *) {
       -     margin-top: 0;
 
       ---
 
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl figure figcaption {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure figcaption) {
       -     font-size: 0.8333333em;
       -     line-height: 1.6;
       -     margin-top: 1em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl code {
+      -   .\\\\32xl\\\\:prose-2xl :where(code) {
       -     font-size: 0.8333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h2 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 code) {
       -     font-size: 0.875em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h3 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl pre {
+      -   .\\\\32xl\\\\:prose-2xl :where(pre) {
       -     font-size: 0.8333333em;
       -     line-height: 1.8;
       -     margin-top: 2em;
@@ -17429,182 +17429,182 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ul {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl li {
+      -   .\\\\32xl\\\\:prose-2xl :where(li) {
       -     margin-top: 0.5em;
       -     margin-bottom: 0.5em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ol > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ol > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ul > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li) {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ul > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
       -     left: 0.25em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > ul > li p {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li p) {
       -     margin-top: 0.8333333em;
       -     margin-bottom: 0.8333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
       -     margin-top: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.3333333em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl ul ul, .\\\\32xl\\\\:prose-2xl ul ol, .\\\\32xl\\\\:prose-2xl ol ul, .\\\\32xl\\\\:prose-2xl ol ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.6666667em;
       -     margin-bottom: 0.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl hr {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr) {
       -     margin-top: 3em;
       -     margin-bottom: 3em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl hr + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h2 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h3 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl h4 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl table {
+      -   .\\\\32xl\\\\:prose-2xl :where(table) {
       -     font-size: 0.8333333em;
       -     line-height: 1.4;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl thead th {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th) {
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl thead th:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl thead th:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl tbody td {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td) {
       -     padding-top: 0.8em;
       -     padding-right: 0.6em;
       -     padding-bottom: 0.8em;
       -     padding-left: 0.6em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > :first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl > :last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-red a {
+      -   .\\\\32xl\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-red a code {
+      -   .\\\\32xl\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-yellow a {
+      -   .\\\\32xl\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-yellow a code {
+      -   .\\\\32xl\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-green a {
+      -   .\\\\32xl\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-green a code {
+      -   .\\\\32xl\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-blue a {
+      -   .\\\\32xl\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-blue a code {
+      -   .\\\\32xl\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-indigo a {
+      -   .\\\\32xl\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-indigo a code {
+      -   .\\\\32xl\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-purple a {
+      -   .\\\\32xl\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-purple a code {
+      -   .\\\\32xl\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-pink a {
+      -   .\\\\32xl\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-pink a code {
+      -   .\\\\32xl\\\\:prose-pink :where(a code) {
       -     color: #db2777;
 
     "
@@ -17621,218 +17621,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose [class~='lead'] {
-      + .markdown [class~='lead'] {
+      - .prose :where([class~='lead']) {
+      + .markdown :where([class~='lead']) {
 
       ---
 
-      - .prose a {
-      + .markdown a {
+      - .prose :where(a) {
+      + .markdown :where(a) {
 
       ---
 
-      - .prose strong {
-      + .markdown strong {
+      - .prose :where(strong) {
+      + .markdown :where(strong) {
 
       ---
 
-      - .prose ol[type='A'] {
-      + .markdown ol[type='A'] {
+      - .prose :where(ol[type='A']) {
+      + .markdown :where(ol[type='A']) {
 
       ---
 
-      - .prose ol[type='a'] {
-      + .markdown ol[type='a'] {
+      - .prose :where(ol[type='a']) {
+      + .markdown :where(ol[type='a']) {
 
       ---
 
-      - .prose ol[type='A' s] {
-      + .markdown ol[type='A' s] {
+      - .prose :where(ol[type='A' s]) {
+      + .markdown :where(ol[type='A' s]) {
 
       ---
 
-      - .prose ol[type='a' s] {
-      + .markdown ol[type='a' s] {
+      - .prose :where(ol[type='a' s]) {
+      + .markdown :where(ol[type='a' s]) {
 
       ---
 
-      - .prose ol[type='I'] {
-      + .markdown ol[type='I'] {
+      - .prose :where(ol[type='I']) {
+      + .markdown :where(ol[type='I']) {
 
       ---
 
-      - .prose ol[type='i'] {
-      + .markdown ol[type='i'] {
+      - .prose :where(ol[type='i']) {
+      + .markdown :where(ol[type='i']) {
 
       ---
 
-      - .prose ol[type='I' s] {
-      + .markdown ol[type='I' s] {
+      - .prose :where(ol[type='I' s]) {
+      + .markdown :where(ol[type='I' s]) {
 
       ---
 
-      - .prose ol[type='i' s] {
-      + .markdown ol[type='i' s] {
+      - .prose :where(ol[type='i' s]) {
+      + .markdown :where(ol[type='i' s]) {
 
       ---
 
-      - .prose ol[type='1'] {
-      + .markdown ol[type='1'] {
+      - .prose :where(ol[type='1']) {
+      + .markdown :where(ol[type='1']) {
 
       ---
 
-      - .prose ol > li {
-      + .markdown ol > li {
+      - .prose :where(ol > li) {
+      + .markdown :where(ol > li) {
 
       ---
 
-      - .prose ol > li::before {
-      + .markdown ol > li::before {
+      - .prose :where(ol > li::before) {
+      + .markdown :where(ol > li::before) {
 
       ---
 
-      - .prose ul > li {
-      + .markdown ul > li {
+      - .prose :where(ul > li) {
+      + .markdown :where(ul > li) {
 
       ---
 
-      - .prose ul > li::before {
-      + .markdown ul > li::before {
+      - .prose :where(ul > li::before) {
+      + .markdown :where(ul > li::before) {
 
       ---
 
-      - .prose hr {
-      + .markdown hr {
+      - .prose :where(hr) {
+      + .markdown :where(hr) {
 
       ---
 
-      - .prose blockquote {
-      + .markdown blockquote {
+      - .prose :where(blockquote) {
+      + .markdown :where(blockquote) {
 
       ---
 
-      - .prose blockquote p:first-of-type::before {
-      + .markdown blockquote p:first-of-type::before {
+      - .prose :where(blockquote p:first-of-type::before) {
+      + .markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      - .prose blockquote p:last-of-type::after {
-      + .markdown blockquote p:last-of-type::after {
+      - .prose :where(blockquote p:last-of-type::after) {
+      + .markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      - .prose h1 {
-      + .markdown h1 {
+      - .prose :where(h1) {
+      + .markdown :where(h1) {
 
       ---
 
-      - .prose h1 strong {
-      + .markdown h1 strong {
+      - .prose :where(h1 strong) {
+      + .markdown :where(h1 strong) {
 
       ---
 
-      - .prose h2 {
-      + .markdown h2 {
+      - .prose :where(h2) {
+      + .markdown :where(h2) {
 
       ---
 
-      - .prose h2 strong {
-      + .markdown h2 strong {
+      - .prose :where(h2 strong) {
+      + .markdown :where(h2 strong) {
 
       ---
 
-      - .prose h3 {
-      + .markdown h3 {
+      - .prose :where(h3) {
+      + .markdown :where(h3) {
 
       ---
 
-      - .prose h3 strong {
-      + .markdown h3 strong {
+      - .prose :where(h3 strong) {
+      + .markdown :where(h3 strong) {
 
       ---
 
-      - .prose h4 {
-      + .markdown h4 {
+      - .prose :where(h4) {
+      + .markdown :where(h4) {
 
       ---
 
-      - .prose h4 strong {
-      + .markdown h4 strong {
+      - .prose :where(h4 strong) {
+      + .markdown :where(h4 strong) {
 
       ---
 
-      - .prose figure figcaption {
-      + .markdown figure figcaption {
+      - .prose :where(figure figcaption) {
+      + .markdown :where(figure figcaption) {
 
       ---
 
-      - .prose code {
-      + .markdown code {
+      - .prose :where(code) {
+      + .markdown :where(code) {
 
       ---
 
-      - .prose code::before {
-      + .markdown code::before {
+      - .prose :where(code::before) {
+      + .markdown :where(code::before) {
 
       ---
 
-      - .prose code::after {
-      + .markdown code::after {
+      - .prose :where(code::after) {
+      + .markdown :where(code::after) {
 
       ---
 
-      - .prose a code {
-      + .markdown a code {
+      - .prose :where(a code) {
+      + .markdown :where(a code) {
 
       ---
 
-      - .prose pre {
-      + .markdown pre {
+      - .prose :where(pre) {
+      + .markdown :where(pre) {
 
       ---
 
-      - .prose pre code {
-      + .markdown pre code {
+      - .prose :where(pre code) {
+      + .markdown :where(pre code) {
 
       ---
 
-      - .prose pre code::before {
-      + .markdown pre code::before {
+      - .prose :where(pre code::before) {
+      + .markdown :where(pre code::before) {
 
       ---
 
-      - .prose pre code::after {
-      + .markdown pre code::after {
+      - .prose :where(pre code::after) {
+      + .markdown :where(pre code::after) {
 
       ---
 
-      - .prose table {
-      + .markdown table {
+      - .prose :where(table) {
+      + .markdown :where(table) {
 
       ---
 
-      - .prose thead {
-      + .markdown thead {
+      - .prose :where(thead) {
+      + .markdown :where(thead) {
 
       ---
 
-      - .prose thead th {
-      + .markdown thead th {
+      - .prose :where(thead th) {
+      + .markdown :where(thead th) {
 
       ---
 
-      - .prose tbody tr {
-      + .markdown tbody tr {
+      - .prose :where(tbody tr) {
+      + .markdown :where(tbody tr) {
 
       ---
 
-      - .prose tbody tr:last-child {
-      + .markdown tbody tr:last-child {
+      - .prose :where(tbody tr:last-child) {
+      + .markdown :where(tbody tr:last-child) {
 
       ---
 
-      - .prose tbody td {
-      + .markdown tbody td {
+      - .prose :where(tbody td) {
+      + .markdown :where(tbody td) {
 
       ---
 
@@ -17841,152 +17841,152 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose p {
-      + .markdown p {
+      - .prose :where(p) {
+      + .markdown :where(p) {
 
       ---
 
-      - .prose img {
-      + .markdown img {
+      - .prose :where(img) {
+      + .markdown :where(img) {
 
       ---
 
-      - .prose video {
-      + .markdown video {
+      - .prose :where(video) {
+      + .markdown :where(video) {
 
       ---
 
-      - .prose figure {
-      + .markdown figure {
+      - .prose :where(figure) {
+      + .markdown :where(figure) {
 
       ---
 
-      - .prose figure > * {
-      + .markdown figure > * {
+      - .prose :where(figure > *) {
+      + .markdown :where(figure > *) {
 
       ---
 
-      - .prose h2 code {
-      + .markdown h2 code {
+      - .prose :where(h2 code) {
+      + .markdown :where(h2 code) {
 
       ---
 
-      - .prose h3 code {
-      + .markdown h3 code {
+      - .prose :where(h3 code) {
+      + .markdown :where(h3 code) {
 
       ---
 
-      - .prose ol {
-      + .markdown ol {
+      - .prose :where(ol) {
+      + .markdown :where(ol) {
 
       ---
 
-      - .prose ul {
-      + .markdown ul {
+      - .prose :where(ul) {
+      + .markdown :where(ul) {
 
       ---
 
-      - .prose li {
-      + .markdown li {
+      - .prose :where(li) {
+      + .markdown :where(li) {
 
       ---
 
-      - .prose > ul > li p {
-      + .markdown > ul > li p {
+      - .prose :where(> ul > li p) {
+      + .markdown :where(> ul > li p) {
 
       ---
 
-      - .prose > ul > li > *:first-child {
-      + .markdown > ul > li > *:first-child {
+      - .prose :where(> ul > li > *:first-child) {
+      + .markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose > ul > li > *:last-child {
-      + .markdown > ul > li > *:last-child {
+      - .prose :where(> ul > li > *:last-child) {
+      + .markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose > ol > li > *:first-child {
-      + .markdown > ol > li > *:first-child {
+      - .prose :where(> ol > li > *:first-child) {
+      + .markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose > ol > li > *:last-child {
-      + .markdown > ol > li > *:last-child {
+      - .prose :where(> ol > li > *:last-child) {
+      + .markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
-      + .markdown ul ul, .markdown ul ol, .markdown ol ul, .markdown ol ol {
+      - .prose :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
       - }
       -
-      - .prose hr + * {
+      - .prose :where(hr + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose h2 + * {
+      - .prose :where(h2 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose h3 + * {
+      - .prose :where(h3 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose h4 + * {
+      - .prose :where(h4 + *) {
       -   margin-top: 0;
       - }
       -
-      - .prose thead th:first-child {
+      - .prose :where(thead th:first-child) {
       -   padding-left: 0;
       - }
       -
-      - .prose thead th:last-child {
+      - .prose :where(thead th:last-child) {
       -   padding-right: 0;
       - }
       -
-      - .prose tbody td:first-child {
+      - .prose :where(tbody td:first-child) {
       -   padding-left: 0;
       - }
       -
-      - .prose tbody td:last-child {
+      - .prose :where(tbody td:last-child) {
       -   padding-right: 0;
       - }
       -
-      - .prose > :first-child {
+      - .prose :where(> :first-child) {
       -   margin-top: 0;
       - }
       -
-      - .prose > :last-child {
+      - .prose :where(> :last-child) {
       -   margin-bottom: 0;
       - }
       -
       - .prose-sm {
-      -   font-size: 0.875rem;
-      -   line-height: 1.7142857;
+      -   :where(font-size): 0.875rem;
+      -   :where(line-height): 1.7142857;
       - }
       -
-      - .prose-sm p {
+      - .prose-sm :where(p) {
       -   margin-top: 1.1428571em;
       -   margin-bottom: 1.1428571em;
       - }
       -
-      - .prose-sm [class~='lead'] {
+      - .prose-sm :where([class~='lead']) {
       -   font-size: 1.2857143em;
       -   line-height: 1.5555556;
       -   margin-top: 0.8888889em;
       -   margin-bottom: 0.8888889em;
       - }
       -
-      - .prose-sm blockquote {
+      - .prose-sm :where(blockquote) {
       -   margin-top: 1.3333333em;
       -   margin-bottom: 1.3333333em;
       -   padding-left: 1.1111111em;
       - }
       -
-      - .prose-sm h1 {
+      - .prose-sm :where(h1) {
       -   font-size: 2.1428571em;
       -   margin-top: 0;
       -   margin-bottom: 0.8em;
@@ -17994,65 +17994,65 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-sm h2 {
+      - .prose-sm :where(h2) {
       -   font-size: 1.4285714em;
       -   margin-top: 1.6em;
       -   margin-bottom: 0.8em;
       -   line-height: 1.4;
       - }
       -
-      - .prose-sm h3 {
+      - .prose-sm :where(h3) {
       -   font-size: 1.2857143em;
       -   margin-top: 1.5555556em;
       -   margin-bottom: 0.4444444em;
       -   line-height: 1.5555556;
       - }
       -
-      - .prose-sm h4 {
+      - .prose-sm :where(h4) {
       -   margin-top: 1.4285714em;
       -   margin-bottom: 0.5714286em;
       -   line-height: 1.4285714;
       - }
       -
-      - .prose-sm img {
+      - .prose-sm :where(img) {
       -   margin-top: 1.7142857em;
       -   margin-bottom: 1.7142857em;
       - }
       -
-      - .prose-sm video {
+      - .prose-sm :where(video) {
       -   margin-top: 1.7142857em;
       -   margin-bottom: 1.7142857em;
       - }
       -
-      - .prose-sm figure {
+      - .prose-sm :where(figure) {
       -   margin-top: 1.7142857em;
       -   margin-bottom: 1.7142857em;
       - }
       -
-      - .prose-sm figure > * {
+      - .prose-sm :where(figure > *) {
       -   margin-top: 0;
       -   margin-bottom: 0;
       - }
       -
-      - .prose-sm figure figcaption {
+      - .prose-sm :where(figure figcaption) {
       -   font-size: 0.8571429em;
       -   line-height: 1.3333333;
       -   margin-top: 0.6666667em;
       - }
       -
-      - .prose-sm code {
+      - .prose-sm :where(code) {
       -   font-size: 0.8571429em;
       - }
       -
-      - .prose-sm h2 code {
+      - .prose-sm :where(h2 code) {
       -   font-size: 0.9em;
       - }
       -
-      - .prose-sm h3 code {
+      - .prose-sm :where(h3 code) {
       -   font-size: 0.8888889em;
       - }
       -
-      - .prose-sm pre {
+      - .prose-sm :where(pre) {
       -   font-size: 0.8571429em;
       -   line-height: 1.6666667;
       -   margin-top: 1.6666667em;
@@ -18064,136 +18064,136 @@ it('should be possible to change the default modifiers and change the className'
       -   padding-left: 1em;
       - }
       -
-      - .prose-sm ol {
+      - .prose-sm :where(ol) {
       -   margin-top: 1.1428571em;
       -   margin-bottom: 1.1428571em;
       - }
       -
-      - .prose-sm ul {
+      - .prose-sm :where(ul) {
       -   margin-top: 1.1428571em;
       -   margin-bottom: 1.1428571em;
       - }
       -
-      - .prose-sm li {
+      - .prose-sm :where(li) {
       -   margin-top: 0.2857143em;
       -   margin-bottom: 0.2857143em;
       - }
       -
-      - .prose-sm ol > li {
+      - .prose-sm :where(ol > li) {
       -   padding-left: 1.5714286em;
       - }
       -
-      - .prose-sm ol > li::before {
+      - .prose-sm :where(ol > li::before) {
       -   left: 0;
       - }
       -
-      - .prose-sm ul > li {
+      - .prose-sm :where(ul > li) {
       -   padding-left: 1.5714286em;
       - }
       -
-      - .prose-sm ul > li::before {
+      - .prose-sm :where(ul > li::before) {
       -   height: 0.3571429em;
       -   width: 0.3571429em;
       -   top: calc(0.8571429em - 0.1785714em);
       -   left: 0.2142857em;
       - }
       -
-      - .prose-sm > ul > li p {
+      - .prose-sm :where(> ul > li p) {
       -   margin-top: 0.5714286em;
       -   margin-bottom: 0.5714286em;
       - }
       -
-      - .prose-sm > ul > li > *:first-child {
+      - .prose-sm :where(> ul > li > *:first-child) {
       -   margin-top: 1.1428571em;
       - }
       -
-      - .prose-sm > ul > li > *:last-child {
+      - .prose-sm :where(> ul > li > *:last-child) {
       -   margin-bottom: 1.1428571em;
       - }
       -
-      - .prose-sm > ol > li > *:first-child {
+      - .prose-sm :where(> ol > li > *:first-child) {
       -   margin-top: 1.1428571em;
       - }
       -
-      - .prose-sm > ol > li > *:last-child {
+      - .prose-sm :where(> ol > li > *:last-child) {
       -   margin-bottom: 1.1428571em;
       - }
       -
-      - .prose-sm ul ul, .prose-sm ul ol, .prose-sm ol ul, .prose-sm ol ol {
+      - .prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -   margin-top: 0.5714286em;
       -   margin-bottom: 0.5714286em;
       - }
       -
-      - .prose-sm hr {
+      - .prose-sm :where(hr) {
       -   margin-top: 2.8571429em;
       -   margin-bottom: 2.8571429em;
       - }
       -
-      - .prose-sm hr + * {
-      + .markdown hr + * {
+      - .prose-sm :where(hr + *) {
+      + .markdown :where(hr + *) {
 
       ---
 
-      - .prose-sm h2 + * {
-      + .markdown h2 + * {
+      - .prose-sm :where(h2 + *) {
+      + .markdown :where(h2 + *) {
 
       ---
 
-      - .prose-sm h3 + * {
-      + .markdown h3 + * {
+      - .prose-sm :where(h3 + *) {
+      + .markdown :where(h3 + *) {
 
       ---
 
-      - .prose-sm h4 + * {
-      + .markdown h4 + * {
+      - .prose-sm :where(h4 + *) {
+      + .markdown :where(h4 + *) {
 
       ---
 
-      - .prose-sm table {
+      - .prose-sm :where(table) {
       -   font-size: 0.8571429em;
       -   line-height: 1.5;
       - }
       -
-      - .prose-sm thead th {
+      - .prose-sm :where(thead th) {
       -   padding-right: 1em;
       -   padding-bottom: 0.6666667em;
       -   padding-left: 1em;
       - }
       -
-      - .prose-sm thead th:first-child {
-      + .markdown thead th:first-child {
+      - .prose-sm :where(thead th:first-child) {
+      + .markdown :where(thead th:first-child) {
 
       ---
 
-      - .prose-sm thead th:last-child {
-      + .markdown thead th:last-child {
+      - .prose-sm :where(thead th:last-child) {
+      + .markdown :where(thead th:last-child) {
 
       ---
 
-      - .prose-sm tbody td {
+      - .prose-sm :where(tbody td) {
       -   padding-top: 0.6666667em;
       -   padding-right: 1em;
       -   padding-bottom: 0.6666667em;
       -   padding-left: 1em;
       - }
       -
-      - .prose-sm tbody td:first-child {
-      + .markdown tbody td:first-child {
+      - .prose-sm :where(tbody td:first-child) {
+      + .markdown :where(tbody td:first-child) {
 
       ---
 
-      - .prose-sm tbody td:last-child {
-      + .markdown tbody td:last-child {
+      - .prose-sm :where(tbody td:last-child) {
+      + .markdown :where(tbody td:last-child) {
 
       ---
 
-      - .prose-sm > :first-child {
-      + .markdown > :first-child {
+      - .prose-sm :where(> :first-child) {
+      + .markdown :where(> :first-child) {
 
       ---
 
-      - .prose-sm > :last-child {
-      + .markdown > :last-child {
+      - .prose-sm :where(> :last-child) {
+      + .markdown :where(> :last-child) {
 
       ---
 
@@ -18202,218 +18202,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-lg p {
-      + .markdown-lg p {
+      - .prose-lg :where(p) {
+      + .markdown-lg :where(p) {
 
       ---
 
-      - .prose-lg [class~='lead'] {
-      + .markdown-lg [class~='lead'] {
+      - .prose-lg :where([class~='lead']) {
+      + .markdown-lg :where([class~='lead']) {
 
       ---
 
-      - .prose-lg blockquote {
-      + .markdown-lg blockquote {
+      - .prose-lg :where(blockquote) {
+      + .markdown-lg :where(blockquote) {
 
       ---
 
-      - .prose-lg h1 {
-      + .markdown-lg h1 {
+      - .prose-lg :where(h1) {
+      + .markdown-lg :where(h1) {
 
       ---
 
-      - .prose-lg h2 {
-      + .markdown-lg h2 {
+      - .prose-lg :where(h2) {
+      + .markdown-lg :where(h2) {
 
       ---
 
-      - .prose-lg h3 {
-      + .markdown-lg h3 {
+      - .prose-lg :where(h3) {
+      + .markdown-lg :where(h3) {
 
       ---
 
-      - .prose-lg h4 {
-      + .markdown-lg h4 {
+      - .prose-lg :where(h4) {
+      + .markdown-lg :where(h4) {
 
       ---
 
-      - .prose-lg img {
-      + .markdown-lg img {
+      - .prose-lg :where(img) {
+      + .markdown-lg :where(img) {
 
       ---
 
-      - .prose-lg video {
-      + .markdown-lg video {
+      - .prose-lg :where(video) {
+      + .markdown-lg :where(video) {
 
       ---
 
-      - .prose-lg figure {
-      + .markdown-lg figure {
+      - .prose-lg :where(figure) {
+      + .markdown-lg :where(figure) {
 
       ---
 
-      - .prose-lg figure > * {
-      + .markdown-lg figure > * {
+      - .prose-lg :where(figure > *) {
+      + .markdown-lg :where(figure > *) {
 
       ---
 
-      - .prose-lg figure figcaption {
-      + .markdown-lg figure figcaption {
+      - .prose-lg :where(figure figcaption) {
+      + .markdown-lg :where(figure figcaption) {
 
       ---
 
-      - .prose-lg code {
-      + .markdown-lg code {
+      - .prose-lg :where(code) {
+      + .markdown-lg :where(code) {
 
       ---
 
-      - .prose-lg h2 code {
-      + .markdown-lg h2 code {
+      - .prose-lg :where(h2 code) {
+      + .markdown-lg :where(h2 code) {
 
       ---
 
-      - .prose-lg h3 code {
-      + .markdown-lg h3 code {
+      - .prose-lg :where(h3 code) {
+      + .markdown-lg :where(h3 code) {
 
       ---
 
-      - .prose-lg pre {
-      + .markdown-lg pre {
+      - .prose-lg :where(pre) {
+      + .markdown-lg :where(pre) {
 
       ---
 
-      - .prose-lg ol {
-      + .markdown-lg ol {
+      - .prose-lg :where(ol) {
+      + .markdown-lg :where(ol) {
 
       ---
 
-      - .prose-lg ul {
-      + .markdown-lg ul {
+      - .prose-lg :where(ul) {
+      + .markdown-lg :where(ul) {
 
       ---
 
-      - .prose-lg li {
-      + .markdown-lg li {
+      - .prose-lg :where(li) {
+      + .markdown-lg :where(li) {
 
       ---
 
-      - .prose-lg ol > li {
-      + .markdown-lg ol > li {
+      - .prose-lg :where(ol > li) {
+      + .markdown-lg :where(ol > li) {
 
       ---
 
-      - .prose-lg ol > li::before {
-      + .markdown-lg ol > li::before {
+      - .prose-lg :where(ol > li::before) {
+      + .markdown-lg :where(ol > li::before) {
 
       ---
 
-      - .prose-lg ul > li {
-      + .markdown-lg ul > li {
+      - .prose-lg :where(ul > li) {
+      + .markdown-lg :where(ul > li) {
 
       ---
 
-      - .prose-lg ul > li::before {
-      + .markdown-lg ul > li::before {
+      - .prose-lg :where(ul > li::before) {
+      + .markdown-lg :where(ul > li::before) {
 
       ---
 
-      - .prose-lg > ul > li p {
-      + .markdown-lg > ul > li p {
+      - .prose-lg :where(> ul > li p) {
+      + .markdown-lg :where(> ul > li p) {
 
       ---
 
-      - .prose-lg > ul > li > *:first-child {
-      + .markdown-lg > ul > li > *:first-child {
+      - .prose-lg :where(> ul > li > *:first-child) {
+      + .markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-lg > ul > li > *:last-child {
-      + .markdown-lg > ul > li > *:last-child {
+      - .prose-lg :where(> ul > li > *:last-child) {
+      + .markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-lg > ol > li > *:first-child {
-      + .markdown-lg > ol > li > *:first-child {
+      - .prose-lg :where(> ol > li > *:first-child) {
+      + .markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-lg > ol > li > *:last-child {
-      + .markdown-lg > ol > li > *:last-child {
+      - .prose-lg :where(> ol > li > *:last-child) {
+      + .markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
-      + .markdown-lg ul ul, .markdown-lg ul ol, .markdown-lg ol ul, .markdown-lg ol ol {
+      - .prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-lg hr {
-      + .markdown-lg hr {
+      - .prose-lg :where(hr) {
+      + .markdown-lg :where(hr) {
 
       ---
 
-      - .prose-lg hr + * {
-      + .markdown-lg hr + * {
+      - .prose-lg :where(hr + *) {
+      + .markdown-lg :where(hr + *) {
 
       ---
 
-      - .prose-lg h2 + * {
-      + .markdown-lg h2 + * {
+      - .prose-lg :where(h2 + *) {
+      + .markdown-lg :where(h2 + *) {
 
       ---
 
-      - .prose-lg h3 + * {
-      + .markdown-lg h3 + * {
+      - .prose-lg :where(h3 + *) {
+      + .markdown-lg :where(h3 + *) {
 
       ---
 
-      - .prose-lg h4 + * {
-      + .markdown-lg h4 + * {
+      - .prose-lg :where(h4 + *) {
+      + .markdown-lg :where(h4 + *) {
 
       ---
 
-      - .prose-lg table {
-      + .markdown-lg table {
+      - .prose-lg :where(table) {
+      + .markdown-lg :where(table) {
 
       ---
 
-      - .prose-lg thead th {
-      + .markdown-lg thead th {
+      - .prose-lg :where(thead th) {
+      + .markdown-lg :where(thead th) {
 
       ---
 
-      - .prose-lg thead th:first-child {
-      + .markdown-lg thead th:first-child {
+      - .prose-lg :where(thead th:first-child) {
+      + .markdown-lg :where(thead th:first-child) {
 
       ---
 
-      - .prose-lg thead th:last-child {
-      + .markdown-lg thead th:last-child {
+      - .prose-lg :where(thead th:last-child) {
+      + .markdown-lg :where(thead th:last-child) {
 
       ---
 
-      - .prose-lg tbody td {
-      + .markdown-lg tbody td {
+      - .prose-lg :where(tbody td) {
+      + .markdown-lg :where(tbody td) {
 
       ---
 
-      - .prose-lg tbody td:first-child {
-      + .markdown-lg tbody td:first-child {
+      - .prose-lg :where(tbody td:first-child) {
+      + .markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      - .prose-lg tbody td:last-child {
-      + .markdown-lg tbody td:last-child {
+      - .prose-lg :where(tbody td:last-child) {
+      + .markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      - .prose-lg > :first-child {
-      + .markdown-lg > :first-child {
+      - .prose-lg :where(> :first-child) {
+      + .markdown-lg :where(> :first-child) {
 
       ---
 
-      - .prose-lg > :last-child {
-      + .markdown-lg > :last-child {
+      - .prose-lg :where(> :last-child) {
+      + .markdown-lg :where(> :last-child) {
 
       ---
 
@@ -18422,218 +18422,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-xl p {
-      + .markdown-xl p {
+      - .prose-xl :where(p) {
+      + .markdown-xl :where(p) {
 
       ---
 
-      - .prose-xl [class~='lead'] {
-      + .markdown-xl [class~='lead'] {
+      - .prose-xl :where([class~='lead']) {
+      + .markdown-xl :where([class~='lead']) {
 
       ---
 
-      - .prose-xl blockquote {
-      + .markdown-xl blockquote {
+      - .prose-xl :where(blockquote) {
+      + .markdown-xl :where(blockquote) {
 
       ---
 
-      - .prose-xl h1 {
-      + .markdown-xl h1 {
+      - .prose-xl :where(h1) {
+      + .markdown-xl :where(h1) {
 
       ---
 
-      - .prose-xl h2 {
-      + .markdown-xl h2 {
+      - .prose-xl :where(h2) {
+      + .markdown-xl :where(h2) {
 
       ---
 
-      - .prose-xl h3 {
-      + .markdown-xl h3 {
+      - .prose-xl :where(h3) {
+      + .markdown-xl :where(h3) {
 
       ---
 
-      - .prose-xl h4 {
-      + .markdown-xl h4 {
+      - .prose-xl :where(h4) {
+      + .markdown-xl :where(h4) {
 
       ---
 
-      - .prose-xl img {
-      + .markdown-xl img {
+      - .prose-xl :where(img) {
+      + .markdown-xl :where(img) {
 
       ---
 
-      - .prose-xl video {
-      + .markdown-xl video {
+      - .prose-xl :where(video) {
+      + .markdown-xl :where(video) {
 
       ---
 
-      - .prose-xl figure {
-      + .markdown-xl figure {
+      - .prose-xl :where(figure) {
+      + .markdown-xl :where(figure) {
 
       ---
 
-      - .prose-xl figure > * {
-      + .markdown-xl figure > * {
+      - .prose-xl :where(figure > *) {
+      + .markdown-xl :where(figure > *) {
 
       ---
 
-      - .prose-xl figure figcaption {
-      + .markdown-xl figure figcaption {
+      - .prose-xl :where(figure figcaption) {
+      + .markdown-xl :where(figure figcaption) {
 
       ---
 
-      - .prose-xl code {
-      + .markdown-xl code {
+      - .prose-xl :where(code) {
+      + .markdown-xl :where(code) {
 
       ---
 
-      - .prose-xl h2 code {
-      + .markdown-xl h2 code {
+      - .prose-xl :where(h2 code) {
+      + .markdown-xl :where(h2 code) {
 
       ---
 
-      - .prose-xl h3 code {
-      + .markdown-xl h3 code {
+      - .prose-xl :where(h3 code) {
+      + .markdown-xl :where(h3 code) {
 
       ---
 
-      - .prose-xl pre {
-      + .markdown-xl pre {
+      - .prose-xl :where(pre) {
+      + .markdown-xl :where(pre) {
 
       ---
 
-      - .prose-xl ol {
-      + .markdown-xl ol {
+      - .prose-xl :where(ol) {
+      + .markdown-xl :where(ol) {
 
       ---
 
-      - .prose-xl ul {
-      + .markdown-xl ul {
+      - .prose-xl :where(ul) {
+      + .markdown-xl :where(ul) {
 
       ---
 
-      - .prose-xl li {
-      + .markdown-xl li {
+      - .prose-xl :where(li) {
+      + .markdown-xl :where(li) {
 
       ---
 
-      - .prose-xl ol > li {
-      + .markdown-xl ol > li {
+      - .prose-xl :where(ol > li) {
+      + .markdown-xl :where(ol > li) {
 
       ---
 
-      - .prose-xl ol > li::before {
-      + .markdown-xl ol > li::before {
+      - .prose-xl :where(ol > li::before) {
+      + .markdown-xl :where(ol > li::before) {
 
       ---
 
-      - .prose-xl ul > li {
-      + .markdown-xl ul > li {
+      - .prose-xl :where(ul > li) {
+      + .markdown-xl :where(ul > li) {
 
       ---
 
-      - .prose-xl ul > li::before {
-      + .markdown-xl ul > li::before {
+      - .prose-xl :where(ul > li::before) {
+      + .markdown-xl :where(ul > li::before) {
 
       ---
 
-      - .prose-xl > ul > li p {
-      + .markdown-xl > ul > li p {
+      - .prose-xl :where(> ul > li p) {
+      + .markdown-xl :where(> ul > li p) {
 
       ---
 
-      - .prose-xl > ul > li > *:first-child {
-      + .markdown-xl > ul > li > *:first-child {
+      - .prose-xl :where(> ul > li > *:first-child) {
+      + .markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-xl > ul > li > *:last-child {
-      + .markdown-xl > ul > li > *:last-child {
+      - .prose-xl :where(> ul > li > *:last-child) {
+      + .markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-xl > ol > li > *:first-child {
-      + .markdown-xl > ol > li > *:first-child {
+      - .prose-xl :where(> ol > li > *:first-child) {
+      + .markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-xl > ol > li > *:last-child {
-      + .markdown-xl > ol > li > *:last-child {
+      - .prose-xl :where(> ol > li > *:last-child) {
+      + .markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-xl ul ul, .prose-xl ul ol, .prose-xl ol ul, .prose-xl ol ol {
-      + .markdown-xl ul ul, .markdown-xl ul ol, .markdown-xl ol ul, .markdown-xl ol ol {
+      - .prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-xl hr {
-      + .markdown-xl hr {
+      - .prose-xl :where(hr) {
+      + .markdown-xl :where(hr) {
 
       ---
 
-      - .prose-xl hr + * {
-      + .markdown-xl hr + * {
+      - .prose-xl :where(hr + *) {
+      + .markdown-xl :where(hr + *) {
 
       ---
 
-      - .prose-xl h2 + * {
-      + .markdown-xl h2 + * {
+      - .prose-xl :where(h2 + *) {
+      + .markdown-xl :where(h2 + *) {
 
       ---
 
-      - .prose-xl h3 + * {
-      + .markdown-xl h3 + * {
+      - .prose-xl :where(h3 + *) {
+      + .markdown-xl :where(h3 + *) {
 
       ---
 
-      - .prose-xl h4 + * {
-      + .markdown-xl h4 + * {
+      - .prose-xl :where(h4 + *) {
+      + .markdown-xl :where(h4 + *) {
 
       ---
 
-      - .prose-xl table {
-      + .markdown-xl table {
+      - .prose-xl :where(table) {
+      + .markdown-xl :where(table) {
 
       ---
 
-      - .prose-xl thead th {
-      + .markdown-xl thead th {
+      - .prose-xl :where(thead th) {
+      + .markdown-xl :where(thead th) {
 
       ---
 
-      - .prose-xl thead th:first-child {
-      + .markdown-xl thead th:first-child {
+      - .prose-xl :where(thead th:first-child) {
+      + .markdown-xl :where(thead th:first-child) {
 
       ---
 
-      - .prose-xl thead th:last-child {
-      + .markdown-xl thead th:last-child {
+      - .prose-xl :where(thead th:last-child) {
+      + .markdown-xl :where(thead th:last-child) {
 
       ---
 
-      - .prose-xl tbody td {
-      + .markdown-xl tbody td {
+      - .prose-xl :where(tbody td) {
+      + .markdown-xl :where(tbody td) {
 
       ---
 
-      - .prose-xl tbody td:first-child {
-      + .markdown-xl tbody td:first-child {
+      - .prose-xl :where(tbody td:first-child) {
+      + .markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      - .prose-xl tbody td:last-child {
-      + .markdown-xl tbody td:last-child {
+      - .prose-xl :where(tbody td:last-child) {
+      + .markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      - .prose-xl > :first-child {
-      + .markdown-xl > :first-child {
+      - .prose-xl :where(> :first-child) {
+      + .markdown-xl :where(> :first-child) {
 
       ---
 
-      - .prose-xl > :last-child {
-      + .markdown-xl > :last-child {
+      - .prose-xl :where(> :last-child) {
+      + .markdown-xl :where(> :last-child) {
 
       ---
 
@@ -18642,277 +18642,277 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-2xl p {
-      + .markdown-2xl p {
+      - .prose-2xl :where(p) {
+      + .markdown-2xl :where(p) {
 
       ---
 
-      - .prose-2xl [class~='lead'] {
-      + .markdown-2xl [class~='lead'] {
+      - .prose-2xl :where([class~='lead']) {
+      + .markdown-2xl :where([class~='lead']) {
 
       ---
 
-      - .prose-2xl blockquote {
-      + .markdown-2xl blockquote {
+      - .prose-2xl :where(blockquote) {
+      + .markdown-2xl :where(blockquote) {
 
       ---
 
-      - .prose-2xl h1 {
-      + .markdown-2xl h1 {
+      - .prose-2xl :where(h1) {
+      + .markdown-2xl :where(h1) {
 
       ---
 
-      - .prose-2xl h2 {
-      + .markdown-2xl h2 {
+      - .prose-2xl :where(h2) {
+      + .markdown-2xl :where(h2) {
 
       ---
 
-      - .prose-2xl h3 {
-      + .markdown-2xl h3 {
+      - .prose-2xl :where(h3) {
+      + .markdown-2xl :where(h3) {
 
       ---
 
-      - .prose-2xl h4 {
-      + .markdown-2xl h4 {
+      - .prose-2xl :where(h4) {
+      + .markdown-2xl :where(h4) {
 
       ---
 
-      - .prose-2xl img {
-      + .markdown-2xl img {
+      - .prose-2xl :where(img) {
+      + .markdown-2xl :where(img) {
 
       ---
 
-      - .prose-2xl video {
-      + .markdown-2xl video {
+      - .prose-2xl :where(video) {
+      + .markdown-2xl :where(video) {
 
       ---
 
-      - .prose-2xl figure {
-      + .markdown-2xl figure {
+      - .prose-2xl :where(figure) {
+      + .markdown-2xl :where(figure) {
 
       ---
 
-      - .prose-2xl figure > * {
-      + .markdown-2xl figure > * {
+      - .prose-2xl :where(figure > *) {
+      + .markdown-2xl :where(figure > *) {
 
       ---
 
-      - .prose-2xl figure figcaption {
-      + .markdown-2xl figure figcaption {
+      - .prose-2xl :where(figure figcaption) {
+      + .markdown-2xl :where(figure figcaption) {
 
       ---
 
-      - .prose-2xl code {
-      + .markdown-2xl code {
+      - .prose-2xl :where(code) {
+      + .markdown-2xl :where(code) {
 
       ---
 
-      - .prose-2xl h2 code {
-      + .markdown-2xl h2 code {
+      - .prose-2xl :where(h2 code) {
+      + .markdown-2xl :where(h2 code) {
 
       ---
 
-      - .prose-2xl h3 code {
-      + .markdown-2xl h3 code {
+      - .prose-2xl :where(h3 code) {
+      + .markdown-2xl :where(h3 code) {
 
       ---
 
-      - .prose-2xl pre {
-      + .markdown-2xl pre {
+      - .prose-2xl :where(pre) {
+      + .markdown-2xl :where(pre) {
 
       ---
 
-      - .prose-2xl ol {
-      + .markdown-2xl ol {
+      - .prose-2xl :where(ol) {
+      + .markdown-2xl :where(ol) {
 
       ---
 
-      - .prose-2xl ul {
-      + .markdown-2xl ul {
+      - .prose-2xl :where(ul) {
+      + .markdown-2xl :where(ul) {
 
       ---
 
-      - .prose-2xl li {
-      + .markdown-2xl li {
+      - .prose-2xl :where(li) {
+      + .markdown-2xl :where(li) {
 
       ---
 
-      - .prose-2xl ol > li {
-      + .markdown-2xl ol > li {
+      - .prose-2xl :where(ol > li) {
+      + .markdown-2xl :where(ol > li) {
 
       ---
 
-      - .prose-2xl ol > li::before {
-      + .markdown-2xl ol > li::before {
+      - .prose-2xl :where(ol > li::before) {
+      + .markdown-2xl :where(ol > li::before) {
 
       ---
 
-      - .prose-2xl ul > li {
-      + .markdown-2xl ul > li {
+      - .prose-2xl :where(ul > li) {
+      + .markdown-2xl :where(ul > li) {
 
       ---
 
-      - .prose-2xl ul > li::before {
-      + .markdown-2xl ul > li::before {
+      - .prose-2xl :where(ul > li::before) {
+      + .markdown-2xl :where(ul > li::before) {
 
       ---
 
-      - .prose-2xl > ul > li p {
-      + .markdown-2xl > ul > li p {
+      - .prose-2xl :where(> ul > li p) {
+      + .markdown-2xl :where(> ul > li p) {
 
       ---
 
-      - .prose-2xl > ul > li > *:first-child {
-      + .markdown-2xl > ul > li > *:first-child {
+      - .prose-2xl :where(> ul > li > *:first-child) {
+      + .markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      - .prose-2xl > ul > li > *:last-child {
-      + .markdown-2xl > ul > li > *:last-child {
+      - .prose-2xl :where(> ul > li > *:last-child) {
+      + .markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      - .prose-2xl > ol > li > *:first-child {
-      + .markdown-2xl > ol > li > *:first-child {
+      - .prose-2xl :where(> ol > li > *:first-child) {
+      + .markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      - .prose-2xl > ol > li > *:last-child {
-      + .markdown-2xl > ol > li > *:last-child {
+      - .prose-2xl :where(> ol > li > *:last-child) {
+      + .markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      - .prose-2xl ul ul, .prose-2xl ul ol, .prose-2xl ol ul, .prose-2xl ol ol {
-      + .markdown-2xl ul ul, .markdown-2xl ul ol, .markdown-2xl ol ul, .markdown-2xl ol ol {
+      - .prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      - .prose-2xl hr {
-      + .markdown-2xl hr {
+      - .prose-2xl :where(hr) {
+      + .markdown-2xl :where(hr) {
 
       ---
 
-      - .prose-2xl hr + * {
-      + .markdown-2xl hr + * {
+      - .prose-2xl :where(hr + *) {
+      + .markdown-2xl :where(hr + *) {
 
       ---
 
-      - .prose-2xl h2 + * {
-      + .markdown-2xl h2 + * {
+      - .prose-2xl :where(h2 + *) {
+      + .markdown-2xl :where(h2 + *) {
 
       ---
 
-      - .prose-2xl h3 + * {
-      + .markdown-2xl h3 + * {
+      - .prose-2xl :where(h3 + *) {
+      + .markdown-2xl :where(h3 + *) {
 
       ---
 
-      - .prose-2xl h4 + * {
-      + .markdown-2xl h4 + * {
+      - .prose-2xl :where(h4 + *) {
+      + .markdown-2xl :where(h4 + *) {
 
       ---
 
-      - .prose-2xl table {
-      + .markdown-2xl table {
+      - .prose-2xl :where(table) {
+      + .markdown-2xl :where(table) {
 
       ---
 
-      - .prose-2xl thead th {
-      + .markdown-2xl thead th {
+      - .prose-2xl :where(thead th) {
+      + .markdown-2xl :where(thead th) {
 
       ---
 
-      - .prose-2xl thead th:first-child {
-      + .markdown-2xl thead th:first-child {
+      - .prose-2xl :where(thead th:first-child) {
+      + .markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      - .prose-2xl thead th:last-child {
-      + .markdown-2xl thead th:last-child {
+      - .prose-2xl :where(thead th:last-child) {
+      + .markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      - .prose-2xl tbody td {
-      + .markdown-2xl tbody td {
+      - .prose-2xl :where(tbody td) {
+      + .markdown-2xl :where(tbody td) {
 
       ---
 
-      - .prose-2xl tbody td:first-child {
-      + .markdown-2xl tbody td:first-child {
+      - .prose-2xl :where(tbody td:first-child) {
+      + .markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      - .prose-2xl tbody td:last-child {
-      + .markdown-2xl tbody td:last-child {
+      - .prose-2xl :where(tbody td:last-child) {
+      + .markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      - .prose-2xl > :first-child {
-      + .markdown-2xl > :first-child {
+      - .prose-2xl :where(> :first-child) {
+      + .markdown-2xl :where(> :first-child) {
 
       ---
 
-      - .prose-2xl > :last-child {
-      + .markdown-2xl > :last-child {
+      - .prose-2xl :where(> :last-child) {
+      + .markdown-2xl :where(> :last-child) {
 
       ---
 
       - }
       -
-      - .prose-red a {
+      - .prose-red :where(a) {
       -   color: #dc2626;
       - }
       -
-      - .prose-red a code {
+      - .prose-red :where(a code) {
       -   color: #dc2626;
       - }
       -
-      - .prose-yellow a {
+      - .prose-yellow :where(a) {
       -   color: #d97706;
       - }
       -
-      - .prose-yellow a code {
+      - .prose-yellow :where(a code) {
       -   color: #d97706;
 
       ---
 
-      - .prose-green a {
+      - .prose-green :where(a) {
       -   color: #059669;
       - }
       -
-      - .prose-green a code {
+      - .prose-green :where(a code) {
       -   color: #059669;
       - }
       -
-      - .prose-blue a {
+      - .prose-blue :where(a) {
       -   color: #2563eb;
       - }
       -
-      - .prose-blue a code {
+      - .prose-blue :where(a code) {
       -   color: #2563eb;
       - }
       -
-      - .prose-indigo a {
+      - .prose-indigo :where(a) {
       -   color: #4f46e5;
       - }
       -
-      - .prose-indigo a code {
+      - .prose-indigo :where(a code) {
       -   color: #4f46e5;
       - }
       -
-      - .prose-purple a {
+      - .prose-purple :where(a) {
       -   color: #7c3aed;
       - }
       -
-      - .prose-purple a code {
+      - .prose-purple :where(a code) {
       -   color: #7c3aed;
       - }
       -
-      - .prose-pink a {
+      - .prose-pink :where(a) {
       -   color: #db2777;
       - }
       -
-      - .prose-pink a code {
+      - .prose-pink :where(a code) {
       -   color: #db2777;
       - }
       -
@@ -18924,218 +18924,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose [class~='lead'] {
-      +   .sm\\\\:markdown [class~='lead'] {
+      -   .sm\\\\:prose :where([class~='lead']) {
+      +   .sm\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose a {
-      +   .sm\\\\:markdown a {
+      -   .sm\\\\:prose :where(a) {
+      +   .sm\\\\:markdown :where(a) {
 
       ---
 
-      -   .sm\\\\:prose strong {
-      +   .sm\\\\:markdown strong {
+      -   .sm\\\\:prose :where(strong) {
+      +   .sm\\\\:markdown :where(strong) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='A'] {
-      +   .sm\\\\:markdown ol[type='A'] {
+      -   .sm\\\\:prose :where(ol[type='A']) {
+      +   .sm\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='a'] {
-      +   .sm\\\\:markdown ol[type='a'] {
+      -   .sm\\\\:prose :where(ol[type='a']) {
+      +   .sm\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='A' s] {
-      +   .sm\\\\:markdown ol[type='A' s] {
+      -   .sm\\\\:prose :where(ol[type='A' s]) {
+      +   .sm\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='a' s] {
-      +   .sm\\\\:markdown ol[type='a' s] {
+      -   .sm\\\\:prose :where(ol[type='a' s]) {
+      +   .sm\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='I'] {
-      +   .sm\\\\:markdown ol[type='I'] {
+      -   .sm\\\\:prose :where(ol[type='I']) {
+      +   .sm\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='i'] {
-      +   .sm\\\\:markdown ol[type='i'] {
+      -   .sm\\\\:prose :where(ol[type='i']) {
+      +   .sm\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='I' s] {
-      +   .sm\\\\:markdown ol[type='I' s] {
+      -   .sm\\\\:prose :where(ol[type='I' s]) {
+      +   .sm\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='i' s] {
-      +   .sm\\\\:markdown ol[type='i' s] {
+      -   .sm\\\\:prose :where(ol[type='i' s]) {
+      +   .sm\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .sm\\\\:prose ol[type='1'] {
-      +   .sm\\\\:markdown ol[type='1'] {
+      -   .sm\\\\:prose :where(ol[type='1']) {
+      +   .sm\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .sm\\\\:prose ol > li {
-      +   .sm\\\\:markdown ol > li {
+      -   .sm\\\\:prose :where(ol > li) {
+      +   .sm\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose ol > li::before {
-      +   .sm\\\\:markdown ol > li::before {
+      -   .sm\\\\:prose :where(ol > li::before) {
+      +   .sm\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose ul > li {
-      +   .sm\\\\:markdown ul > li {
+      -   .sm\\\\:prose :where(ul > li) {
+      +   .sm\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose ul > li::before {
-      +   .sm\\\\:markdown ul > li::before {
+      -   .sm\\\\:prose :where(ul > li::before) {
+      +   .sm\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose hr {
-      +   .sm\\\\:markdown hr {
+      -   .sm\\\\:prose :where(hr) {
+      +   .sm\\\\:markdown :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose blockquote {
-      +   .sm\\\\:markdown blockquote {
+      -   .sm\\\\:prose :where(blockquote) {
+      +   .sm\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose blockquote p:first-of-type::before {
-      +   .sm\\\\:markdown blockquote p:first-of-type::before {
+      -   .sm\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .sm\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .sm\\\\:prose blockquote p:last-of-type::after {
-      +   .sm\\\\:markdown blockquote p:last-of-type::after {
+      -   .sm\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .sm\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .sm\\\\:prose h1 {
-      +   .sm\\\\:markdown h1 {
+      -   .sm\\\\:prose :where(h1) {
+      +   .sm\\\\:markdown :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose h1 strong {
-      +   .sm\\\\:markdown h1 strong {
+      -   .sm\\\\:prose :where(h1 strong) {
+      +   .sm\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .sm\\\\:prose h2 {
-      +   .sm\\\\:markdown h2 {
+      -   .sm\\\\:prose :where(h2) {
+      +   .sm\\\\:markdown :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose h2 strong {
-      +   .sm\\\\:markdown h2 strong {
+      -   .sm\\\\:prose :where(h2 strong) {
+      +   .sm\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .sm\\\\:prose h3 {
-      +   .sm\\\\:markdown h3 {
+      -   .sm\\\\:prose :where(h3) {
+      +   .sm\\\\:markdown :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose h3 strong {
-      +   .sm\\\\:markdown h3 strong {
+      -   .sm\\\\:prose :where(h3 strong) {
+      +   .sm\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .sm\\\\:prose h4 {
-      +   .sm\\\\:markdown h4 {
+      -   .sm\\\\:prose :where(h4) {
+      +   .sm\\\\:markdown :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose h4 strong {
-      +   .sm\\\\:markdown h4 strong {
+      -   .sm\\\\:prose :where(h4 strong) {
+      +   .sm\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .sm\\\\:prose figure figcaption {
-      +   .sm\\\\:markdown figure figcaption {
+      -   .sm\\\\:prose :where(figure figcaption) {
+      +   .sm\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose code {
-      +   .sm\\\\:markdown code {
+      -   .sm\\\\:prose :where(code) {
+      +   .sm\\\\:markdown :where(code) {
 
       ---
 
-      -   .sm\\\\:prose code::before {
-      +   .sm\\\\:markdown code::before {
+      -   .sm\\\\:prose :where(code::before) {
+      +   .sm\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .sm\\\\:prose code::after {
-      +   .sm\\\\:markdown code::after {
+      -   .sm\\\\:prose :where(code::after) {
+      +   .sm\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .sm\\\\:prose a code {
-      +   .sm\\\\:markdown a code {
+      -   .sm\\\\:prose :where(a code) {
+      +   .sm\\\\:markdown :where(a code) {
 
       ---
 
-      -   .sm\\\\:prose pre {
-      +   .sm\\\\:markdown pre {
+      -   .sm\\\\:prose :where(pre) {
+      +   .sm\\\\:markdown :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose pre code {
-      +   .sm\\\\:markdown pre code {
+      -   .sm\\\\:prose :where(pre code) {
+      +   .sm\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .sm\\\\:prose pre code::before {
-      +   .sm\\\\:markdown pre code::before {
+      -   .sm\\\\:prose :where(pre code::before) {
+      +   .sm\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .sm\\\\:prose pre code::after {
-      +   .sm\\\\:markdown pre code::after {
+      -   .sm\\\\:prose :where(pre code::after) {
+      +   .sm\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .sm\\\\:prose table {
-      +   .sm\\\\:markdown table {
+      -   .sm\\\\:prose :where(table) {
+      +   .sm\\\\:markdown :where(table) {
 
       ---
 
-      -   .sm\\\\:prose thead {
-      +   .sm\\\\:markdown thead {
+      -   .sm\\\\:prose :where(thead) {
+      +   .sm\\\\:markdown :where(thead) {
 
       ---
 
-      -   .sm\\\\:prose thead th {
-      +   .sm\\\\:markdown thead th {
+      -   .sm\\\\:prose :where(thead th) {
+      +   .sm\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose tbody tr {
-      +   .sm\\\\:markdown tbody tr {
+      -   .sm\\\\:prose :where(tbody tr) {
+      +   .sm\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .sm\\\\:prose tbody tr:last-child {
-      +   .sm\\\\:markdown tbody tr:last-child {
+      -   .sm\\\\:prose :where(tbody tr:last-child) {
+      +   .sm\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .sm\\\\:prose tbody td {
-      +   .sm\\\\:markdown tbody td {
+      -   .sm\\\\:prose :where(tbody td) {
+      +   .sm\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -19144,225 +19144,225 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose p {
-      +   .sm\\\\:markdown p {
+      -   .sm\\\\:prose :where(p) {
+      +   .sm\\\\:markdown :where(p) {
 
       ---
 
-      -   .sm\\\\:prose img {
-      +   .sm\\\\:markdown img {
+      -   .sm\\\\:prose :where(img) {
+      +   .sm\\\\:markdown :where(img) {
 
       ---
 
-      -   .sm\\\\:prose video {
-      +   .sm\\\\:markdown video {
+      -   .sm\\\\:prose :where(video) {
+      +   .sm\\\\:markdown :where(video) {
 
       ---
 
-      -   .sm\\\\:prose figure {
-      +   .sm\\\\:markdown figure {
+      -   .sm\\\\:prose :where(figure) {
+      +   .sm\\\\:markdown :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose figure > * {
-      +   .sm\\\\:markdown figure > * {
+      -   .sm\\\\:prose :where(figure > *) {
+      +   .sm\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose h2 code {
-      +   .sm\\\\:markdown h2 code {
+      -   .sm\\\\:prose :where(h2 code) {
+      +   .sm\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose h3 code {
-      +   .sm\\\\:markdown h3 code {
+      -   .sm\\\\:prose :where(h3 code) {
+      +   .sm\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose ol {
-      +   .sm\\\\:markdown ol {
+      -   .sm\\\\:prose :where(ol) {
+      +   .sm\\\\:markdown :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose ul {
-      +   .sm\\\\:markdown ul {
+      -   .sm\\\\:prose :where(ul) {
+      +   .sm\\\\:markdown :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose li {
-      +   .sm\\\\:markdown li {
+      -   .sm\\\\:prose :where(li) {
+      +   .sm\\\\:markdown :where(li) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li p {
-      +   .sm\\\\:markdown > ul > li p {
+      -   .sm\\\\:prose :where(> ul > li p) {
+      +   .sm\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li > *:first-child {
-      +   .sm\\\\:markdown > ul > li > *:first-child {
+      -   .sm\\\\:prose :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose > ul > li > *:last-child {
-      +   .sm\\\\:markdown > ul > li > *:last-child {
+      -   .sm\\\\:prose :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose > ol > li > *:first-child {
-      +   .sm\\\\:markdown > ol > li > *:first-child {
+      -   .sm\\\\:prose :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose > ol > li > *:last-child {
-      +   .sm\\\\:markdown > ol > li > *:last-child {
+      -   .sm\\\\:prose :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose ul ul, .sm\\\\:prose ul ol, .sm\\\\:prose ol ul, .sm\\\\:prose ol ol {
-      +   .sm\\\\:markdown ul ul, .sm\\\\:markdown ul ol, .sm\\\\:markdown ol ul, .sm\\\\:markdown ol ol {
+      -   .sm\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
       -   }
       -
-      -   .sm\\\\:prose hr + * {
+      -   .sm\\\\:prose :where(hr + *) {
       -     margin-top: 0;
 
       ---
 
-      -   .sm\\\\:prose h2 + * {
-      +   .sm\\\\:markdown hr + * {
+      -   .sm\\\\:prose :where(h2 + *) {
+      +   .sm\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose h3 + * {
-      +   .sm\\\\:markdown h2 + * {
+      -   .sm\\\\:prose :where(h3 + *) {
+      +   .sm\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose h4 + * {
-      +   .sm\\\\:markdown h3 + * {
+      -   .sm\\\\:prose :where(h4 + *) {
+      +   .sm\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose thead th:first-child {
+      -   .sm\\\\:prose :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .sm\\\\:prose thead th:last-child {
+      -   .sm\\\\:prose :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .sm\\\\:prose tbody td:first-child {
+      -   .sm\\\\:prose :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .sm\\\\:prose tbody td:last-child {
+      -   .sm\\\\:prose :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .sm\\\\:prose > :first-child {
+      -   .sm\\\\:prose :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose > :last-child {
+      -   .sm\\\\:prose :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
       -   .sm\\\\:prose-sm {
-      -     font-size: 0.875rem;
-      -     line-height: 1.7142857;
+      -     :where(font-size): 0.875rem;
+      -     :where(line-height): 1.7142857;
       -   }
       -
-      -   .sm\\\\:prose-sm p {
+      -   .sm\\\\:prose-sm :where(p) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm [class~='lead'] {
+      -   .sm\\\\:prose-sm :where([class~='lead']) {
       -     font-size: 1.2857143em;
       -     line-height: 1.5555556;
       -     margin-top: 0.8888889em;
       -     margin-bottom: 0.8888889em;
       -   }
       -
-      -   .sm\\\\:prose-sm blockquote {
+      -   .sm\\\\:prose-sm :where(blockquote) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .sm\\\\:prose-sm h1 {
+      -   .sm\\\\:prose-sm :where(h1) {
       -     font-size: 2.1428571em;
       -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
       -
-      -   .sm\\\\:prose-sm h2 {
+      -   .sm\\\\:prose-sm :where(h2) {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
       -   }
       -
-      -   .sm\\\\:prose-sm h3 {
+      -   .sm\\\\:prose-sm :where(h3) {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.4444444em;
       -     line-height: 1.5555556;
       -   }
       -
-      -   .sm\\\\:prose-sm h4 {
+      -   .sm\\\\:prose-sm :where(h4) {
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
       -   }
       -
-      -   .sm\\\\:prose-sm img {
+      -   .sm\\\\:prose-sm :where(img) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .sm\\\\:prose-sm video {
+      -   .sm\\\\:prose-sm :where(video) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .sm\\\\:prose-sm figure {
+      -   .sm\\\\:prose-sm :where(figure) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .sm\\\\:prose-sm figure > * {
-      +   .sm\\\\:markdown h4 + * {
+      -   .sm\\\\:prose-sm :where(figure > *) {
+      +   .sm\\\\:markdown :where(h4 + *) {
 
       ---
 
       -     margin-bottom: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm figure figcaption {
+      -   .sm\\\\:prose-sm :where(figure figcaption) {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
 
       ---
 
-      -   .sm\\\\:prose-sm code {
+      -   .sm\\\\:prose-sm :where(code) {
       -     font-size: 0.8571429em;
       -   }
       -
-      -   .sm\\\\:prose-sm h2 code {
+      -   .sm\\\\:prose-sm :where(h2 code) {
       -     font-size: 0.9em;
       -   }
       -
-      -   .sm\\\\:prose-sm h3 code {
+      -   .sm\\\\:prose-sm :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .sm\\\\:prose-sm pre {
+      -   .sm\\\\:prose-sm :where(pre) {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
       -     margin-top: 1.6666667em;
@@ -19374,132 +19374,132 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1em;
       -   }
       -
-      -   .sm\\\\:prose-sm ol {
+      -   .sm\\\\:prose-sm :where(ol) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm ul {
+      -   .sm\\\\:prose-sm :where(ul) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm li {
+      -   .sm\\\\:prose-sm :where(li) {
       -     margin-top: 0.2857143em;
       -     margin-bottom: 0.2857143em;
       -   }
       -
-      -   .sm\\\\:prose-sm ol > li {
+      -   .sm\\\\:prose-sm :where(ol > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm ol > li::before {
+      -   .sm\\\\:prose-sm :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm ul > li {
+      -   .sm\\\\:prose-sm :where(ul > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm ul > li::before {
+      -   .sm\\\\:prose-sm :where(ul > li::before) {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
       -     left: 0.2142857em;
       -   }
       -
-      -   .sm\\\\:prose-sm > ul > li p {
+      -   .sm\\\\:prose-sm :where(> ul > li p) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm > ul > li > *:first-child {
+      -   .sm\\\\:prose-sm :where(> ul > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm > ul > li > *:last-child {
+      -   .sm\\\\:prose-sm :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm > ol > li > *:first-child {
+      -   .sm\\\\:prose-sm :where(> ol > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm > ol > li > *:last-child {
+      -   .sm\\\\:prose-sm :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .sm\\\\:prose-sm ul ul, .sm\\\\:prose-sm ul ol, .sm\\\\:prose-sm ol ul, .sm\\\\:prose-sm ol ol {
+      -   .sm\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm hr {
+      -   .sm\\\\:prose-sm :where(hr) {
       -     margin-top: 2.8571429em;
       -     margin-bottom: 2.8571429em;
       -   }
       -
-      -   .sm\\\\:prose-sm hr + * {
+      -   .sm\\\\:prose-sm :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm h2 + * {
+      -   .sm\\\\:prose-sm :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm h3 + * {
+      -   .sm\\\\:prose-sm :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm h4 + * {
+      -   .sm\\\\:prose-sm :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .sm\\\\:prose-sm table {
+      -   .sm\\\\:prose-sm :where(table) {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
       -   }
       -
-      -   .sm\\\\:prose-sm thead th {
+      -   .sm\\\\:prose-sm :where(thead th) {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .sm\\\\:prose-sm thead th:first-child {
-      +   .sm\\\\:markdown thead th:first-child {
+      -   .sm\\\\:prose-sm :where(thead th:first-child) {
+      +   .sm\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm thead th:last-child {
-      +   .sm\\\\:markdown thead th:last-child {
+      -   .sm\\\\:prose-sm :where(thead th:last-child) {
+      +   .sm\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm tbody td {
+      -   .sm\\\\:prose-sm :where(tbody td) {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .sm\\\\:prose-sm tbody td:first-child {
-      +   .sm\\\\:markdown tbody td:first-child {
+      -   .sm\\\\:prose-sm :where(tbody td:first-child) {
+      +   .sm\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm tbody td:last-child {
-      +   .sm\\\\:markdown tbody td:last-child {
+      -   .sm\\\\:prose-sm :where(tbody td:last-child) {
+      +   .sm\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > :first-child {
-      +   .sm\\\\:markdown > :first-child {
+      -   .sm\\\\:prose-sm :where(> :first-child) {
+      +   .sm\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-sm > :last-child {
-      +   .sm\\\\:markdown > :last-child {
+      -   .sm\\\\:prose-sm :where(> :last-child) {
+      +   .sm\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -19508,218 +19508,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-lg p {
-      +   .sm\\\\:markdown-lg p {
+      -   .sm\\\\:prose-lg :where(p) {
+      +   .sm\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-lg [class~='lead'] {
-      +   .sm\\\\:markdown-lg [class~='lead'] {
+      -   .sm\\\\:prose-lg :where([class~='lead']) {
+      +   .sm\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-lg blockquote {
-      +   .sm\\\\:markdown-lg blockquote {
+      -   .sm\\\\:prose-lg :where(blockquote) {
+      +   .sm\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-lg h1 {
-      +   .sm\\\\:markdown-lg h1 {
+      -   .sm\\\\:prose-lg :where(h1) {
+      +   .sm\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 {
-      +   .sm\\\\:markdown-lg h2 {
+      -   .sm\\\\:prose-lg :where(h2) {
+      +   .sm\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 {
-      +   .sm\\\\:markdown-lg h3 {
+      -   .sm\\\\:prose-lg :where(h3) {
+      +   .sm\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-lg h4 {
-      +   .sm\\\\:markdown-lg h4 {
+      -   .sm\\\\:prose-lg :where(h4) {
+      +   .sm\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-lg img {
-      +   .sm\\\\:markdown-lg img {
+      -   .sm\\\\:prose-lg :where(img) {
+      +   .sm\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-lg video {
-      +   .sm\\\\:markdown-lg video {
+      -   .sm\\\\:prose-lg :where(video) {
+      +   .sm\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure {
-      +   .sm\\\\:markdown-lg figure {
+      -   .sm\\\\:prose-lg :where(figure) {
+      +   .sm\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure > * {
-      +   .sm\\\\:markdown-lg figure > * {
+      -   .sm\\\\:prose-lg :where(figure > *) {
+      +   .sm\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-lg figure figcaption {
-      +   .sm\\\\:markdown-lg figure figcaption {
+      -   .sm\\\\:prose-lg :where(figure figcaption) {
+      +   .sm\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-lg code {
-      +   .sm\\\\:markdown-lg code {
+      -   .sm\\\\:prose-lg :where(code) {
+      +   .sm\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 code {
-      +   .sm\\\\:markdown-lg h2 code {
+      -   .sm\\\\:prose-lg :where(h2 code) {
+      +   .sm\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 code {
-      +   .sm\\\\:markdown-lg h3 code {
+      -   .sm\\\\:prose-lg :where(h3 code) {
+      +   .sm\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-lg pre {
-      +   .sm\\\\:markdown-lg pre {
+      -   .sm\\\\:prose-lg :where(pre) {
+      +   .sm\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol {
-      +   .sm\\\\:markdown-lg ol {
+      -   .sm\\\\:prose-lg :where(ol) {
+      +   .sm\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul {
-      +   .sm\\\\:markdown-lg ul {
+      -   .sm\\\\:prose-lg :where(ul) {
+      +   .sm\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-lg li {
-      +   .sm\\\\:markdown-lg li {
+      -   .sm\\\\:prose-lg :where(li) {
+      +   .sm\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol > li {
-      +   .sm\\\\:markdown-lg ol > li {
+      -   .sm\\\\:prose-lg :where(ol > li) {
+      +   .sm\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ol > li::before {
-      +   .sm\\\\:markdown-lg ol > li::before {
+      -   .sm\\\\:prose-lg :where(ol > li::before) {
+      +   .sm\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul > li {
-      +   .sm\\\\:markdown-lg ul > li {
+      -   .sm\\\\:prose-lg :where(ul > li) {
+      +   .sm\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul > li::before {
-      +   .sm\\\\:markdown-lg ul > li::before {
+      -   .sm\\\\:prose-lg :where(ul > li::before) {
+      +   .sm\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li p {
-      +   .sm\\\\:markdown-lg > ul > li p {
+      -   .sm\\\\:prose-lg :where(> ul > li p) {
+      +   .sm\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li > *:first-child {
-      +   .sm\\\\:markdown-lg > ul > li > *:first-child {
+      -   .sm\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ul > li > *:last-child {
-      +   .sm\\\\:markdown-lg > ul > li > *:last-child {
+      -   .sm\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ol > li > *:first-child {
-      +   .sm\\\\:markdown-lg > ol > li > *:first-child {
+      -   .sm\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > ol > li > *:last-child {
-      +   .sm\\\\:markdown-lg > ol > li > *:last-child {
+      -   .sm\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg ul ul, .sm\\\\:prose-lg ul ol, .sm\\\\:prose-lg ol ul, .sm\\\\:prose-lg ol ol {
-      +   .sm\\\\:markdown-lg ul ul, .sm\\\\:markdown-lg ul ol, .sm\\\\:markdown-lg ol ul, .sm\\\\:markdown-lg ol ol {
+      -   .sm\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-lg hr {
-      +   .sm\\\\:markdown-lg hr {
+      -   .sm\\\\:prose-lg :where(hr) {
+      +   .sm\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-lg hr + * {
-      +   .sm\\\\:markdown-lg hr + * {
+      -   .sm\\\\:prose-lg :where(hr + *) {
+      +   .sm\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h2 + * {
-      +   .sm\\\\:markdown-lg h2 + * {
+      -   .sm\\\\:prose-lg :where(h2 + *) {
+      +   .sm\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h3 + * {
-      +   .sm\\\\:markdown-lg h3 + * {
+      -   .sm\\\\:prose-lg :where(h3 + *) {
+      +   .sm\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg h4 + * {
-      +   .sm\\\\:markdown-lg h4 + * {
+      -   .sm\\\\:prose-lg :where(h4 + *) {
+      +   .sm\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-lg table {
-      +   .sm\\\\:markdown-lg table {
+      -   .sm\\\\:prose-lg :where(table) {
+      +   .sm\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th {
-      +   .sm\\\\:markdown-lg thead th {
+      -   .sm\\\\:prose-lg :where(thead th) {
+      +   .sm\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th:first-child {
-      +   .sm\\\\:markdown-lg thead th:first-child {
+      -   .sm\\\\:prose-lg :where(thead th:first-child) {
+      +   .sm\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg thead th:last-child {
-      +   .sm\\\\:markdown-lg thead th:last-child {
+      -   .sm\\\\:prose-lg :where(thead th:last-child) {
+      +   .sm\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td {
-      +   .sm\\\\:markdown-lg tbody td {
+      -   .sm\\\\:prose-lg :where(tbody td) {
+      +   .sm\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td:first-child {
-      +   .sm\\\\:markdown-lg tbody td:first-child {
+      -   .sm\\\\:prose-lg :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg tbody td:last-child {
-      +   .sm\\\\:markdown-lg tbody td:last-child {
+      -   .sm\\\\:prose-lg :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > :first-child {
-      +   .sm\\\\:markdown-lg > :first-child {
+      -   .sm\\\\:prose-lg :where(> :first-child) {
+      +   .sm\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-lg > :last-child {
-      +   .sm\\\\:markdown-lg > :last-child {
+      -   .sm\\\\:prose-lg :where(> :last-child) {
+      +   .sm\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -19728,218 +19728,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-xl p {
-      +   .sm\\\\:markdown-xl p {
+      -   .sm\\\\:prose-xl :where(p) {
+      +   .sm\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-xl [class~='lead'] {
-      +   .sm\\\\:markdown-xl [class~='lead'] {
+      -   .sm\\\\:prose-xl :where([class~='lead']) {
+      +   .sm\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-xl blockquote {
-      +   .sm\\\\:markdown-xl blockquote {
+      -   .sm\\\\:prose-xl :where(blockquote) {
+      +   .sm\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-xl h1 {
-      +   .sm\\\\:markdown-xl h1 {
+      -   .sm\\\\:prose-xl :where(h1) {
+      +   .sm\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 {
-      +   .sm\\\\:markdown-xl h2 {
+      -   .sm\\\\:prose-xl :where(h2) {
+      +   .sm\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 {
-      +   .sm\\\\:markdown-xl h3 {
+      -   .sm\\\\:prose-xl :where(h3) {
+      +   .sm\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-xl h4 {
-      +   .sm\\\\:markdown-xl h4 {
+      -   .sm\\\\:prose-xl :where(h4) {
+      +   .sm\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-xl img {
-      +   .sm\\\\:markdown-xl img {
+      -   .sm\\\\:prose-xl :where(img) {
+      +   .sm\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-xl video {
-      +   .sm\\\\:markdown-xl video {
+      -   .sm\\\\:prose-xl :where(video) {
+      +   .sm\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure {
-      +   .sm\\\\:markdown-xl figure {
+      -   .sm\\\\:prose-xl :where(figure) {
+      +   .sm\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure > * {
-      +   .sm\\\\:markdown-xl figure > * {
+      -   .sm\\\\:prose-xl :where(figure > *) {
+      +   .sm\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-xl figure figcaption {
-      +   .sm\\\\:markdown-xl figure figcaption {
+      -   .sm\\\\:prose-xl :where(figure figcaption) {
+      +   .sm\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-xl code {
-      +   .sm\\\\:markdown-xl code {
+      -   .sm\\\\:prose-xl :where(code) {
+      +   .sm\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 code {
-      +   .sm\\\\:markdown-xl h2 code {
+      -   .sm\\\\:prose-xl :where(h2 code) {
+      +   .sm\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 code {
-      +   .sm\\\\:markdown-xl h3 code {
+      -   .sm\\\\:prose-xl :where(h3 code) {
+      +   .sm\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-xl pre {
-      +   .sm\\\\:markdown-xl pre {
+      -   .sm\\\\:prose-xl :where(pre) {
+      +   .sm\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol {
-      +   .sm\\\\:markdown-xl ol {
+      -   .sm\\\\:prose-xl :where(ol) {
+      +   .sm\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul {
-      +   .sm\\\\:markdown-xl ul {
+      -   .sm\\\\:prose-xl :where(ul) {
+      +   .sm\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-xl li {
-      +   .sm\\\\:markdown-xl li {
+      -   .sm\\\\:prose-xl :where(li) {
+      +   .sm\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol > li {
-      +   .sm\\\\:markdown-xl ol > li {
+      -   .sm\\\\:prose-xl :where(ol > li) {
+      +   .sm\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ol > li::before {
-      +   .sm\\\\:markdown-xl ol > li::before {
+      -   .sm\\\\:prose-xl :where(ol > li::before) {
+      +   .sm\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul > li {
-      +   .sm\\\\:markdown-xl ul > li {
+      -   .sm\\\\:prose-xl :where(ul > li) {
+      +   .sm\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul > li::before {
-      +   .sm\\\\:markdown-xl ul > li::before {
+      -   .sm\\\\:prose-xl :where(ul > li::before) {
+      +   .sm\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li p {
-      +   .sm\\\\:markdown-xl > ul > li p {
+      -   .sm\\\\:prose-xl :where(> ul > li p) {
+      +   .sm\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li > *:first-child {
-      +   .sm\\\\:markdown-xl > ul > li > *:first-child {
+      -   .sm\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ul > li > *:last-child {
-      +   .sm\\\\:markdown-xl > ul > li > *:last-child {
+      -   .sm\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ol > li > *:first-child {
-      +   .sm\\\\:markdown-xl > ol > li > *:first-child {
+      -   .sm\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > ol > li > *:last-child {
-      +   .sm\\\\:markdown-xl > ol > li > *:last-child {
+      -   .sm\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl ul ul, .sm\\\\:prose-xl ul ol, .sm\\\\:prose-xl ol ul, .sm\\\\:prose-xl ol ol {
-      +   .sm\\\\:markdown-xl ul ul, .sm\\\\:markdown-xl ul ol, .sm\\\\:markdown-xl ol ul, .sm\\\\:markdown-xl ol ol {
+      -   .sm\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-xl hr {
-      +   .sm\\\\:markdown-xl hr {
+      -   .sm\\\\:prose-xl :where(hr) {
+      +   .sm\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-xl hr + * {
-      +   .sm\\\\:markdown-xl hr + * {
+      -   .sm\\\\:prose-xl :where(hr + *) {
+      +   .sm\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h2 + * {
-      +   .sm\\\\:markdown-xl h2 + * {
+      -   .sm\\\\:prose-xl :where(h2 + *) {
+      +   .sm\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h3 + * {
-      +   .sm\\\\:markdown-xl h3 + * {
+      -   .sm\\\\:prose-xl :where(h3 + *) {
+      +   .sm\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl h4 + * {
-      +   .sm\\\\:markdown-xl h4 + * {
+      -   .sm\\\\:prose-xl :where(h4 + *) {
+      +   .sm\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-xl table {
-      +   .sm\\\\:markdown-xl table {
+      -   .sm\\\\:prose-xl :where(table) {
+      +   .sm\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th {
-      +   .sm\\\\:markdown-xl thead th {
+      -   .sm\\\\:prose-xl :where(thead th) {
+      +   .sm\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th:first-child {
-      +   .sm\\\\:markdown-xl thead th:first-child {
+      -   .sm\\\\:prose-xl :where(thead th:first-child) {
+      +   .sm\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl thead th:last-child {
-      +   .sm\\\\:markdown-xl thead th:last-child {
+      -   .sm\\\\:prose-xl :where(thead th:last-child) {
+      +   .sm\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td {
-      +   .sm\\\\:markdown-xl tbody td {
+      -   .sm\\\\:prose-xl :where(tbody td) {
+      +   .sm\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td:first-child {
-      +   .sm\\\\:markdown-xl tbody td:first-child {
+      -   .sm\\\\:prose-xl :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl tbody td:last-child {
-      +   .sm\\\\:markdown-xl tbody td:last-child {
+      -   .sm\\\\:prose-xl :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > :first-child {
-      +   .sm\\\\:markdown-xl > :first-child {
+      -   .sm\\\\:prose-xl :where(> :first-child) {
+      +   .sm\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-xl > :last-child {
-      +   .sm\\\\:markdown-xl > :last-child {
+      -   .sm\\\\:prose-xl :where(> :last-child) {
+      +   .sm\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -19948,278 +19948,278 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-2xl p {
-      +   .sm\\\\:markdown-2xl p {
+      -   .sm\\\\:prose-2xl :where(p) {
+      +   .sm\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .sm\\\\:prose-2xl [class~='lead'] {
-      +   .sm\\\\:markdown-2xl [class~='lead'] {
+      -   .sm\\\\:prose-2xl :where([class~='lead']) {
+      +   .sm\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .sm\\\\:prose-2xl blockquote {
-      +   .sm\\\\:markdown-2xl blockquote {
+      -   .sm\\\\:prose-2xl :where(blockquote) {
+      +   .sm\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h1 {
-      +   .sm\\\\:markdown-2xl h1 {
+      -   .sm\\\\:prose-2xl :where(h1) {
+      +   .sm\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 {
-      +   .sm\\\\:markdown-2xl h2 {
+      -   .sm\\\\:prose-2xl :where(h2) {
+      +   .sm\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 {
-      +   .sm\\\\:markdown-2xl h3 {
+      -   .sm\\\\:prose-2xl :where(h3) {
+      +   .sm\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h4 {
-      +   .sm\\\\:markdown-2xl h4 {
+      -   .sm\\\\:prose-2xl :where(h4) {
+      +   .sm\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .sm\\\\:prose-2xl img {
-      +   .sm\\\\:markdown-2xl img {
+      -   .sm\\\\:prose-2xl :where(img) {
+      +   .sm\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .sm\\\\:prose-2xl video {
-      +   .sm\\\\:markdown-2xl video {
+      -   .sm\\\\:prose-2xl :where(video) {
+      +   .sm\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure {
-      +   .sm\\\\:markdown-2xl figure {
+      -   .sm\\\\:prose-2xl :where(figure) {
+      +   .sm\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure > * {
-      +   .sm\\\\:markdown-2xl figure > * {
+      -   .sm\\\\:prose-2xl :where(figure > *) {
+      +   .sm\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl figure figcaption {
-      +   .sm\\\\:markdown-2xl figure figcaption {
+      -   .sm\\\\:prose-2xl :where(figure figcaption) {
+      +   .sm\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .sm\\\\:prose-2xl code {
-      +   .sm\\\\:markdown-2xl code {
+      -   .sm\\\\:prose-2xl :where(code) {
+      +   .sm\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 code {
-      +   .sm\\\\:markdown-2xl h2 code {
+      -   .sm\\\\:prose-2xl :where(h2 code) {
+      +   .sm\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 code {
-      +   .sm\\\\:markdown-2xl h3 code {
+      -   .sm\\\\:prose-2xl :where(h3 code) {
+      +   .sm\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .sm\\\\:prose-2xl pre {
-      +   .sm\\\\:markdown-2xl pre {
+      -   .sm\\\\:prose-2xl :where(pre) {
+      +   .sm\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol {
-      +   .sm\\\\:markdown-2xl ol {
+      -   .sm\\\\:prose-2xl :where(ol) {
+      +   .sm\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul {
-      +   .sm\\\\:markdown-2xl ul {
+      -   .sm\\\\:prose-2xl :where(ul) {
+      +   .sm\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .sm\\\\:prose-2xl li {
-      +   .sm\\\\:markdown-2xl li {
+      -   .sm\\\\:prose-2xl :where(li) {
+      +   .sm\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol > li {
-      +   .sm\\\\:markdown-2xl ol > li {
+      -   .sm\\\\:prose-2xl :where(ol > li) {
+      +   .sm\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ol > li::before {
-      +   .sm\\\\:markdown-2xl ol > li::before {
+      -   .sm\\\\:prose-2xl :where(ol > li::before) {
+      +   .sm\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul > li {
-      +   .sm\\\\:markdown-2xl ul > li {
+      -   .sm\\\\:prose-2xl :where(ul > li) {
+      +   .sm\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul > li::before {
-      +   .sm\\\\:markdown-2xl ul > li::before {
+      -   .sm\\\\:prose-2xl :where(ul > li::before) {
+      +   .sm\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li p {
-      +   .sm\\\\:markdown-2xl > ul > li p {
+      -   .sm\\\\:prose-2xl :where(> ul > li p) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li > *:first-child {
-      +   .sm\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ul > li > *:last-child {
-      +   .sm\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ol > li > *:first-child {
-      +   .sm\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > ol > li > *:last-child {
-      +   .sm\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl ul ul, .sm\\\\:prose-2xl ul ol, .sm\\\\:prose-2xl ol ul, .sm\\\\:prose-2xl ol ol {
-      +   .sm\\\\:markdown-2xl ul ul, .sm\\\\:markdown-2xl ul ol, .sm\\\\:markdown-2xl ol ul, .sm\\\\:markdown-2xl ol ol {
+      -   .sm\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .sm\\\\:prose-2xl hr {
-      +   .sm\\\\:markdown-2xl hr {
+      -   .sm\\\\:prose-2xl :where(hr) {
+      +   .sm\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .sm\\\\:prose-2xl hr + * {
-      +   .sm\\\\:markdown-2xl hr + * {
+      -   .sm\\\\:prose-2xl :where(hr + *) {
+      +   .sm\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h2 + * {
-      +   .sm\\\\:markdown-2xl h2 + * {
+      -   .sm\\\\:prose-2xl :where(h2 + *) {
+      +   .sm\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h3 + * {
-      +   .sm\\\\:markdown-2xl h3 + * {
+      -   .sm\\\\:prose-2xl :where(h3 + *) {
+      +   .sm\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl h4 + * {
-      +   .sm\\\\:markdown-2xl h4 + * {
+      -   .sm\\\\:prose-2xl :where(h4 + *) {
+      +   .sm\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .sm\\\\:prose-2xl table {
-      +   .sm\\\\:markdown-2xl table {
+      -   .sm\\\\:prose-2xl :where(table) {
+      +   .sm\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th {
-      +   .sm\\\\:markdown-2xl thead th {
+      -   .sm\\\\:prose-2xl :where(thead th) {
+      +   .sm\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th:first-child {
-      +   .sm\\\\:markdown-2xl thead th:first-child {
+      -   .sm\\\\:prose-2xl :where(thead th:first-child) {
+      +   .sm\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl thead th:last-child {
-      +   .sm\\\\:markdown-2xl thead th:last-child {
+      -   .sm\\\\:prose-2xl :where(thead th:last-child) {
+      +   .sm\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td {
-      +   .sm\\\\:markdown-2xl tbody td {
+      -   .sm\\\\:prose-2xl :where(tbody td) {
+      +   .sm\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td:first-child {
-      +   .sm\\\\:markdown-2xl tbody td:first-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .sm\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl tbody td:last-child {
-      +   .sm\\\\:markdown-2xl tbody td:last-child {
+      -   .sm\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .sm\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > :first-child {
-      +   .sm\\\\:markdown-2xl > :first-child {
+      -   .sm\\\\:prose-2xl :where(> :first-child) {
+      +   .sm\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .sm\\\\:prose-2xl > :last-child {
-      +   .sm\\\\:markdown-2xl > :last-child {
+      -   .sm\\\\:prose-2xl :where(> :last-child) {
+      +   .sm\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .sm\\\\:prose-red a {
+      -   .sm\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .sm\\\\:prose-red a code {
+      -   .sm\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .sm\\\\:prose-yellow a {
+      -   .sm\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .sm\\\\:prose-yellow a code {
+      -   .sm\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .sm\\\\:prose-green a {
+      -   .sm\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .sm\\\\:prose-green a code {
+      -   .sm\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .sm\\\\:prose-blue a {
+      -   .sm\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .sm\\\\:prose-blue a code {
+      -   .sm\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .sm\\\\:prose-indigo a {
+      -   .sm\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
 
       ---
 
       -
-      -   .sm\\\\:prose-indigo a code {
+      -   .sm\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .sm\\\\:prose-purple a {
+      -   .sm\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .sm\\\\:prose-purple a code {
+      -   .sm\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .sm\\\\:prose-pink a {
+      -   .sm\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .sm\\\\:prose-pink a code {
+      -   .sm\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -20230,218 +20230,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose [class~='lead'] {
-      +   .md\\\\:markdown [class~='lead'] {
+      -   .md\\\\:prose :where([class~='lead']) {
+      +   .md\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose a {
-      +   .md\\\\:markdown a {
+      -   .md\\\\:prose :where(a) {
+      +   .md\\\\:markdown :where(a) {
 
       ---
 
-      -   .md\\\\:prose strong {
-      +   .md\\\\:markdown strong {
+      -   .md\\\\:prose :where(strong) {
+      +   .md\\\\:markdown :where(strong) {
 
       ---
 
-      -   .md\\\\:prose ol[type='A'] {
-      +   .md\\\\:markdown ol[type='A'] {
+      -   .md\\\\:prose :where(ol[type='A']) {
+      +   .md\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='a'] {
-      +   .md\\\\:markdown ol[type='a'] {
+      -   .md\\\\:prose :where(ol[type='a']) {
+      +   .md\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='A' s] {
-      +   .md\\\\:markdown ol[type='A' s] {
+      -   .md\\\\:prose :where(ol[type='A' s]) {
+      +   .md\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='a' s] {
-      +   .md\\\\:markdown ol[type='a' s] {
+      -   .md\\\\:prose :where(ol[type='a' s]) {
+      +   .md\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='I'] {
-      +   .md\\\\:markdown ol[type='I'] {
+      -   .md\\\\:prose :where(ol[type='I']) {
+      +   .md\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='i'] {
-      +   .md\\\\:markdown ol[type='i'] {
+      -   .md\\\\:prose :where(ol[type='i']) {
+      +   .md\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .md\\\\:prose ol[type='I' s] {
-      +   .md\\\\:markdown ol[type='I' s] {
+      -   .md\\\\:prose :where(ol[type='I' s]) {
+      +   .md\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='i' s] {
-      +   .md\\\\:markdown ol[type='i' s] {
+      -   .md\\\\:prose :where(ol[type='i' s]) {
+      +   .md\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .md\\\\:prose ol[type='1'] {
-      +   .md\\\\:markdown ol[type='1'] {
+      -   .md\\\\:prose :where(ol[type='1']) {
+      +   .md\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .md\\\\:prose ol > li {
-      +   .md\\\\:markdown ol > li {
+      -   .md\\\\:prose :where(ol > li) {
+      +   .md\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose ol > li::before {
-      +   .md\\\\:markdown ol > li::before {
+      -   .md\\\\:prose :where(ol > li::before) {
+      +   .md\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose ul > li {
-      +   .md\\\\:markdown ul > li {
+      -   .md\\\\:prose :where(ul > li) {
+      +   .md\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose ul > li::before {
-      +   .md\\\\:markdown ul > li::before {
+      -   .md\\\\:prose :where(ul > li::before) {
+      +   .md\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose hr {
-      +   .md\\\\:markdown hr {
+      -   .md\\\\:prose :where(hr) {
+      +   .md\\\\:markdown :where(hr) {
 
       ---
 
-      -   .md\\\\:prose blockquote {
-      +   .md\\\\:markdown blockquote {
+      -   .md\\\\:prose :where(blockquote) {
+      +   .md\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose blockquote p:first-of-type::before {
-      +   .md\\\\:markdown blockquote p:first-of-type::before {
+      -   .md\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .md\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .md\\\\:prose blockquote p:last-of-type::after {
-      +   .md\\\\:markdown blockquote p:last-of-type::after {
+      -   .md\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .md\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .md\\\\:prose h1 {
-      +   .md\\\\:markdown h1 {
+      -   .md\\\\:prose :where(h1) {
+      +   .md\\\\:markdown :where(h1) {
 
       ---
 
-      -   .md\\\\:prose h1 strong {
-      +   .md\\\\:markdown h1 strong {
+      -   .md\\\\:prose :where(h1 strong) {
+      +   .md\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .md\\\\:prose h2 {
-      +   .md\\\\:markdown h2 {
+      -   .md\\\\:prose :where(h2) {
+      +   .md\\\\:markdown :where(h2) {
 
       ---
 
-      -   .md\\\\:prose h2 strong {
-      +   .md\\\\:markdown h2 strong {
+      -   .md\\\\:prose :where(h2 strong) {
+      +   .md\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .md\\\\:prose h3 {
-      +   .md\\\\:markdown h3 {
+      -   .md\\\\:prose :where(h3) {
+      +   .md\\\\:markdown :where(h3) {
 
       ---
 
-      -   .md\\\\:prose h3 strong {
-      +   .md\\\\:markdown h3 strong {
+      -   .md\\\\:prose :where(h3 strong) {
+      +   .md\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .md\\\\:prose h4 {
-      +   .md\\\\:markdown h4 {
+      -   .md\\\\:prose :where(h4) {
+      +   .md\\\\:markdown :where(h4) {
 
       ---
 
-      -   .md\\\\:prose h4 strong {
-      +   .md\\\\:markdown h4 strong {
+      -   .md\\\\:prose :where(h4 strong) {
+      +   .md\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .md\\\\:prose figure figcaption {
-      +   .md\\\\:markdown figure figcaption {
+      -   .md\\\\:prose :where(figure figcaption) {
+      +   .md\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose code {
-      +   .md\\\\:markdown code {
+      -   .md\\\\:prose :where(code) {
+      +   .md\\\\:markdown :where(code) {
 
       ---
 
-      -   .md\\\\:prose code::before {
-      +   .md\\\\:markdown code::before {
+      -   .md\\\\:prose :where(code::before) {
+      +   .md\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .md\\\\:prose code::after {
-      +   .md\\\\:markdown code::after {
+      -   .md\\\\:prose :where(code::after) {
+      +   .md\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .md\\\\:prose a code {
-      +   .md\\\\:markdown a code {
+      -   .md\\\\:prose :where(a code) {
+      +   .md\\\\:markdown :where(a code) {
 
       ---
 
-      -   .md\\\\:prose pre {
-      +   .md\\\\:markdown pre {
+      -   .md\\\\:prose :where(pre) {
+      +   .md\\\\:markdown :where(pre) {
 
       ---
 
-      -   .md\\\\:prose pre code {
-      +   .md\\\\:markdown pre code {
+      -   .md\\\\:prose :where(pre code) {
+      +   .md\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .md\\\\:prose pre code::before {
-      +   .md\\\\:markdown pre code::before {
+      -   .md\\\\:prose :where(pre code::before) {
+      +   .md\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .md\\\\:prose pre code::after {
-      +   .md\\\\:markdown pre code::after {
+      -   .md\\\\:prose :where(pre code::after) {
+      +   .md\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .md\\\\:prose table {
-      +   .md\\\\:markdown table {
+      -   .md\\\\:prose :where(table) {
+      +   .md\\\\:markdown :where(table) {
 
       ---
 
-      -   .md\\\\:prose thead {
-      +   .md\\\\:markdown thead {
+      -   .md\\\\:prose :where(thead) {
+      +   .md\\\\:markdown :where(thead) {
 
       ---
 
-      -   .md\\\\:prose thead th {
-      +   .md\\\\:markdown thead th {
+      -   .md\\\\:prose :where(thead th) {
+      +   .md\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose tbody tr {
-      +   .md\\\\:markdown tbody tr {
+      -   .md\\\\:prose :where(tbody tr) {
+      +   .md\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .md\\\\:prose tbody tr:last-child {
-      +   .md\\\\:markdown tbody tr:last-child {
+      -   .md\\\\:prose :where(tbody tr:last-child) {
+      +   .md\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .md\\\\:prose tbody td {
-      +   .md\\\\:markdown tbody td {
+      -   .md\\\\:prose :where(tbody td) {
+      +   .md\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -20450,152 +20450,152 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose p {
-      +   .md\\\\:markdown p {
+      -   .md\\\\:prose :where(p) {
+      +   .md\\\\:markdown :where(p) {
 
       ---
 
-      -   .md\\\\:prose img {
-      +   .md\\\\:markdown img {
+      -   .md\\\\:prose :where(img) {
+      +   .md\\\\:markdown :where(img) {
 
       ---
 
-      -   .md\\\\:prose video {
-      +   .md\\\\:markdown video {
+      -   .md\\\\:prose :where(video) {
+      +   .md\\\\:markdown :where(video) {
 
       ---
 
-      -   .md\\\\:prose figure {
-      +   .md\\\\:markdown figure {
+      -   .md\\\\:prose :where(figure) {
+      +   .md\\\\:markdown :where(figure) {
 
       ---
 
-      -   .md\\\\:prose figure > * {
-      +   .md\\\\:markdown figure > * {
+      -   .md\\\\:prose :where(figure > *) {
+      +   .md\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose h2 code {
-      +   .md\\\\:markdown h2 code {
+      -   .md\\\\:prose :where(h2 code) {
+      +   .md\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose h3 code {
-      +   .md\\\\:markdown h3 code {
+      -   .md\\\\:prose :where(h3 code) {
+      +   .md\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose ol {
-      +   .md\\\\:markdown ol {
+      -   .md\\\\:prose :where(ol) {
+      +   .md\\\\:markdown :where(ol) {
 
       ---
 
-      -   .md\\\\:prose ul {
-      +   .md\\\\:markdown ul {
+      -   .md\\\\:prose :where(ul) {
+      +   .md\\\\:markdown :where(ul) {
 
       ---
 
-      -   .md\\\\:prose li {
-      +   .md\\\\:markdown li {
+      -   .md\\\\:prose :where(li) {
+      +   .md\\\\:markdown :where(li) {
 
       ---
 
-      -   .md\\\\:prose > ul > li p {
-      +   .md\\\\:markdown > ul > li p {
+      -   .md\\\\:prose :where(> ul > li p) {
+      +   .md\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose > ul > li > *:first-child {
-      +   .md\\\\:markdown > ul > li > *:first-child {
+      -   .md\\\\:prose :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose > ul > li > *:last-child {
-      +   .md\\\\:markdown > ul > li > *:last-child {
+      -   .md\\\\:prose :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose > ol > li > *:first-child {
-      +   .md\\\\:markdown > ol > li > *:first-child {
+      -   .md\\\\:prose :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose > ol > li > *:last-child {
-      +   .md\\\\:markdown > ol > li > *:last-child {
+      -   .md\\\\:prose :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose ul ul, .md\\\\:prose ul ol, .md\\\\:prose ol ul, .md\\\\:prose ol ol {
-      +   .md\\\\:markdown ul ul, .md\\\\:markdown ul ol, .md\\\\:markdown ol ul, .md\\\\:markdown ol ol {
+      -   .md\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose hr + * {
+      -   .md\\\\:prose :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose h2 + * {
+      -   .md\\\\:prose :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose h3 + * {
+      -   .md\\\\:prose :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose h4 + * {
+      -   .md\\\\:prose :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose thead th:first-child {
+      -   .md\\\\:prose :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .md\\\\:prose thead th:last-child {
+      -   .md\\\\:prose :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .md\\\\:prose tbody td:first-child {
+      -   .md\\\\:prose :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .md\\\\:prose tbody td:last-child {
+      -   .md\\\\:prose :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .md\\\\:prose > :first-child {
+      -   .md\\\\:prose :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose > :last-child {
+      -   .md\\\\:prose :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
       -   .md\\\\:prose-sm {
-      -     font-size: 0.875rem;
-      -     line-height: 1.7142857;
+      -     :where(font-size): 0.875rem;
+      -     :where(line-height): 1.7142857;
       -   }
       -
-      -   .md\\\\:prose-sm p {
+      -   .md\\\\:prose-sm :where(p) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm [class~='lead'] {
+      -   .md\\\\:prose-sm :where([class~='lead']) {
       -     font-size: 1.2857143em;
       -     line-height: 1.5555556;
       -     margin-top: 0.8888889em;
       -     margin-bottom: 0.8888889em;
       -   }
       -
-      -   .md\\\\:prose-sm blockquote {
+      -   .md\\\\:prose-sm :where(blockquote) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .md\\\\:prose-sm h1 {
+      -   .md\\\\:prose-sm :where(h1) {
       -     font-size: 2.1428571em;
-      +   .md\\\\:markdown hr + * {
+      +   .md\\\\:markdown :where(hr + *) {
 
       ---
 
@@ -20604,43 +20604,43 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-sm h2 {
+      -   .md\\\\:prose-sm :where(h2) {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
       -   }
       -
-      -   .md\\\\:prose-sm h3 {
+      -   .md\\\\:prose-sm :where(h3) {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.4444444em;
       -     line-height: 1.5555556;
       -   }
       -
-      -   .md\\\\:prose-sm h4 {
+      -   .md\\\\:prose-sm :where(h4) {
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
       -   }
       -
-      -   .md\\\\:prose-sm img {
+      -   .md\\\\:prose-sm :where(img) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .md\\\\:prose-sm video {
+      -   .md\\\\:prose-sm :where(video) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .md\\\\:prose-sm figure {
+      -   .md\\\\:prose-sm :where(figure) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .md\\\\:prose-sm figure > * {
-      +   .md\\\\:markdown h2 + * {
+      -   .md\\\\:prose-sm :where(figure > *) {
+      +   .md\\\\:markdown :where(h2 + *) {
 
       ---
 
@@ -20648,25 +20648,25 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-sm figure figcaption {
+      -   .md\\\\:prose-sm :where(figure figcaption) {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
       -   }
       -
-      -   .md\\\\:prose-sm code {
+      -   .md\\\\:prose-sm :where(code) {
       -     font-size: 0.8571429em;
       -   }
       -
-      -   .md\\\\:prose-sm h2 code {
+      -   .md\\\\:prose-sm :where(h2 code) {
       -     font-size: 0.9em;
       -   }
       -
-      -   .md\\\\:prose-sm h3 code {
+      -   .md\\\\:prose-sm :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .md\\\\:prose-sm pre {
+      -   .md\\\\:prose-sm :where(pre) {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
       -     margin-top: 1.6666667em;
@@ -20678,137 +20678,137 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1em;
       -   }
       -
-      -   .md\\\\:prose-sm ol {
+      -   .md\\\\:prose-sm :where(ol) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm ul {
+      -   .md\\\\:prose-sm :where(ul) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm li {
+      -   .md\\\\:prose-sm :where(li) {
       -     margin-top: 0.2857143em;
       -     margin-bottom: 0.2857143em;
       -   }
       -
-      -   .md\\\\:prose-sm ol > li {
+      -   .md\\\\:prose-sm :where(ol > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm ol > li::before {
+      -   .md\\\\:prose-sm :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .md\\\\:prose-sm ul > li {
+      -   .md\\\\:prose-sm :where(ul > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm ul > li::before {
+      -   .md\\\\:prose-sm :where(ul > li::before) {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
       -     left: 0.2142857em;
       -   }
       -
-      -   .md\\\\:prose-sm > ul > li p {
+      -   .md\\\\:prose-sm :where(> ul > li p) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm > ul > li > *:first-child {
+      -   .md\\\\:prose-sm :where(> ul > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm > ul > li > *:last-child {
+      -   .md\\\\:prose-sm :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm > ol > li > *:first-child {
+      -   .md\\\\:prose-sm :where(> ol > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm > ol > li > *:last-child {
+      -   .md\\\\:prose-sm :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .md\\\\:prose-sm ul ul, .md\\\\:prose-sm ul ol, .md\\\\:prose-sm ol ul, .md\\\\:prose-sm ol ol {
+      -   .md\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm hr {
+      -   .md\\\\:prose-sm :where(hr) {
       -     margin-top: 2.8571429em;
       -     margin-bottom: 2.8571429em;
       -   }
       -
-      -   .md\\\\:prose-sm hr + * {
-      +   .md\\\\:markdown h3 + * {
+      -   .md\\\\:prose-sm :where(hr + *) {
+      +   .md\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-sm h2 + * {
+      -   .md\\\\:prose-sm :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-sm h3 + * {
+      -   .md\\\\:prose-sm :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .md\\\\:prose-sm h4 + * {
-      +   .md\\\\:markdown h4 + * {
+      -   .md\\\\:prose-sm :where(h4 + *) {
+      +   .md\\\\:markdown :where(h4 + *) {
 
       ---
 
       -   }
       -
-      -   .md\\\\:prose-sm table {
+      -   .md\\\\:prose-sm :where(table) {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
 
       ---
 
-      -   .md\\\\:prose-sm thead th {
+      -   .md\\\\:prose-sm :where(thead th) {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .md\\\\:prose-sm thead th:first-child {
-      +   .md\\\\:markdown thead th:first-child {
+      -   .md\\\\:prose-sm :where(thead th:first-child) {
+      +   .md\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm thead th:last-child {
-      +   .md\\\\:markdown thead th:last-child {
+      -   .md\\\\:prose-sm :where(thead th:last-child) {
+      +   .md\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm tbody td {
+      -   .md\\\\:prose-sm :where(tbody td) {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .md\\\\:prose-sm tbody td:first-child {
-      +   .md\\\\:markdown tbody td:first-child {
+      -   .md\\\\:prose-sm :where(tbody td:first-child) {
+      +   .md\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm tbody td:last-child {
-      +   .md\\\\:markdown tbody td:last-child {
+      -   .md\\\\:prose-sm :where(tbody td:last-child) {
+      +   .md\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > :first-child {
-      +   .md\\\\:markdown > :first-child {
+      -   .md\\\\:prose-sm :where(> :first-child) {
+      +   .md\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-sm > :last-child {
-      +   .md\\\\:markdown > :last-child {
+      -   .md\\\\:prose-sm :where(> :last-child) {
+      +   .md\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -20817,218 +20817,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-lg p {
-      +   .md\\\\:markdown-lg p {
+      -   .md\\\\:prose-lg :where(p) {
+      +   .md\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .md\\\\:prose-lg [class~='lead'] {
-      +   .md\\\\:markdown-lg [class~='lead'] {
+      -   .md\\\\:prose-lg :where([class~='lead']) {
+      +   .md\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-lg blockquote {
-      +   .md\\\\:markdown-lg blockquote {
+      -   .md\\\\:prose-lg :where(blockquote) {
+      +   .md\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-lg h1 {
-      +   .md\\\\:markdown-lg h1 {
+      -   .md\\\\:prose-lg :where(h1) {
+      +   .md\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 {
-      +   .md\\\\:markdown-lg h2 {
+      -   .md\\\\:prose-lg :where(h2) {
+      +   .md\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 {
-      +   .md\\\\:markdown-lg h3 {
+      -   .md\\\\:prose-lg :where(h3) {
+      +   .md\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-lg h4 {
-      +   .md\\\\:markdown-lg h4 {
+      -   .md\\\\:prose-lg :where(h4) {
+      +   .md\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-lg img {
-      +   .md\\\\:markdown-lg img {
+      -   .md\\\\:prose-lg :where(img) {
+      +   .md\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .md\\\\:prose-lg video {
-      +   .md\\\\:markdown-lg video {
+      -   .md\\\\:prose-lg :where(video) {
+      +   .md\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .md\\\\:prose-lg figure {
-      +   .md\\\\:markdown-lg figure {
+      -   .md\\\\:prose-lg :where(figure) {
+      +   .md\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-lg figure > * {
-      +   .md\\\\:markdown-lg figure > * {
+      -   .md\\\\:prose-lg :where(figure > *) {
+      +   .md\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-lg figure figcaption {
-      +   .md\\\\:markdown-lg figure figcaption {
+      -   .md\\\\:prose-lg :where(figure figcaption) {
+      +   .md\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-lg code {
-      +   .md\\\\:markdown-lg code {
+      -   .md\\\\:prose-lg :where(code) {
+      +   .md\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 code {
-      +   .md\\\\:markdown-lg h2 code {
+      -   .md\\\\:prose-lg :where(h2 code) {
+      +   .md\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 code {
-      +   .md\\\\:markdown-lg h3 code {
+      -   .md\\\\:prose-lg :where(h3 code) {
+      +   .md\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-lg pre {
-      +   .md\\\\:markdown-lg pre {
+      -   .md\\\\:prose-lg :where(pre) {
+      +   .md\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-lg ol {
-      +   .md\\\\:markdown-lg ol {
+      -   .md\\\\:prose-lg :where(ol) {
+      +   .md\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-lg ul {
-      +   .md\\\\:markdown-lg ul {
+      -   .md\\\\:prose-lg :where(ul) {
+      +   .md\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-lg li {
-      +   .md\\\\:markdown-lg li {
+      -   .md\\\\:prose-lg :where(li) {
+      +   .md\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .md\\\\:prose-lg ol > li {
-      +   .md\\\\:markdown-lg ol > li {
+      -   .md\\\\:prose-lg :where(ol > li) {
+      +   .md\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-lg ol > li::before {
-      +   .md\\\\:markdown-lg ol > li::before {
+      -   .md\\\\:prose-lg :where(ol > li::before) {
+      +   .md\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-lg ul > li {
-      +   .md\\\\:markdown-lg ul > li {
+      -   .md\\\\:prose-lg :where(ul > li) {
+      +   .md\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-lg ul > li::before {
-      +   .md\\\\:markdown-lg ul > li::before {
+      -   .md\\\\:prose-lg :where(ul > li::before) {
+      +   .md\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li p {
-      +   .md\\\\:markdown-lg > ul > li p {
+      -   .md\\\\:prose-lg :where(> ul > li p) {
+      +   .md\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li > *:first-child {
-      +   .md\\\\:markdown-lg > ul > li > *:first-child {
+      -   .md\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ul > li > *:last-child {
-      +   .md\\\\:markdown-lg > ul > li > *:last-child {
+      -   .md\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ol > li > *:first-child {
-      +   .md\\\\:markdown-lg > ol > li > *:first-child {
+      -   .md\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > ol > li > *:last-child {
-      +   .md\\\\:markdown-lg > ol > li > *:last-child {
+      -   .md\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg ul ul, .md\\\\:prose-lg ul ol, .md\\\\:prose-lg ol ul, .md\\\\:prose-lg ol ol {
-      +   .md\\\\:markdown-lg ul ul, .md\\\\:markdown-lg ul ol, .md\\\\:markdown-lg ol ul, .md\\\\:markdown-lg ol ol {
+      -   .md\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-lg hr {
-      +   .md\\\\:markdown-lg hr {
+      -   .md\\\\:prose-lg :where(hr) {
+      +   .md\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-lg hr + * {
-      +   .md\\\\:markdown-lg hr + * {
+      -   .md\\\\:prose-lg :where(hr + *) {
+      +   .md\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h2 + * {
-      +   .md\\\\:markdown-lg h2 + * {
+      -   .md\\\\:prose-lg :where(h2 + *) {
+      +   .md\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h3 + * {
-      +   .md\\\\:markdown-lg h3 + * {
+      -   .md\\\\:prose-lg :where(h3 + *) {
+      +   .md\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg h4 + * {
-      +   .md\\\\:markdown-lg h4 + * {
+      -   .md\\\\:prose-lg :where(h4 + *) {
+      +   .md\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-lg table {
-      +   .md\\\\:markdown-lg table {
+      -   .md\\\\:prose-lg :where(table) {
+      +   .md\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th {
-      +   .md\\\\:markdown-lg thead th {
+      -   .md\\\\:prose-lg :where(thead th) {
+      +   .md\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th:first-child {
-      +   .md\\\\:markdown-lg thead th:first-child {
+      -   .md\\\\:prose-lg :where(thead th:first-child) {
+      +   .md\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg thead th:last-child {
-      +   .md\\\\:markdown-lg thead th:last-child {
+      -   .md\\\\:prose-lg :where(thead th:last-child) {
+      +   .md\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td {
-      +   .md\\\\:markdown-lg tbody td {
+      -   .md\\\\:prose-lg :where(tbody td) {
+      +   .md\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td:first-child {
-      +   .md\\\\:markdown-lg tbody td:first-child {
+      -   .md\\\\:prose-lg :where(tbody td:first-child) {
+      +   .md\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg tbody td:last-child {
-      +   .md\\\\:markdown-lg tbody td:last-child {
+      -   .md\\\\:prose-lg :where(tbody td:last-child) {
+      +   .md\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > :first-child {
-      +   .md\\\\:markdown-lg > :first-child {
+      -   .md\\\\:prose-lg :where(> :first-child) {
+      +   .md\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-lg > :last-child {
-      +   .md\\\\:markdown-lg > :last-child {
+      -   .md\\\\:prose-lg :where(> :last-child) {
+      +   .md\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -21037,218 +21037,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-xl p {
-      +   .md\\\\:markdown-xl p {
+      -   .md\\\\:prose-xl :where(p) {
+      +   .md\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .md\\\\:prose-xl [class~='lead'] {
-      +   .md\\\\:markdown-xl [class~='lead'] {
+      -   .md\\\\:prose-xl :where([class~='lead']) {
+      +   .md\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-xl blockquote {
-      +   .md\\\\:markdown-xl blockquote {
+      -   .md\\\\:prose-xl :where(blockquote) {
+      +   .md\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-xl h1 {
-      +   .md\\\\:markdown-xl h1 {
+      -   .md\\\\:prose-xl :where(h1) {
+      +   .md\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 {
-      +   .md\\\\:markdown-xl h2 {
+      -   .md\\\\:prose-xl :where(h2) {
+      +   .md\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 {
-      +   .md\\\\:markdown-xl h3 {
+      -   .md\\\\:prose-xl :where(h3) {
+      +   .md\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-xl h4 {
-      +   .md\\\\:markdown-xl h4 {
+      -   .md\\\\:prose-xl :where(h4) {
+      +   .md\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-xl img {
-      +   .md\\\\:markdown-xl img {
+      -   .md\\\\:prose-xl :where(img) {
+      +   .md\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .md\\\\:prose-xl video {
-      +   .md\\\\:markdown-xl video {
+      -   .md\\\\:prose-xl :where(video) {
+      +   .md\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .md\\\\:prose-xl figure {
-      +   .md\\\\:markdown-xl figure {
+      -   .md\\\\:prose-xl :where(figure) {
+      +   .md\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-xl figure > * {
-      +   .md\\\\:markdown-xl figure > * {
+      -   .md\\\\:prose-xl :where(figure > *) {
+      +   .md\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-xl figure figcaption {
-      +   .md\\\\:markdown-xl figure figcaption {
+      -   .md\\\\:prose-xl :where(figure figcaption) {
+      +   .md\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-xl code {
-      +   .md\\\\:markdown-xl code {
+      -   .md\\\\:prose-xl :where(code) {
+      +   .md\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 code {
-      +   .md\\\\:markdown-xl h2 code {
+      -   .md\\\\:prose-xl :where(h2 code) {
+      +   .md\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 code {
-      +   .md\\\\:markdown-xl h3 code {
+      -   .md\\\\:prose-xl :where(h3 code) {
+      +   .md\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-xl pre {
-      +   .md\\\\:markdown-xl pre {
+      -   .md\\\\:prose-xl :where(pre) {
+      +   .md\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-xl ol {
-      +   .md\\\\:markdown-xl ol {
+      -   .md\\\\:prose-xl :where(ol) {
+      +   .md\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-xl ul {
-      +   .md\\\\:markdown-xl ul {
+      -   .md\\\\:prose-xl :where(ul) {
+      +   .md\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-xl li {
-      +   .md\\\\:markdown-xl li {
+      -   .md\\\\:prose-xl :where(li) {
+      +   .md\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .md\\\\:prose-xl ol > li {
-      +   .md\\\\:markdown-xl ol > li {
+      -   .md\\\\:prose-xl :where(ol > li) {
+      +   .md\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-xl ol > li::before {
-      +   .md\\\\:markdown-xl ol > li::before {
+      -   .md\\\\:prose-xl :where(ol > li::before) {
+      +   .md\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-xl ul > li {
-      +   .md\\\\:markdown-xl ul > li {
+      -   .md\\\\:prose-xl :where(ul > li) {
+      +   .md\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-xl ul > li::before {
-      +   .md\\\\:markdown-xl ul > li::before {
+      -   .md\\\\:prose-xl :where(ul > li::before) {
+      +   .md\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li p {
-      +   .md\\\\:markdown-xl > ul > li p {
+      -   .md\\\\:prose-xl :where(> ul > li p) {
+      +   .md\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li > *:first-child {
-      +   .md\\\\:markdown-xl > ul > li > *:first-child {
+      -   .md\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ul > li > *:last-child {
-      +   .md\\\\:markdown-xl > ul > li > *:last-child {
+      -   .md\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ol > li > *:first-child {
-      +   .md\\\\:markdown-xl > ol > li > *:first-child {
+      -   .md\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > ol > li > *:last-child {
-      +   .md\\\\:markdown-xl > ol > li > *:last-child {
+      -   .md\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl ul ul, .md\\\\:prose-xl ul ol, .md\\\\:prose-xl ol ul, .md\\\\:prose-xl ol ol {
-      +   .md\\\\:markdown-xl ul ul, .md\\\\:markdown-xl ul ol, .md\\\\:markdown-xl ol ul, .md\\\\:markdown-xl ol ol {
+      -   .md\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-xl hr {
-      +   .md\\\\:markdown-xl hr {
+      -   .md\\\\:prose-xl :where(hr) {
+      +   .md\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-xl hr + * {
-      +   .md\\\\:markdown-xl hr + * {
+      -   .md\\\\:prose-xl :where(hr + *) {
+      +   .md\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h2 + * {
-      +   .md\\\\:markdown-xl h2 + * {
+      -   .md\\\\:prose-xl :where(h2 + *) {
+      +   .md\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h3 + * {
-      +   .md\\\\:markdown-xl h3 + * {
+      -   .md\\\\:prose-xl :where(h3 + *) {
+      +   .md\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl h4 + * {
-      +   .md\\\\:markdown-xl h4 + * {
+      -   .md\\\\:prose-xl :where(h4 + *) {
+      +   .md\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-xl table {
-      +   .md\\\\:markdown-xl table {
+      -   .md\\\\:prose-xl :where(table) {
+      +   .md\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th {
-      +   .md\\\\:markdown-xl thead th {
+      -   .md\\\\:prose-xl :where(thead th) {
+      +   .md\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th:first-child {
-      +   .md\\\\:markdown-xl thead th:first-child {
+      -   .md\\\\:prose-xl :where(thead th:first-child) {
+      +   .md\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl thead th:last-child {
-      +   .md\\\\:markdown-xl thead th:last-child {
+      -   .md\\\\:prose-xl :where(thead th:last-child) {
+      +   .md\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td {
-      +   .md\\\\:markdown-xl tbody td {
+      -   .md\\\\:prose-xl :where(tbody td) {
+      +   .md\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td:first-child {
-      +   .md\\\\:markdown-xl tbody td:first-child {
+      -   .md\\\\:prose-xl :where(tbody td:first-child) {
+      +   .md\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl tbody td:last-child {
-      +   .md\\\\:markdown-xl tbody td:last-child {
+      -   .md\\\\:prose-xl :where(tbody td:last-child) {
+      +   .md\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > :first-child {
-      +   .md\\\\:markdown-xl > :first-child {
+      -   .md\\\\:prose-xl :where(> :first-child) {
+      +   .md\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-xl > :last-child {
-      +   .md\\\\:markdown-xl > :last-child {
+      -   .md\\\\:prose-xl :where(> :last-child) {
+      +   .md\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -21257,276 +21257,276 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-2xl p {
-      +   .md\\\\:markdown-2xl p {
+      -   .md\\\\:prose-2xl :where(p) {
+      +   .md\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .md\\\\:prose-2xl [class~='lead'] {
-      +   .md\\\\:markdown-2xl [class~='lead'] {
+      -   .md\\\\:prose-2xl :where([class~='lead']) {
+      +   .md\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .md\\\\:prose-2xl blockquote {
-      +   .md\\\\:markdown-2xl blockquote {
+      -   .md\\\\:prose-2xl :where(blockquote) {
+      +   .md\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .md\\\\:prose-2xl h1 {
-      +   .md\\\\:markdown-2xl h1 {
+      -   .md\\\\:prose-2xl :where(h1) {
+      +   .md\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 {
-      +   .md\\\\:markdown-2xl h2 {
+      -   .md\\\\:prose-2xl :where(h2) {
+      +   .md\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 {
-      +   .md\\\\:markdown-2xl h3 {
+      -   .md\\\\:prose-2xl :where(h3) {
+      +   .md\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .md\\\\:prose-2xl h4 {
-      +   .md\\\\:markdown-2xl h4 {
+      -   .md\\\\:prose-2xl :where(h4) {
+      +   .md\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .md\\\\:prose-2xl img {
-      +   .md\\\\:markdown-2xl img {
+      -   .md\\\\:prose-2xl :where(img) {
+      +   .md\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .md\\\\:prose-2xl video {
-      +   .md\\\\:markdown-2xl video {
+      -   .md\\\\:prose-2xl :where(video) {
+      +   .md\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure {
-      +   .md\\\\:markdown-2xl figure {
+      -   .md\\\\:prose-2xl :where(figure) {
+      +   .md\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure > * {
-      +   .md\\\\:markdown-2xl figure > * {
+      -   .md\\\\:prose-2xl :where(figure > *) {
+      +   .md\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .md\\\\:prose-2xl figure figcaption {
-      +   .md\\\\:markdown-2xl figure figcaption {
+      -   .md\\\\:prose-2xl :where(figure figcaption) {
+      +   .md\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .md\\\\:prose-2xl code {
-      +   .md\\\\:markdown-2xl code {
+      -   .md\\\\:prose-2xl :where(code) {
+      +   .md\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 code {
-      +   .md\\\\:markdown-2xl h2 code {
+      -   .md\\\\:prose-2xl :where(h2 code) {
+      +   .md\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 code {
-      +   .md\\\\:markdown-2xl h3 code {
+      -   .md\\\\:prose-2xl :where(h3 code) {
+      +   .md\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .md\\\\:prose-2xl pre {
-      +   .md\\\\:markdown-2xl pre {
+      -   .md\\\\:prose-2xl :where(pre) {
+      +   .md\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol {
-      +   .md\\\\:markdown-2xl ol {
+      -   .md\\\\:prose-2xl :where(ol) {
+      +   .md\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul {
-      +   .md\\\\:markdown-2xl ul {
+      -   .md\\\\:prose-2xl :where(ul) {
+      +   .md\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .md\\\\:prose-2xl li {
-      +   .md\\\\:markdown-2xl li {
+      -   .md\\\\:prose-2xl :where(li) {
+      +   .md\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol > li {
-      +   .md\\\\:markdown-2xl ol > li {
+      -   .md\\\\:prose-2xl :where(ol > li) {
+      +   .md\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ol > li::before {
-      +   .md\\\\:markdown-2xl ol > li::before {
+      -   .md\\\\:prose-2xl :where(ol > li::before) {
+      +   .md\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul > li {
-      +   .md\\\\:markdown-2xl ul > li {
+      -   .md\\\\:prose-2xl :where(ul > li) {
+      +   .md\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul > li::before {
-      +   .md\\\\:markdown-2xl ul > li::before {
+      -   .md\\\\:prose-2xl :where(ul > li::before) {
+      +   .md\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li p {
-      +   .md\\\\:markdown-2xl > ul > li p {
+      -   .md\\\\:prose-2xl :where(> ul > li p) {
+      +   .md\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li > *:first-child {
-      +   .md\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ul > li > *:last-child {
-      +   .md\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ol > li > *:first-child {
-      +   .md\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > ol > li > *:last-child {
-      +   .md\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .md\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl ul ul, .md\\\\:prose-2xl ul ol, .md\\\\:prose-2xl ol ul, .md\\\\:prose-2xl ol ol {
-      +   .md\\\\:markdown-2xl ul ul, .md\\\\:markdown-2xl ul ol, .md\\\\:markdown-2xl ol ul, .md\\\\:markdown-2xl ol ol {
+      -   .md\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .md\\\\:prose-2xl hr {
-      +   .md\\\\:markdown-2xl hr {
+      -   .md\\\\:prose-2xl :where(hr) {
+      +   .md\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .md\\\\:prose-2xl hr + * {
-      +   .md\\\\:markdown-2xl hr + * {
+      -   .md\\\\:prose-2xl :where(hr + *) {
+      +   .md\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h2 + * {
-      +   .md\\\\:markdown-2xl h2 + * {
+      -   .md\\\\:prose-2xl :where(h2 + *) {
+      +   .md\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h3 + * {
-      +   .md\\\\:markdown-2xl h3 + * {
+      -   .md\\\\:prose-2xl :where(h3 + *) {
+      +   .md\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl h4 + * {
-      +   .md\\\\:markdown-2xl h4 + * {
+      -   .md\\\\:prose-2xl :where(h4 + *) {
+      +   .md\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .md\\\\:prose-2xl table {
-      +   .md\\\\:markdown-2xl table {
+      -   .md\\\\:prose-2xl :where(table) {
+      +   .md\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th {
-      +   .md\\\\:markdown-2xl thead th {
+      -   .md\\\\:prose-2xl :where(thead th) {
+      +   .md\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th:first-child {
-      +   .md\\\\:markdown-2xl thead th:first-child {
+      -   .md\\\\:prose-2xl :where(thead th:first-child) {
+      +   .md\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl thead th:last-child {
-      +   .md\\\\:markdown-2xl thead th:last-child {
+      -   .md\\\\:prose-2xl :where(thead th:last-child) {
+      +   .md\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td {
-      +   .md\\\\:markdown-2xl tbody td {
+      -   .md\\\\:prose-2xl :where(tbody td) {
+      +   .md\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td:first-child {
-      +   .md\\\\:markdown-2xl tbody td:first-child {
+      -   .md\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .md\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl tbody td:last-child {
-      +   .md\\\\:markdown-2xl tbody td:last-child {
+      -   .md\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .md\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > :first-child {
-      +   .md\\\\:markdown-2xl > :first-child {
+      -   .md\\\\:prose-2xl :where(> :first-child) {
+      +   .md\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .md\\\\:prose-2xl > :last-child {
-      +   .md\\\\:markdown-2xl > :last-child {
+      -   .md\\\\:prose-2xl :where(> :last-child) {
+      +   .md\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .md\\\\:prose-red a {
+      -   .md\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .md\\\\:prose-red a code {
+      -   .md\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .md\\\\:prose-yellow a {
+      -   .md\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .md\\\\:prose-yellow a code {
+      -   .md\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .md\\\\:prose-green a {
+      -   .md\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .md\\\\:prose-green a code {
+      -   .md\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .md\\\\:prose-blue a {
+      -   .md\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .md\\\\:prose-blue a code {
+      -   .md\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .md\\\\:prose-indigo a {
+      -   .md\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .md\\\\:prose-indigo a code {
+      -   .md\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .md\\\\:prose-purple a {
+      -   .md\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .md\\\\:prose-purple a code {
+      -   .md\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .md\\\\:prose-pink a {
+      -   .md\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .md\\\\:prose-pink a code {
+      -   .md\\\\:prose-pink :where(a code) {
       -     color: #db2777;
 
       ---
@@ -21536,218 +21536,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose [class~='lead'] {
-      +   .lg\\\\:markdown [class~='lead'] {
+      -   .lg\\\\:prose :where([class~='lead']) {
+      +   .lg\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose a {
-      +   .lg\\\\:markdown a {
+      -   .lg\\\\:prose :where(a) {
+      +   .lg\\\\:markdown :where(a) {
 
       ---
 
-      -   .lg\\\\:prose strong {
-      +   .lg\\\\:markdown strong {
+      -   .lg\\\\:prose :where(strong) {
+      +   .lg\\\\:markdown :where(strong) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='A'] {
-      +   .lg\\\\:markdown ol[type='A'] {
+      -   .lg\\\\:prose :where(ol[type='A']) {
+      +   .lg\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='a'] {
-      +   .lg\\\\:markdown ol[type='a'] {
+      -   .lg\\\\:prose :where(ol[type='a']) {
+      +   .lg\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='A' s] {
-      +   .lg\\\\:markdown ol[type='A' s] {
+      -   .lg\\\\:prose :where(ol[type='A' s]) {
+      +   .lg\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='a' s] {
-      +   .lg\\\\:markdown ol[type='a' s] {
+      -   .lg\\\\:prose :where(ol[type='a' s]) {
+      +   .lg\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='I'] {
-      +   .lg\\\\:markdown ol[type='I'] {
+      -   .lg\\\\:prose :where(ol[type='I']) {
+      +   .lg\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='i'] {
-      +   .lg\\\\:markdown ol[type='i'] {
+      -   .lg\\\\:prose :where(ol[type='i']) {
+      +   .lg\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='I' s] {
-      +   .lg\\\\:markdown ol[type='I' s] {
+      -   .lg\\\\:prose :where(ol[type='I' s]) {
+      +   .lg\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='i' s] {
-      +   .lg\\\\:markdown ol[type='i' s] {
+      -   .lg\\\\:prose :where(ol[type='i' s]) {
+      +   .lg\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .lg\\\\:prose ol[type='1'] {
-      +   .lg\\\\:markdown ol[type='1'] {
+      -   .lg\\\\:prose :where(ol[type='1']) {
+      +   .lg\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .lg\\\\:prose ol > li {
-      +   .lg\\\\:markdown ol > li {
+      -   .lg\\\\:prose :where(ol > li) {
+      +   .lg\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose ol > li::before {
-      +   .lg\\\\:markdown ol > li::before {
+      -   .lg\\\\:prose :where(ol > li::before) {
+      +   .lg\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose ul > li {
-      +   .lg\\\\:markdown ul > li {
+      -   .lg\\\\:prose :where(ul > li) {
+      +   .lg\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose ul > li::before {
-      +   .lg\\\\:markdown ul > li::before {
+      -   .lg\\\\:prose :where(ul > li::before) {
+      +   .lg\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose hr {
-      +   .lg\\\\:markdown hr {
+      -   .lg\\\\:prose :where(hr) {
+      +   .lg\\\\:markdown :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose blockquote {
-      +   .lg\\\\:markdown blockquote {
+      -   .lg\\\\:prose :where(blockquote) {
+      +   .lg\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose blockquote p:first-of-type::before {
-      +   .lg\\\\:markdown blockquote p:first-of-type::before {
+      -   .lg\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .lg\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .lg\\\\:prose blockquote p:last-of-type::after {
-      +   .lg\\\\:markdown blockquote p:last-of-type::after {
+      -   .lg\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .lg\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .lg\\\\:prose h1 {
-      +   .lg\\\\:markdown h1 {
+      -   .lg\\\\:prose :where(h1) {
+      +   .lg\\\\:markdown :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose h1 strong {
-      +   .lg\\\\:markdown h1 strong {
+      -   .lg\\\\:prose :where(h1 strong) {
+      +   .lg\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .lg\\\\:prose h2 {
-      +   .lg\\\\:markdown h2 {
+      -   .lg\\\\:prose :where(h2) {
+      +   .lg\\\\:markdown :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose h2 strong {
-      +   .lg\\\\:markdown h2 strong {
+      -   .lg\\\\:prose :where(h2 strong) {
+      +   .lg\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .lg\\\\:prose h3 {
-      +   .lg\\\\:markdown h3 {
+      -   .lg\\\\:prose :where(h3) {
+      +   .lg\\\\:markdown :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose h3 strong {
-      +   .lg\\\\:markdown h3 strong {
+      -   .lg\\\\:prose :where(h3 strong) {
+      +   .lg\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .lg\\\\:prose h4 {
-      +   .lg\\\\:markdown h4 {
+      -   .lg\\\\:prose :where(h4) {
+      +   .lg\\\\:markdown :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose h4 strong {
-      +   .lg\\\\:markdown h4 strong {
+      -   .lg\\\\:prose :where(h4 strong) {
+      +   .lg\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .lg\\\\:prose figure figcaption {
-      +   .lg\\\\:markdown figure figcaption {
+      -   .lg\\\\:prose :where(figure figcaption) {
+      +   .lg\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose code {
-      +   .lg\\\\:markdown code {
+      -   .lg\\\\:prose :where(code) {
+      +   .lg\\\\:markdown :where(code) {
 
       ---
 
-      -   .lg\\\\:prose code::before {
-      +   .lg\\\\:markdown code::before {
+      -   .lg\\\\:prose :where(code::before) {
+      +   .lg\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .lg\\\\:prose code::after {
-      +   .lg\\\\:markdown code::after {
+      -   .lg\\\\:prose :where(code::after) {
+      +   .lg\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .lg\\\\:prose a code {
-      +   .lg\\\\:markdown a code {
+      -   .lg\\\\:prose :where(a code) {
+      +   .lg\\\\:markdown :where(a code) {
 
       ---
 
-      -   .lg\\\\:prose pre {
-      +   .lg\\\\:markdown pre {
+      -   .lg\\\\:prose :where(pre) {
+      +   .lg\\\\:markdown :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose pre code {
-      +   .lg\\\\:markdown pre code {
+      -   .lg\\\\:prose :where(pre code) {
+      +   .lg\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .lg\\\\:prose pre code::before {
-      +   .lg\\\\:markdown pre code::before {
+      -   .lg\\\\:prose :where(pre code::before) {
+      +   .lg\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .lg\\\\:prose pre code::after {
-      +   .lg\\\\:markdown pre code::after {
+      -   .lg\\\\:prose :where(pre code::after) {
+      +   .lg\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .lg\\\\:prose table {
-      +   .lg\\\\:markdown table {
+      -   .lg\\\\:prose :where(table) {
+      +   .lg\\\\:markdown :where(table) {
 
       ---
 
-      -   .lg\\\\:prose thead {
-      +   .lg\\\\:markdown thead {
+      -   .lg\\\\:prose :where(thead) {
+      +   .lg\\\\:markdown :where(thead) {
 
       ---
 
-      -   .lg\\\\:prose thead th {
-      +   .lg\\\\:markdown thead th {
+      -   .lg\\\\:prose :where(thead th) {
+      +   .lg\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose tbody tr {
-      +   .lg\\\\:markdown tbody tr {
+      -   .lg\\\\:prose :where(tbody tr) {
+      +   .lg\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .lg\\\\:prose tbody tr:last-child {
-      +   .lg\\\\:markdown tbody tr:last-child {
+      -   .lg\\\\:prose :where(tbody tr:last-child) {
+      +   .lg\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .lg\\\\:prose tbody td {
-      +   .lg\\\\:markdown tbody td {
+      -   .lg\\\\:prose :where(tbody td) {
+      +   .lg\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -21756,218 +21756,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose p {
-      +   .lg\\\\:markdown p {
+      -   .lg\\\\:prose :where(p) {
+      +   .lg\\\\:markdown :where(p) {
 
       ---
 
-      -   .lg\\\\:prose img {
-      +   .lg\\\\:markdown img {
+      -   .lg\\\\:prose :where(img) {
+      +   .lg\\\\:markdown :where(img) {
 
       ---
 
-      -   .lg\\\\:prose video {
-      +   .lg\\\\:markdown video {
+      -   .lg\\\\:prose :where(video) {
+      +   .lg\\\\:markdown :where(video) {
 
       ---
 
-      -   .lg\\\\:prose figure {
-      +   .lg\\\\:markdown figure {
+      -   .lg\\\\:prose :where(figure) {
+      +   .lg\\\\:markdown :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose figure > * {
-      +   .lg\\\\:markdown figure > * {
+      -   .lg\\\\:prose :where(figure > *) {
+      +   .lg\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose h2 code {
-      +   .lg\\\\:markdown h2 code {
+      -   .lg\\\\:prose :where(h2 code) {
+      +   .lg\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose h3 code {
-      +   .lg\\\\:markdown h3 code {
+      -   .lg\\\\:prose :where(h3 code) {
+      +   .lg\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose ol {
-      +   .lg\\\\:markdown ol {
+      -   .lg\\\\:prose :where(ol) {
+      +   .lg\\\\:markdown :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose ul {
-      +   .lg\\\\:markdown ul {
+      -   .lg\\\\:prose :where(ul) {
+      +   .lg\\\\:markdown :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose li {
-      +   .lg\\\\:markdown li {
+      -   .lg\\\\:prose :where(li) {
+      +   .lg\\\\:markdown :where(li) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li p {
-      +   .lg\\\\:markdown > ul > li p {
+      -   .lg\\\\:prose :where(> ul > li p) {
+      +   .lg\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li > *:first-child {
-      +   .lg\\\\:markdown > ul > li > *:first-child {
+      -   .lg\\\\:prose :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose > ul > li > *:last-child {
-      +   .lg\\\\:markdown > ul > li > *:last-child {
+      -   .lg\\\\:prose :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose > ol > li > *:first-child {
-      +   .lg\\\\:markdown > ol > li > *:first-child {
+      -   .lg\\\\:prose :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose > ol > li > *:last-child {
-      +   .lg\\\\:markdown > ol > li > *:last-child {
+      -   .lg\\\\:prose :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose ul ul, .lg\\\\:prose ul ol, .lg\\\\:prose ol ul, .lg\\\\:prose ol ol {
-      +   .lg\\\\:markdown ul ul, .lg\\\\:markdown ul ol, .lg\\\\:markdown ol ul, .lg\\\\:markdown ol ol {
+      -   .lg\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
       -   }
       -
-      -   .lg\\\\:prose hr + * {
+      -   .lg\\\\:prose :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose h2 + * {
+      -   .lg\\\\:prose :where(h2 + *) {
       -     margin-top: 0;
 
       ---
 
-      -   .lg\\\\:prose h3 + * {
+      -   .lg\\\\:prose :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose h4 + * {
+      -   .lg\\\\:prose :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose thead th:first-child {
+      -   .lg\\\\:prose :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .lg\\\\:prose thead th:last-child {
+      -   .lg\\\\:prose :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .lg\\\\:prose tbody td:first-child {
+      -   .lg\\\\:prose :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .lg\\\\:prose tbody td:last-child {
+      -   .lg\\\\:prose :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .lg\\\\:prose > :first-child {
+      -   .lg\\\\:prose :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .lg\\\\:prose > :last-child {
+      -   .lg\\\\:prose :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
       -   .lg\\\\:prose-sm {
-      -     font-size: 0.875rem;
-      -     line-height: 1.7142857;
+      -     :where(font-size): 0.875rem;
+      -     :where(line-height): 1.7142857;
       -   }
       -
-      -   .lg\\\\:prose-sm p {
+      -   .lg\\\\:prose-sm :where(p) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm [class~='lead'] {
+      -   .lg\\\\:prose-sm :where([class~='lead']) {
       -     font-size: 1.2857143em;
       -     line-height: 1.5555556;
       -     margin-top: 0.8888889em;
       -     margin-bottom: 0.8888889em;
       -   }
       -
-      -   .lg\\\\:prose-sm blockquote {
+      -   .lg\\\\:prose-sm :where(blockquote) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .lg\\\\:prose-sm h1 {
+      -   .lg\\\\:prose-sm :where(h1) {
       -     font-size: 2.1428571em;
       -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
       -
-      -   .lg\\\\:prose-sm h2 {
+      -   .lg\\\\:prose-sm :where(h2) {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
       -   }
       -
-      -   .lg\\\\:prose-sm h3 {
+      -   .lg\\\\:prose-sm :where(h3) {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.4444444em;
       -     line-height: 1.5555556;
       -   }
       -
-      -   .lg\\\\:prose-sm h4 {
+      -   .lg\\\\:prose-sm :where(h4) {
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
       -   }
       -
-      -   .lg\\\\:prose-sm img {
+      -   .lg\\\\:prose-sm :where(img) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .lg\\\\:prose-sm video {
+      -   .lg\\\\:prose-sm :where(video) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .lg\\\\:prose-sm figure {
+      -   .lg\\\\:prose-sm :where(figure) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .lg\\\\:prose-sm figure > * {
+      -   .lg\\\\:prose-sm :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .lg\\\\:prose-sm figure figcaption {
+      -   .lg\\\\:prose-sm :where(figure figcaption) {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-sm code {
+      -   .lg\\\\:prose-sm :where(code) {
       -     font-size: 0.8571429em;
       -   }
       -
-      -   .lg\\\\:prose-sm h2 code {
+      -   .lg\\\\:prose-sm :where(h2 code) {
       -     font-size: 0.9em;
       -   }
       -
-      -   .lg\\\\:prose-sm h3 code {
+      -   .lg\\\\:prose-sm :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .lg\\\\:prose-sm pre {
+      -   .lg\\\\:prose-sm :where(pre) {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
       -     margin-top: 1.6666667em;
@@ -21979,136 +21979,136 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1em;
       -   }
       -
-      -   .lg\\\\:prose-sm ol {
+      -   .lg\\\\:prose-sm :where(ol) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm ul {
+      -   .lg\\\\:prose-sm :where(ul) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm li {
+      -   .lg\\\\:prose-sm :where(li) {
       -     margin-top: 0.2857143em;
       -     margin-bottom: 0.2857143em;
       -   }
       -
-      -   .lg\\\\:prose-sm ol > li {
+      -   .lg\\\\:prose-sm :where(ol > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm ol > li::before {
+      -   .lg\\\\:prose-sm :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .lg\\\\:prose-sm ul > li {
+      -   .lg\\\\:prose-sm :where(ul > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm ul > li::before {
+      -   .lg\\\\:prose-sm :where(ul > li::before) {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
       -     left: 0.2142857em;
       -   }
       -
-      -   .lg\\\\:prose-sm > ul > li p {
+      -   .lg\\\\:prose-sm :where(> ul > li p) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm > ul > li > *:first-child {
+      -   .lg\\\\:prose-sm :where(> ul > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm > ul > li > *:last-child {
+      -   .lg\\\\:prose-sm :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm > ol > li > *:first-child {
+      -   .lg\\\\:prose-sm :where(> ol > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm > ol > li > *:last-child {
+      -   .lg\\\\:prose-sm :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .lg\\\\:prose-sm ul ul, .lg\\\\:prose-sm ul ol, .lg\\\\:prose-sm ol ul, .lg\\\\:prose-sm ol ol {
+      -   .lg\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm hr {
+      -   .lg\\\\:prose-sm :where(hr) {
       -     margin-top: 2.8571429em;
       -     margin-bottom: 2.8571429em;
       -   }
       -
-      -   .lg\\\\:prose-sm hr + * {
-      +   .lg\\\\:markdown hr + * {
+      -   .lg\\\\:prose-sm :where(hr + *) {
+      +   .lg\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h2 + * {
-      +   .lg\\\\:markdown h2 + * {
+      -   .lg\\\\:prose-sm :where(h2 + *) {
+      +   .lg\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h3 + * {
-      +   .lg\\\\:markdown h3 + * {
+      -   .lg\\\\:prose-sm :where(h3 + *) {
+      +   .lg\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm h4 + * {
-      +   .lg\\\\:markdown h4 + * {
+      -   .lg\\\\:prose-sm :where(h4 + *) {
+      +   .lg\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-sm table {
+      -   .lg\\\\:prose-sm :where(table) {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
       -   }
       -
-      -   .lg\\\\:prose-sm thead th {
+      -   .lg\\\\:prose-sm :where(thead th) {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .lg\\\\:prose-sm thead th:first-child {
-      +   .lg\\\\:markdown thead th:first-child {
+      -   .lg\\\\:prose-sm :where(thead th:first-child) {
+      +   .lg\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm thead th:last-child {
-      +   .lg\\\\:markdown thead th:last-child {
+      -   .lg\\\\:prose-sm :where(thead th:last-child) {
+      +   .lg\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm tbody td {
+      -   .lg\\\\:prose-sm :where(tbody td) {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .lg\\\\:prose-sm tbody td:first-child {
-      +   .lg\\\\:markdown tbody td:first-child {
+      -   .lg\\\\:prose-sm :where(tbody td:first-child) {
+      +   .lg\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm tbody td:last-child {
-      +   .lg\\\\:markdown tbody td:last-child {
+      -   .lg\\\\:prose-sm :where(tbody td:last-child) {
+      +   .lg\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > :first-child {
-      +   .lg\\\\:markdown > :first-child {
+      -   .lg\\\\:prose-sm :where(> :first-child) {
+      +   .lg\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-sm > :last-child {
-      +   .lg\\\\:markdown > :last-child {
+      -   .lg\\\\:prose-sm :where(> :last-child) {
+      +   .lg\\\\:markdown :where(> :last-child) {
 
       ---
 
@@ -22117,218 +22117,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-lg p {
-      +   .lg\\\\:markdown-lg p {
+      -   .lg\\\\:prose-lg :where(p) {
+      +   .lg\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-lg [class~='lead'] {
-      +   .lg\\\\:markdown-lg [class~='lead'] {
+      -   .lg\\\\:prose-lg :where([class~='lead']) {
+      +   .lg\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-lg blockquote {
-      +   .lg\\\\:markdown-lg blockquote {
+      -   .lg\\\\:prose-lg :where(blockquote) {
+      +   .lg\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-lg h1 {
-      +   .lg\\\\:markdown-lg h1 {
+      -   .lg\\\\:prose-lg :where(h1) {
+      +   .lg\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 {
-      +   .lg\\\\:markdown-lg h2 {
+      -   .lg\\\\:prose-lg :where(h2) {
+      +   .lg\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 {
-      +   .lg\\\\:markdown-lg h3 {
+      -   .lg\\\\:prose-lg :where(h3) {
+      +   .lg\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-lg h4 {
-      +   .lg\\\\:markdown-lg h4 {
+      -   .lg\\\\:prose-lg :where(h4) {
+      +   .lg\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-lg img {
-      +   .lg\\\\:markdown-lg img {
+      -   .lg\\\\:prose-lg :where(img) {
+      +   .lg\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-lg video {
-      +   .lg\\\\:markdown-lg video {
+      -   .lg\\\\:prose-lg :where(video) {
+      +   .lg\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure {
-      +   .lg\\\\:markdown-lg figure {
+      -   .lg\\\\:prose-lg :where(figure) {
+      +   .lg\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure > * {
-      +   .lg\\\\:markdown-lg figure > * {
+      -   .lg\\\\:prose-lg :where(figure > *) {
+      +   .lg\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-lg figure figcaption {
-      +   .lg\\\\:markdown-lg figure figcaption {
+      -   .lg\\\\:prose-lg :where(figure figcaption) {
+      +   .lg\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-lg code {
-      +   .lg\\\\:markdown-lg code {
+      -   .lg\\\\:prose-lg :where(code) {
+      +   .lg\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 code {
-      +   .lg\\\\:markdown-lg h2 code {
+      -   .lg\\\\:prose-lg :where(h2 code) {
+      +   .lg\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 code {
-      +   .lg\\\\:markdown-lg h3 code {
+      -   .lg\\\\:prose-lg :where(h3 code) {
+      +   .lg\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-lg pre {
-      +   .lg\\\\:markdown-lg pre {
+      -   .lg\\\\:prose-lg :where(pre) {
+      +   .lg\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol {
-      +   .lg\\\\:markdown-lg ol {
+      -   .lg\\\\:prose-lg :where(ol) {
+      +   .lg\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul {
-      +   .lg\\\\:markdown-lg ul {
+      -   .lg\\\\:prose-lg :where(ul) {
+      +   .lg\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-lg li {
-      +   .lg\\\\:markdown-lg li {
+      -   .lg\\\\:prose-lg :where(li) {
+      +   .lg\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol > li {
-      +   .lg\\\\:markdown-lg ol > li {
+      -   .lg\\\\:prose-lg :where(ol > li) {
+      +   .lg\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ol > li::before {
-      +   .lg\\\\:markdown-lg ol > li::before {
+      -   .lg\\\\:prose-lg :where(ol > li::before) {
+      +   .lg\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul > li {
-      +   .lg\\\\:markdown-lg ul > li {
+      -   .lg\\\\:prose-lg :where(ul > li) {
+      +   .lg\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul > li::before {
-      +   .lg\\\\:markdown-lg ul > li::before {
+      -   .lg\\\\:prose-lg :where(ul > li::before) {
+      +   .lg\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li p {
-      +   .lg\\\\:markdown-lg > ul > li p {
+      -   .lg\\\\:prose-lg :where(> ul > li p) {
+      +   .lg\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li > *:first-child {
-      +   .lg\\\\:markdown-lg > ul > li > *:first-child {
+      -   .lg\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ul > li > *:last-child {
-      +   .lg\\\\:markdown-lg > ul > li > *:last-child {
+      -   .lg\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ol > li > *:first-child {
-      +   .lg\\\\:markdown-lg > ol > li > *:first-child {
+      -   .lg\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > ol > li > *:last-child {
-      +   .lg\\\\:markdown-lg > ol > li > *:last-child {
+      -   .lg\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg ul ul, .lg\\\\:prose-lg ul ol, .lg\\\\:prose-lg ol ul, .lg\\\\:prose-lg ol ol {
-      +   .lg\\\\:markdown-lg ul ul, .lg\\\\:markdown-lg ul ol, .lg\\\\:markdown-lg ol ul, .lg\\\\:markdown-lg ol ol {
+      -   .lg\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-lg hr {
-      +   .lg\\\\:markdown-lg hr {
+      -   .lg\\\\:prose-lg :where(hr) {
+      +   .lg\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-lg hr + * {
-      +   .lg\\\\:markdown-lg hr + * {
+      -   .lg\\\\:prose-lg :where(hr + *) {
+      +   .lg\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h2 + * {
-      +   .lg\\\\:markdown-lg h2 + * {
+      -   .lg\\\\:prose-lg :where(h2 + *) {
+      +   .lg\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h3 + * {
-      +   .lg\\\\:markdown-lg h3 + * {
+      -   .lg\\\\:prose-lg :where(h3 + *) {
+      +   .lg\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg h4 + * {
-      +   .lg\\\\:markdown-lg h4 + * {
+      -   .lg\\\\:prose-lg :where(h4 + *) {
+      +   .lg\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-lg table {
-      +   .lg\\\\:markdown-lg table {
+      -   .lg\\\\:prose-lg :where(table) {
+      +   .lg\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th {
-      +   .lg\\\\:markdown-lg thead th {
+      -   .lg\\\\:prose-lg :where(thead th) {
+      +   .lg\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th:first-child {
-      +   .lg\\\\:markdown-lg thead th:first-child {
+      -   .lg\\\\:prose-lg :where(thead th:first-child) {
+      +   .lg\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg thead th:last-child {
-      +   .lg\\\\:markdown-lg thead th:last-child {
+      -   .lg\\\\:prose-lg :where(thead th:last-child) {
+      +   .lg\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td {
-      +   .lg\\\\:markdown-lg tbody td {
+      -   .lg\\\\:prose-lg :where(tbody td) {
+      +   .lg\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td:first-child {
-      +   .lg\\\\:markdown-lg tbody td:first-child {
+      -   .lg\\\\:prose-lg :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg tbody td:last-child {
-      +   .lg\\\\:markdown-lg tbody td:last-child {
+      -   .lg\\\\:prose-lg :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > :first-child {
-      +   .lg\\\\:markdown-lg > :first-child {
+      -   .lg\\\\:prose-lg :where(> :first-child) {
+      +   .lg\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-lg > :last-child {
-      +   .lg\\\\:markdown-lg > :last-child {
+      -   .lg\\\\:prose-lg :where(> :last-child) {
+      +   .lg\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -22337,218 +22337,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-xl p {
-      +   .lg\\\\:markdown-xl p {
+      -   .lg\\\\:prose-xl :where(p) {
+      +   .lg\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-xl [class~='lead'] {
-      +   .lg\\\\:markdown-xl [class~='lead'] {
+      -   .lg\\\\:prose-xl :where([class~='lead']) {
+      +   .lg\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-xl blockquote {
-      +   .lg\\\\:markdown-xl blockquote {
+      -   .lg\\\\:prose-xl :where(blockquote) {
+      +   .lg\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-xl h1 {
-      +   .lg\\\\:markdown-xl h1 {
+      -   .lg\\\\:prose-xl :where(h1) {
+      +   .lg\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 {
-      +   .lg\\\\:markdown-xl h2 {
+      -   .lg\\\\:prose-xl :where(h2) {
+      +   .lg\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 {
-      +   .lg\\\\:markdown-xl h3 {
+      -   .lg\\\\:prose-xl :where(h3) {
+      +   .lg\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-xl h4 {
-      +   .lg\\\\:markdown-xl h4 {
+      -   .lg\\\\:prose-xl :where(h4) {
+      +   .lg\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-xl img {
-      +   .lg\\\\:markdown-xl img {
+      -   .lg\\\\:prose-xl :where(img) {
+      +   .lg\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-xl video {
-      +   .lg\\\\:markdown-xl video {
+      -   .lg\\\\:prose-xl :where(video) {
+      +   .lg\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure {
-      +   .lg\\\\:markdown-xl figure {
+      -   .lg\\\\:prose-xl :where(figure) {
+      +   .lg\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure > * {
-      +   .lg\\\\:markdown-xl figure > * {
+      -   .lg\\\\:prose-xl :where(figure > *) {
+      +   .lg\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-xl figure figcaption {
-      +   .lg\\\\:markdown-xl figure figcaption {
+      -   .lg\\\\:prose-xl :where(figure figcaption) {
+      +   .lg\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-xl code {
-      +   .lg\\\\:markdown-xl code {
+      -   .lg\\\\:prose-xl :where(code) {
+      +   .lg\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 code {
-      +   .lg\\\\:markdown-xl h2 code {
+      -   .lg\\\\:prose-xl :where(h2 code) {
+      +   .lg\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 code {
-      +   .lg\\\\:markdown-xl h3 code {
+      -   .lg\\\\:prose-xl :where(h3 code) {
+      +   .lg\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-xl pre {
-      +   .lg\\\\:markdown-xl pre {
+      -   .lg\\\\:prose-xl :where(pre) {
+      +   .lg\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol {
-      +   .lg\\\\:markdown-xl ol {
+      -   .lg\\\\:prose-xl :where(ol) {
+      +   .lg\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul {
-      +   .lg\\\\:markdown-xl ul {
+      -   .lg\\\\:prose-xl :where(ul) {
+      +   .lg\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-xl li {
-      +   .lg\\\\:markdown-xl li {
+      -   .lg\\\\:prose-xl :where(li) {
+      +   .lg\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol > li {
-      +   .lg\\\\:markdown-xl ol > li {
+      -   .lg\\\\:prose-xl :where(ol > li) {
+      +   .lg\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ol > li::before {
-      +   .lg\\\\:markdown-xl ol > li::before {
+      -   .lg\\\\:prose-xl :where(ol > li::before) {
+      +   .lg\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul > li {
-      +   .lg\\\\:markdown-xl ul > li {
+      -   .lg\\\\:prose-xl :where(ul > li) {
+      +   .lg\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul > li::before {
-      +   .lg\\\\:markdown-xl ul > li::before {
+      -   .lg\\\\:prose-xl :where(ul > li::before) {
+      +   .lg\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li p {
-      +   .lg\\\\:markdown-xl > ul > li p {
+      -   .lg\\\\:prose-xl :where(> ul > li p) {
+      +   .lg\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li > *:first-child {
-      +   .lg\\\\:markdown-xl > ul > li > *:first-child {
+      -   .lg\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ul > li > *:last-child {
-      +   .lg\\\\:markdown-xl > ul > li > *:last-child {
+      -   .lg\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ol > li > *:first-child {
-      +   .lg\\\\:markdown-xl > ol > li > *:first-child {
+      -   .lg\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > ol > li > *:last-child {
-      +   .lg\\\\:markdown-xl > ol > li > *:last-child {
+      -   .lg\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl ul ul, .lg\\\\:prose-xl ul ol, .lg\\\\:prose-xl ol ul, .lg\\\\:prose-xl ol ol {
-      +   .lg\\\\:markdown-xl ul ul, .lg\\\\:markdown-xl ul ol, .lg\\\\:markdown-xl ol ul, .lg\\\\:markdown-xl ol ol {
+      -   .lg\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-xl hr {
-      +   .lg\\\\:markdown-xl hr {
+      -   .lg\\\\:prose-xl :where(hr) {
+      +   .lg\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-xl hr + * {
-      +   .lg\\\\:markdown-xl hr + * {
+      -   .lg\\\\:prose-xl :where(hr + *) {
+      +   .lg\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h2 + * {
-      +   .lg\\\\:markdown-xl h2 + * {
+      -   .lg\\\\:prose-xl :where(h2 + *) {
+      +   .lg\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h3 + * {
-      +   .lg\\\\:markdown-xl h3 + * {
+      -   .lg\\\\:prose-xl :where(h3 + *) {
+      +   .lg\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl h4 + * {
-      +   .lg\\\\:markdown-xl h4 + * {
+      -   .lg\\\\:prose-xl :where(h4 + *) {
+      +   .lg\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-xl table {
-      +   .lg\\\\:markdown-xl table {
+      -   .lg\\\\:prose-xl :where(table) {
+      +   .lg\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th {
-      +   .lg\\\\:markdown-xl thead th {
+      -   .lg\\\\:prose-xl :where(thead th) {
+      +   .lg\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th:first-child {
-      +   .lg\\\\:markdown-xl thead th:first-child {
+      -   .lg\\\\:prose-xl :where(thead th:first-child) {
+      +   .lg\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl thead th:last-child {
-      +   .lg\\\\:markdown-xl thead th:last-child {
+      -   .lg\\\\:prose-xl :where(thead th:last-child) {
+      +   .lg\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td {
-      +   .lg\\\\:markdown-xl tbody td {
+      -   .lg\\\\:prose-xl :where(tbody td) {
+      +   .lg\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td:first-child {
-      +   .lg\\\\:markdown-xl tbody td:first-child {
+      -   .lg\\\\:prose-xl :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl tbody td:last-child {
-      +   .lg\\\\:markdown-xl tbody td:last-child {
+      -   .lg\\\\:prose-xl :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > :first-child {
-      +   .lg\\\\:markdown-xl > :first-child {
+      -   .lg\\\\:prose-xl :where(> :first-child) {
+      +   .lg\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-xl > :last-child {
-      +   .lg\\\\:markdown-xl > :last-child {
+      -   .lg\\\\:prose-xl :where(> :last-child) {
+      +   .lg\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -22557,278 +22557,278 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-2xl p {
-      +   .lg\\\\:markdown-2xl p {
+      -   .lg\\\\:prose-2xl :where(p) {
+      +   .lg\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .lg\\\\:prose-2xl [class~='lead'] {
-      +   .lg\\\\:markdown-2xl [class~='lead'] {
+      -   .lg\\\\:prose-2xl :where([class~='lead']) {
+      +   .lg\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .lg\\\\:prose-2xl blockquote {
-      +   .lg\\\\:markdown-2xl blockquote {
+      -   .lg\\\\:prose-2xl :where(blockquote) {
+      +   .lg\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h1 {
-      +   .lg\\\\:markdown-2xl h1 {
+      -   .lg\\\\:prose-2xl :where(h1) {
+      +   .lg\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 {
-      +   .lg\\\\:markdown-2xl h2 {
+      -   .lg\\\\:prose-2xl :where(h2) {
+      +   .lg\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 {
-      +   .lg\\\\:markdown-2xl h3 {
+      -   .lg\\\\:prose-2xl :where(h3) {
+      +   .lg\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h4 {
-      +   .lg\\\\:markdown-2xl h4 {
+      -   .lg\\\\:prose-2xl :where(h4) {
+      +   .lg\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .lg\\\\:prose-2xl img {
-      +   .lg\\\\:markdown-2xl img {
+      -   .lg\\\\:prose-2xl :where(img) {
+      +   .lg\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .lg\\\\:prose-2xl video {
-      +   .lg\\\\:markdown-2xl video {
+      -   .lg\\\\:prose-2xl :where(video) {
+      +   .lg\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure {
-      +   .lg\\\\:markdown-2xl figure {
+      -   .lg\\\\:prose-2xl :where(figure) {
+      +   .lg\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure > * {
-      +   .lg\\\\:markdown-2xl figure > * {
+      -   .lg\\\\:prose-2xl :where(figure > *) {
+      +   .lg\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl figure figcaption {
-      +   .lg\\\\:markdown-2xl figure figcaption {
+      -   .lg\\\\:prose-2xl :where(figure figcaption) {
+      +   .lg\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .lg\\\\:prose-2xl code {
-      +   .lg\\\\:markdown-2xl code {
+      -   .lg\\\\:prose-2xl :where(code) {
+      +   .lg\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 code {
-      +   .lg\\\\:markdown-2xl h2 code {
+      -   .lg\\\\:prose-2xl :where(h2 code) {
+      +   .lg\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 code {
-      +   .lg\\\\:markdown-2xl h3 code {
+      -   .lg\\\\:prose-2xl :where(h3 code) {
+      +   .lg\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .lg\\\\:prose-2xl pre {
-      +   .lg\\\\:markdown-2xl pre {
+      -   .lg\\\\:prose-2xl :where(pre) {
+      +   .lg\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol {
-      +   .lg\\\\:markdown-2xl ol {
+      -   .lg\\\\:prose-2xl :where(ol) {
+      +   .lg\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul {
-      +   .lg\\\\:markdown-2xl ul {
+      -   .lg\\\\:prose-2xl :where(ul) {
+      +   .lg\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .lg\\\\:prose-2xl li {
-      +   .lg\\\\:markdown-2xl li {
+      -   .lg\\\\:prose-2xl :where(li) {
+      +   .lg\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol > li {
-      +   .lg\\\\:markdown-2xl ol > li {
+      -   .lg\\\\:prose-2xl :where(ol > li) {
+      +   .lg\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ol > li::before {
-      +   .lg\\\\:markdown-2xl ol > li::before {
+      -   .lg\\\\:prose-2xl :where(ol > li::before) {
+      +   .lg\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul > li {
-      +   .lg\\\\:markdown-2xl ul > li {
+      -   .lg\\\\:prose-2xl :where(ul > li) {
+      +   .lg\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul > li::before {
-      +   .lg\\\\:markdown-2xl ul > li::before {
+      -   .lg\\\\:prose-2xl :where(ul > li::before) {
+      +   .lg\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li p {
-      +   .lg\\\\:markdown-2xl > ul > li p {
+      -   .lg\\\\:prose-2xl :where(> ul > li p) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li > *:first-child {
-      +   .lg\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ul > li > *:last-child {
-      +   .lg\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ol > li > *:first-child {
-      +   .lg\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > ol > li > *:last-child {
-      +   .lg\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl ul ul, .lg\\\\:prose-2xl ul ol, .lg\\\\:prose-2xl ol ul, .lg\\\\:prose-2xl ol ol {
-      +   .lg\\\\:markdown-2xl ul ul, .lg\\\\:markdown-2xl ul ol, .lg\\\\:markdown-2xl ol ul, .lg\\\\:markdown-2xl ol ol {
+      -   .lg\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .lg\\\\:prose-2xl hr {
-      +   .lg\\\\:markdown-2xl hr {
+      -   .lg\\\\:prose-2xl :where(hr) {
+      +   .lg\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .lg\\\\:prose-2xl hr + * {
-      +   .lg\\\\:markdown-2xl hr + * {
+      -   .lg\\\\:prose-2xl :where(hr + *) {
+      +   .lg\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h2 + * {
-      +   .lg\\\\:markdown-2xl h2 + * {
+      -   .lg\\\\:prose-2xl :where(h2 + *) {
+      +   .lg\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h3 + * {
-      +   .lg\\\\:markdown-2xl h3 + * {
+      -   .lg\\\\:prose-2xl :where(h3 + *) {
+      +   .lg\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl h4 + * {
-      +   .lg\\\\:markdown-2xl h4 + * {
+      -   .lg\\\\:prose-2xl :where(h4 + *) {
+      +   .lg\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .lg\\\\:prose-2xl table {
-      +   .lg\\\\:markdown-2xl table {
+      -   .lg\\\\:prose-2xl :where(table) {
+      +   .lg\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th {
-      +   .lg\\\\:markdown-2xl thead th {
+      -   .lg\\\\:prose-2xl :where(thead th) {
+      +   .lg\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th:first-child {
-      +   .lg\\\\:markdown-2xl thead th:first-child {
+      -   .lg\\\\:prose-2xl :where(thead th:first-child) {
+      +   .lg\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl thead th:last-child {
-      +   .lg\\\\:markdown-2xl thead th:last-child {
+      -   .lg\\\\:prose-2xl :where(thead th:last-child) {
+      +   .lg\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td {
-      +   .lg\\\\:markdown-2xl tbody td {
+      -   .lg\\\\:prose-2xl :where(tbody td) {
+      +   .lg\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td:first-child {
-      +   .lg\\\\:markdown-2xl tbody td:first-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .lg\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl tbody td:last-child {
-      +   .lg\\\\:markdown-2xl tbody td:last-child {
+      -   .lg\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .lg\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > :first-child {
-      +   .lg\\\\:markdown-2xl > :first-child {
+      -   .lg\\\\:prose-2xl :where(> :first-child) {
+      +   .lg\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .lg\\\\:prose-2xl > :last-child {
-      +   .lg\\\\:markdown-2xl > :last-child {
+      -   .lg\\\\:prose-2xl :where(> :last-child) {
+      +   .lg\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .lg\\\\:prose-red a {
+      -   .lg\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .lg\\\\:prose-red a code {
+      -   .lg\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .lg\\\\:prose-yellow a {
+      -   .lg\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .lg\\\\:prose-yellow a code {
+      -   .lg\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
 
       ---
 
       -
-      -   .lg\\\\:prose-green a {
+      -   .lg\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .lg\\\\:prose-green a code {
+      -   .lg\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .lg\\\\:prose-blue a {
+      -   .lg\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .lg\\\\:prose-blue a code {
+      -   .lg\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .lg\\\\:prose-indigo a {
+      -   .lg\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .lg\\\\:prose-indigo a code {
+      -   .lg\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .lg\\\\:prose-purple a {
+      -   .lg\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .lg\\\\:prose-purple a code {
+      -   .lg\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .lg\\\\:prose-pink a {
+      -   .lg\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .lg\\\\:prose-pink a code {
+      -   .lg\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -22839,218 +22839,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose [class~='lead'] {
-      +   .xl\\\\:markdown [class~='lead'] {
+      -   .xl\\\\:prose :where([class~='lead']) {
+      +   .xl\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose a {
-      +   .xl\\\\:markdown a {
+      -   .xl\\\\:prose :where(a) {
+      +   .xl\\\\:markdown :where(a) {
 
       ---
 
-      -   .xl\\\\:prose strong {
-      +   .xl\\\\:markdown strong {
+      -   .xl\\\\:prose :where(strong) {
+      +   .xl\\\\:markdown :where(strong) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='A'] {
-      +   .xl\\\\:markdown ol[type='A'] {
+      -   .xl\\\\:prose :where(ol[type='A']) {
+      +   .xl\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='a'] {
-      +   .xl\\\\:markdown ol[type='a'] {
+      -   .xl\\\\:prose :where(ol[type='a']) {
+      +   .xl\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='A' s] {
-      +   .xl\\\\:markdown ol[type='A' s] {
+      -   .xl\\\\:prose :where(ol[type='A' s]) {
+      +   .xl\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='a' s] {
-      +   .xl\\\\:markdown ol[type='a' s] {
+      -   .xl\\\\:prose :where(ol[type='a' s]) {
+      +   .xl\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='I'] {
-      +   .xl\\\\:markdown ol[type='I'] {
+      -   .xl\\\\:prose :where(ol[type='I']) {
+      +   .xl\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='i'] {
-      +   .xl\\\\:markdown ol[type='i'] {
+      -   .xl\\\\:prose :where(ol[type='i']) {
+      +   .xl\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='I' s] {
-      +   .xl\\\\:markdown ol[type='I' s] {
+      -   .xl\\\\:prose :where(ol[type='I' s]) {
+      +   .xl\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='i' s] {
-      +   .xl\\\\:markdown ol[type='i' s] {
+      -   .xl\\\\:prose :where(ol[type='i' s]) {
+      +   .xl\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .xl\\\\:prose ol[type='1'] {
-      +   .xl\\\\:markdown ol[type='1'] {
+      -   .xl\\\\:prose :where(ol[type='1']) {
+      +   .xl\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .xl\\\\:prose ol > li {
-      +   .xl\\\\:markdown ol > li {
+      -   .xl\\\\:prose :where(ol > li) {
+      +   .xl\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose ol > li::before {
-      +   .xl\\\\:markdown ol > li::before {
+      -   .xl\\\\:prose :where(ol > li::before) {
+      +   .xl\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose ul > li {
-      +   .xl\\\\:markdown ul > li {
+      -   .xl\\\\:prose :where(ul > li) {
+      +   .xl\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose ul > li::before {
-      +   .xl\\\\:markdown ul > li::before {
+      -   .xl\\\\:prose :where(ul > li::before) {
+      +   .xl\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose hr {
-      +   .xl\\\\:markdown hr {
+      -   .xl\\\\:prose :where(hr) {
+      +   .xl\\\\:markdown :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose blockquote {
-      +   .xl\\\\:markdown blockquote {
+      -   .xl\\\\:prose :where(blockquote) {
+      +   .xl\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose blockquote p:first-of-type::before {
-      +   .xl\\\\:markdown blockquote p:first-of-type::before {
+      -   .xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .xl\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .xl\\\\:prose blockquote p:last-of-type::after {
-      +   .xl\\\\:markdown blockquote p:last-of-type::after {
+      -   .xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .xl\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .xl\\\\:prose h1 {
-      +   .xl\\\\:markdown h1 {
+      -   .xl\\\\:prose :where(h1) {
+      +   .xl\\\\:markdown :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose h1 strong {
-      +   .xl\\\\:markdown h1 strong {
+      -   .xl\\\\:prose :where(h1 strong) {
+      +   .xl\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .xl\\\\:prose h2 {
-      +   .xl\\\\:markdown h2 {
+      -   .xl\\\\:prose :where(h2) {
+      +   .xl\\\\:markdown :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose h2 strong {
-      +   .xl\\\\:markdown h2 strong {
+      -   .xl\\\\:prose :where(h2 strong) {
+      +   .xl\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .xl\\\\:prose h3 {
-      +   .xl\\\\:markdown h3 {
+      -   .xl\\\\:prose :where(h3) {
+      +   .xl\\\\:markdown :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose h3 strong {
-      +   .xl\\\\:markdown h3 strong {
+      -   .xl\\\\:prose :where(h3 strong) {
+      +   .xl\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .xl\\\\:prose h4 {
-      +   .xl\\\\:markdown h4 {
+      -   .xl\\\\:prose :where(h4) {
+      +   .xl\\\\:markdown :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose h4 strong {
-      +   .xl\\\\:markdown h4 strong {
+      -   .xl\\\\:prose :where(h4 strong) {
+      +   .xl\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .xl\\\\:prose figure figcaption {
-      +   .xl\\\\:markdown figure figcaption {
+      -   .xl\\\\:prose :where(figure figcaption) {
+      +   .xl\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose code {
-      +   .xl\\\\:markdown code {
+      -   .xl\\\\:prose :where(code) {
+      +   .xl\\\\:markdown :where(code) {
 
       ---
 
-      -   .xl\\\\:prose code::before {
-      +   .xl\\\\:markdown code::before {
+      -   .xl\\\\:prose :where(code::before) {
+      +   .xl\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .xl\\\\:prose code::after {
-      +   .xl\\\\:markdown code::after {
+      -   .xl\\\\:prose :where(code::after) {
+      +   .xl\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .xl\\\\:prose a code {
-      +   .xl\\\\:markdown a code {
+      -   .xl\\\\:prose :where(a code) {
+      +   .xl\\\\:markdown :where(a code) {
 
       ---
 
-      -   .xl\\\\:prose pre {
-      +   .xl\\\\:markdown pre {
+      -   .xl\\\\:prose :where(pre) {
+      +   .xl\\\\:markdown :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose pre code {
-      +   .xl\\\\:markdown pre code {
+      -   .xl\\\\:prose :where(pre code) {
+      +   .xl\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .xl\\\\:prose pre code::before {
-      +   .xl\\\\:markdown pre code::before {
+      -   .xl\\\\:prose :where(pre code::before) {
+      +   .xl\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .xl\\\\:prose pre code::after {
-      +   .xl\\\\:markdown pre code::after {
+      -   .xl\\\\:prose :where(pre code::after) {
+      +   .xl\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .xl\\\\:prose table {
-      +   .xl\\\\:markdown table {
+      -   .xl\\\\:prose :where(table) {
+      +   .xl\\\\:markdown :where(table) {
 
       ---
 
-      -   .xl\\\\:prose thead {
-      +   .xl\\\\:markdown thead {
+      -   .xl\\\\:prose :where(thead) {
+      +   .xl\\\\:markdown :where(thead) {
 
       ---
 
-      -   .xl\\\\:prose thead th {
-      +   .xl\\\\:markdown thead th {
+      -   .xl\\\\:prose :where(thead th) {
+      +   .xl\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose tbody tr {
-      +   .xl\\\\:markdown tbody tr {
+      -   .xl\\\\:prose :where(tbody tr) {
+      +   .xl\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .xl\\\\:prose tbody tr:last-child {
-      +   .xl\\\\:markdown tbody tr:last-child {
+      -   .xl\\\\:prose :where(tbody tr:last-child) {
+      +   .xl\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td {
-      +   .xl\\\\:markdown tbody td {
+      -   .xl\\\\:prose :where(tbody td) {
+      +   .xl\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -23059,225 +23059,225 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose p {
-      +   .xl\\\\:markdown p {
+      -   .xl\\\\:prose :where(p) {
+      +   .xl\\\\:markdown :where(p) {
 
       ---
 
-      -   .xl\\\\:prose img {
-      +   .xl\\\\:markdown img {
+      -   .xl\\\\:prose :where(img) {
+      +   .xl\\\\:markdown :where(img) {
 
       ---
 
-      -   .xl\\\\:prose video {
-      +   .xl\\\\:markdown video {
+      -   .xl\\\\:prose :where(video) {
+      +   .xl\\\\:markdown :where(video) {
 
       ---
 
-      -   .xl\\\\:prose figure {
-      +   .xl\\\\:markdown figure {
+      -   .xl\\\\:prose :where(figure) {
+      +   .xl\\\\:markdown :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose figure > * {
-      +   .xl\\\\:markdown figure > * {
+      -   .xl\\\\:prose :where(figure > *) {
+      +   .xl\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose h2 code {
-      +   .xl\\\\:markdown h2 code {
+      -   .xl\\\\:prose :where(h2 code) {
+      +   .xl\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose h3 code {
-      +   .xl\\\\:markdown h3 code {
+      -   .xl\\\\:prose :where(h3 code) {
+      +   .xl\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose ol {
-      +   .xl\\\\:markdown ol {
+      -   .xl\\\\:prose :where(ol) {
+      +   .xl\\\\:markdown :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose ul {
-      +   .xl\\\\:markdown ul {
+      -   .xl\\\\:prose :where(ul) {
+      +   .xl\\\\:markdown :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose li {
-      +   .xl\\\\:markdown li {
+      -   .xl\\\\:prose :where(li) {
+      +   .xl\\\\:markdown :where(li) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li p {
-      +   .xl\\\\:markdown > ul > li p {
+      -   .xl\\\\:prose :where(> ul > li p) {
+      +   .xl\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li > *:first-child {
-      +   .xl\\\\:markdown > ul > li > *:first-child {
+      -   .xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose > ul > li > *:last-child {
-      +   .xl\\\\:markdown > ul > li > *:last-child {
+      -   .xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose > ol > li > *:first-child {
-      +   .xl\\\\:markdown > ol > li > *:first-child {
+      -   .xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose > ol > li > *:last-child {
-      +   .xl\\\\:markdown > ol > li > *:last-child {
+      -   .xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose ul ul, .xl\\\\:prose ul ol, .xl\\\\:prose ol ul, .xl\\\\:prose ol ol {
-      +   .xl\\\\:markdown ul ul, .xl\\\\:markdown ul ol, .xl\\\\:markdown ol ul, .xl\\\\:markdown ol ol {
+      -   .xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose hr + * {
-      +   .xl\\\\:markdown hr + * {
+      -   .xl\\\\:prose :where(hr + *) {
+      +   .xl\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose h2 + * {
-      +   .xl\\\\:markdown h2 + * {
+      -   .xl\\\\:prose :where(h2 + *) {
+      +   .xl\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose h3 + * {
-      +   .xl\\\\:markdown h3 + * {
+      -   .xl\\\\:prose :where(h3 + *) {
+      +   .xl\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose h4 + * {
-      +   .xl\\\\:markdown h4 + * {
+      -   .xl\\\\:prose :where(h4 + *) {
+      +   .xl\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose thead th:first-child {
-      +   .xl\\\\:markdown thead th:first-child {
+      -   .xl\\\\:prose :where(thead th:first-child) {
+      +   .xl\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose thead th:last-child {
-      +   .xl\\\\:markdown thead th:last-child {
+      -   .xl\\\\:prose :where(thead th:last-child) {
+      +   .xl\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td:first-child {
-      +   .xl\\\\:markdown tbody td:first-child {
+      -   .xl\\\\:prose :where(tbody td:first-child) {
+      +   .xl\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose tbody td:last-child {
-      +   .xl\\\\:markdown tbody td:last-child {
+      -   .xl\\\\:prose :where(tbody td:last-child) {
+      +   .xl\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose > :first-child {
-      +   .xl\\\\:markdown > :first-child {
+      -   .xl\\\\:prose :where(> :first-child) {
+      +   .xl\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose > :last-child {
-      +   .xl\\\\:markdown > :last-child {
+      -   .xl\\\\:prose :where(> :last-child) {
+      +   .xl\\\\:markdown :where(> :last-child) {
 
       ---
 
       -   .xl\\\\:prose-sm {
-      -     font-size: 0.875rem;
-      -     line-height: 1.7142857;
+      -     :where(font-size): 0.875rem;
+      -     :where(line-height): 1.7142857;
       -   }
       -
-      -   .xl\\\\:prose-sm p {
+      -   .xl\\\\:prose-sm :where(p) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm [class~='lead'] {
+      -   .xl\\\\:prose-sm :where([class~='lead']) {
       -     font-size: 1.2857143em;
       -     line-height: 1.5555556;
       -     margin-top: 0.8888889em;
       -     margin-bottom: 0.8888889em;
       -   }
       -
-      -   .xl\\\\:prose-sm blockquote {
+      -   .xl\\\\:prose-sm :where(blockquote) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .xl\\\\:prose-sm h1 {
+      -   .xl\\\\:prose-sm :where(h1) {
       -     font-size: 2.1428571em;
       -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
       -
-      -   .xl\\\\:prose-sm h2 {
+      -   .xl\\\\:prose-sm :where(h2) {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
       -   }
       -
-      -   .xl\\\\:prose-sm h3 {
+      -   .xl\\\\:prose-sm :where(h3) {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.4444444em;
       -     line-height: 1.5555556;
       -   }
       -
-      -   .xl\\\\:prose-sm h4 {
+      -   .xl\\\\:prose-sm :where(h4) {
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
       -   }
       -
-      -   .xl\\\\:prose-sm img {
+      -   .xl\\\\:prose-sm :where(img) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .xl\\\\:prose-sm video {
+      -   .xl\\\\:prose-sm :where(video) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .xl\\\\:prose-sm figure {
+      -   .xl\\\\:prose-sm :where(figure) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .xl\\\\:prose-sm figure > * {
+      -   .xl\\\\:prose-sm :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm figure figcaption {
+      -   .xl\\\\:prose-sm :where(figure figcaption) {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-sm code {
+      -   .xl\\\\:prose-sm :where(code) {
       -     font-size: 0.8571429em;
       -   }
       -
-      -   .xl\\\\:prose-sm h2 code {
+      -   .xl\\\\:prose-sm :where(h2 code) {
       -     font-size: 0.9em;
       -   }
       -
-      -   .xl\\\\:prose-sm h3 code {
+      -   .xl\\\\:prose-sm :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .xl\\\\:prose-sm pre {
+      -   .xl\\\\:prose-sm :where(pre) {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
       -     margin-top: 1.6666667em;
@@ -23289,126 +23289,126 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1em;
       -   }
       -
-      -   .xl\\\\:prose-sm ol {
+      -   .xl\\\\:prose-sm :where(ol) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm ul {
+      -   .xl\\\\:prose-sm :where(ul) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm li {
+      -   .xl\\\\:prose-sm :where(li) {
       -     margin-top: 0.2857143em;
       -     margin-bottom: 0.2857143em;
       -   }
       -
-      -   .xl\\\\:prose-sm ol > li {
+      -   .xl\\\\:prose-sm :where(ol > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm ol > li::before {
+      -   .xl\\\\:prose-sm :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm ul > li {
+      -   .xl\\\\:prose-sm :where(ul > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm ul > li::before {
+      -   .xl\\\\:prose-sm :where(ul > li::before) {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
       -     left: 0.2142857em;
       -   }
       -
-      -   .xl\\\\:prose-sm > ul > li p {
+      -   .xl\\\\:prose-sm :where(> ul > li p) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm > ul > li > *:first-child {
+      -   .xl\\\\:prose-sm :where(> ul > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm > ul > li > *:last-child {
+      -   .xl\\\\:prose-sm :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm > ol > li > *:first-child {
+      -   .xl\\\\:prose-sm :where(> ol > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm > ol > li > *:last-child {
+      -   .xl\\\\:prose-sm :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .xl\\\\:prose-sm ul ul, .xl\\\\:prose-sm ul ol, .xl\\\\:prose-sm ol ul, .xl\\\\:prose-sm ol ol {
+      -   .xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm hr {
+      -   .xl\\\\:prose-sm :where(hr) {
       -     margin-top: 2.8571429em;
       -     margin-bottom: 2.8571429em;
       -   }
       -
-      -   .xl\\\\:prose-sm hr + * {
+      -   .xl\\\\:prose-sm :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm h2 + * {
+      -   .xl\\\\:prose-sm :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm h3 + * {
+      -   .xl\\\\:prose-sm :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm h4 + * {
+      -   .xl\\\\:prose-sm :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm table {
+      -   .xl\\\\:prose-sm :where(table) {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
       -   }
       -
-      -   .xl\\\\:prose-sm thead th {
+      -   .xl\\\\:prose-sm :where(thead th) {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .xl\\\\:prose-sm thead th:first-child {
+      -   .xl\\\\:prose-sm :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm thead th:last-child {
+      -   .xl\\\\:prose-sm :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm tbody td {
+      -   .xl\\\\:prose-sm :where(tbody td) {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .xl\\\\:prose-sm tbody td:first-child {
+      -   .xl\\\\:prose-sm :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm tbody td:last-child {
+      -   .xl\\\\:prose-sm :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm > :first-child {
+      -   .xl\\\\:prose-sm :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .xl\\\\:prose-sm > :last-child {
+      -   .xl\\\\:prose-sm :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
@@ -23417,218 +23417,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-lg p {
-      +   .xl\\\\:markdown-lg p {
+      -   .xl\\\\:prose-lg :where(p) {
+      +   .xl\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-lg [class~='lead'] {
-      +   .xl\\\\:markdown-lg [class~='lead'] {
+      -   .xl\\\\:prose-lg :where([class~='lead']) {
+      +   .xl\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-lg blockquote {
-      +   .xl\\\\:markdown-lg blockquote {
+      -   .xl\\\\:prose-lg :where(blockquote) {
+      +   .xl\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-lg h1 {
-      +   .xl\\\\:markdown-lg h1 {
+      -   .xl\\\\:prose-lg :where(h1) {
+      +   .xl\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 {
-      +   .xl\\\\:markdown-lg h2 {
+      -   .xl\\\\:prose-lg :where(h2) {
+      +   .xl\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 {
-      +   .xl\\\\:markdown-lg h3 {
+      -   .xl\\\\:prose-lg :where(h3) {
+      +   .xl\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-lg h4 {
-      +   .xl\\\\:markdown-lg h4 {
+      -   .xl\\\\:prose-lg :where(h4) {
+      +   .xl\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-lg img {
-      +   .xl\\\\:markdown-lg img {
+      -   .xl\\\\:prose-lg :where(img) {
+      +   .xl\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-lg video {
-      +   .xl\\\\:markdown-lg video {
+      -   .xl\\\\:prose-lg :where(video) {
+      +   .xl\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure {
-      +   .xl\\\\:markdown-lg figure {
+      -   .xl\\\\:prose-lg :where(figure) {
+      +   .xl\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure > * {
-      +   .xl\\\\:markdown-lg figure > * {
+      -   .xl\\\\:prose-lg :where(figure > *) {
+      +   .xl\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-lg figure figcaption {
-      +   .xl\\\\:markdown-lg figure figcaption {
+      -   .xl\\\\:prose-lg :where(figure figcaption) {
+      +   .xl\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-lg code {
-      +   .xl\\\\:markdown-lg code {
+      -   .xl\\\\:prose-lg :where(code) {
+      +   .xl\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 code {
-      +   .xl\\\\:markdown-lg h2 code {
+      -   .xl\\\\:prose-lg :where(h2 code) {
+      +   .xl\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 code {
-      +   .xl\\\\:markdown-lg h3 code {
+      -   .xl\\\\:prose-lg :where(h3 code) {
+      +   .xl\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-lg pre {
-      +   .xl\\\\:markdown-lg pre {
+      -   .xl\\\\:prose-lg :where(pre) {
+      +   .xl\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol {
-      +   .xl\\\\:markdown-lg ol {
+      -   .xl\\\\:prose-lg :where(ol) {
+      +   .xl\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul {
-      +   .xl\\\\:markdown-lg ul {
+      -   .xl\\\\:prose-lg :where(ul) {
+      +   .xl\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-lg li {
-      +   .xl\\\\:markdown-lg li {
+      -   .xl\\\\:prose-lg :where(li) {
+      +   .xl\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol > li {
-      +   .xl\\\\:markdown-lg ol > li {
+      -   .xl\\\\:prose-lg :where(ol > li) {
+      +   .xl\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ol > li::before {
-      +   .xl\\\\:markdown-lg ol > li::before {
+      -   .xl\\\\:prose-lg :where(ol > li::before) {
+      +   .xl\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul > li {
-      +   .xl\\\\:markdown-lg ul > li {
+      -   .xl\\\\:prose-lg :where(ul > li) {
+      +   .xl\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul > li::before {
-      +   .xl\\\\:markdown-lg ul > li::before {
+      -   .xl\\\\:prose-lg :where(ul > li::before) {
+      +   .xl\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li p {
-      +   .xl\\\\:markdown-lg > ul > li p {
+      -   .xl\\\\:prose-lg :where(> ul > li p) {
+      +   .xl\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li > *:first-child {
-      +   .xl\\\\:markdown-lg > ul > li > *:first-child {
+      -   .xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ul > li > *:last-child {
-      +   .xl\\\\:markdown-lg > ul > li > *:last-child {
+      -   .xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ol > li > *:first-child {
-      +   .xl\\\\:markdown-lg > ol > li > *:first-child {
+      -   .xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > ol > li > *:last-child {
-      +   .xl\\\\:markdown-lg > ol > li > *:last-child {
+      -   .xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg ul ul, .xl\\\\:prose-lg ul ol, .xl\\\\:prose-lg ol ul, .xl\\\\:prose-lg ol ol {
-      +   .xl\\\\:markdown-lg ul ul, .xl\\\\:markdown-lg ul ol, .xl\\\\:markdown-lg ol ul, .xl\\\\:markdown-lg ol ol {
+      -   .xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-lg hr {
-      +   .xl\\\\:markdown-lg hr {
+      -   .xl\\\\:prose-lg :where(hr) {
+      +   .xl\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-lg hr + * {
-      +   .xl\\\\:markdown-lg hr + * {
+      -   .xl\\\\:prose-lg :where(hr + *) {
+      +   .xl\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h2 + * {
-      +   .xl\\\\:markdown-lg h2 + * {
+      -   .xl\\\\:prose-lg :where(h2 + *) {
+      +   .xl\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h3 + * {
-      +   .xl\\\\:markdown-lg h3 + * {
+      -   .xl\\\\:prose-lg :where(h3 + *) {
+      +   .xl\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg h4 + * {
-      +   .xl\\\\:markdown-lg h4 + * {
+      -   .xl\\\\:prose-lg :where(h4 + *) {
+      +   .xl\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-lg table {
-      +   .xl\\\\:markdown-lg table {
+      -   .xl\\\\:prose-lg :where(table) {
+      +   .xl\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th {
-      +   .xl\\\\:markdown-lg thead th {
+      -   .xl\\\\:prose-lg :where(thead th) {
+      +   .xl\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th:first-child {
-      +   .xl\\\\:markdown-lg thead th:first-child {
+      -   .xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .xl\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg thead th:last-child {
-      +   .xl\\\\:markdown-lg thead th:last-child {
+      -   .xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .xl\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td {
-      +   .xl\\\\:markdown-lg tbody td {
+      -   .xl\\\\:prose-lg :where(tbody td) {
+      +   .xl\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td:first-child {
-      +   .xl\\\\:markdown-lg tbody td:first-child {
+      -   .xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg tbody td:last-child {
-      +   .xl\\\\:markdown-lg tbody td:last-child {
+      -   .xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > :first-child {
-      +   .xl\\\\:markdown-lg > :first-child {
+      -   .xl\\\\:prose-lg :where(> :first-child) {
+      +   .xl\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-lg > :last-child {
-      +   .xl\\\\:markdown-lg > :last-child {
+      -   .xl\\\\:prose-lg :where(> :last-child) {
+      +   .xl\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -23637,218 +23637,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-xl p {
-      +   .xl\\\\:markdown-xl p {
+      -   .xl\\\\:prose-xl :where(p) {
+      +   .xl\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-xl [class~='lead'] {
-      +   .xl\\\\:markdown-xl [class~='lead'] {
+      -   .xl\\\\:prose-xl :where([class~='lead']) {
+      +   .xl\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-xl blockquote {
-      +   .xl\\\\:markdown-xl blockquote {
+      -   .xl\\\\:prose-xl :where(blockquote) {
+      +   .xl\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-xl h1 {
-      +   .xl\\\\:markdown-xl h1 {
+      -   .xl\\\\:prose-xl :where(h1) {
+      +   .xl\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 {
-      +   .xl\\\\:markdown-xl h2 {
+      -   .xl\\\\:prose-xl :where(h2) {
+      +   .xl\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 {
-      +   .xl\\\\:markdown-xl h3 {
+      -   .xl\\\\:prose-xl :where(h3) {
+      +   .xl\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-xl h4 {
-      +   .xl\\\\:markdown-xl h4 {
+      -   .xl\\\\:prose-xl :where(h4) {
+      +   .xl\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-xl img {
-      +   .xl\\\\:markdown-xl img {
+      -   .xl\\\\:prose-xl :where(img) {
+      +   .xl\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-xl video {
-      +   .xl\\\\:markdown-xl video {
+      -   .xl\\\\:prose-xl :where(video) {
+      +   .xl\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure {
-      +   .xl\\\\:markdown-xl figure {
+      -   .xl\\\\:prose-xl :where(figure) {
+      +   .xl\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure > * {
-      +   .xl\\\\:markdown-xl figure > * {
+      -   .xl\\\\:prose-xl :where(figure > *) {
+      +   .xl\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-xl figure figcaption {
-      +   .xl\\\\:markdown-xl figure figcaption {
+      -   .xl\\\\:prose-xl :where(figure figcaption) {
+      +   .xl\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-xl code {
-      +   .xl\\\\:markdown-xl code {
+      -   .xl\\\\:prose-xl :where(code) {
+      +   .xl\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 code {
-      +   .xl\\\\:markdown-xl h2 code {
+      -   .xl\\\\:prose-xl :where(h2 code) {
+      +   .xl\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 code {
-      +   .xl\\\\:markdown-xl h3 code {
+      -   .xl\\\\:prose-xl :where(h3 code) {
+      +   .xl\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-xl pre {
-      +   .xl\\\\:markdown-xl pre {
+      -   .xl\\\\:prose-xl :where(pre) {
+      +   .xl\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol {
-      +   .xl\\\\:markdown-xl ol {
+      -   .xl\\\\:prose-xl :where(ol) {
+      +   .xl\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul {
-      +   .xl\\\\:markdown-xl ul {
+      -   .xl\\\\:prose-xl :where(ul) {
+      +   .xl\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-xl li {
-      +   .xl\\\\:markdown-xl li {
+      -   .xl\\\\:prose-xl :where(li) {
+      +   .xl\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol > li {
-      +   .xl\\\\:markdown-xl ol > li {
+      -   .xl\\\\:prose-xl :where(ol > li) {
+      +   .xl\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ol > li::before {
-      +   .xl\\\\:markdown-xl ol > li::before {
+      -   .xl\\\\:prose-xl :where(ol > li::before) {
+      +   .xl\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul > li {
-      +   .xl\\\\:markdown-xl ul > li {
+      -   .xl\\\\:prose-xl :where(ul > li) {
+      +   .xl\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul > li::before {
-      +   .xl\\\\:markdown-xl ul > li::before {
+      -   .xl\\\\:prose-xl :where(ul > li::before) {
+      +   .xl\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li p {
-      +   .xl\\\\:markdown-xl > ul > li p {
+      -   .xl\\\\:prose-xl :where(> ul > li p) {
+      +   .xl\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li > *:first-child {
-      +   .xl\\\\:markdown-xl > ul > li > *:first-child {
+      -   .xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ul > li > *:last-child {
-      +   .xl\\\\:markdown-xl > ul > li > *:last-child {
+      -   .xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ol > li > *:first-child {
-      +   .xl\\\\:markdown-xl > ol > li > *:first-child {
+      -   .xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > ol > li > *:last-child {
-      +   .xl\\\\:markdown-xl > ol > li > *:last-child {
+      -   .xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl ul ul, .xl\\\\:prose-xl ul ol, .xl\\\\:prose-xl ol ul, .xl\\\\:prose-xl ol ol {
-      +   .xl\\\\:markdown-xl ul ul, .xl\\\\:markdown-xl ul ol, .xl\\\\:markdown-xl ol ul, .xl\\\\:markdown-xl ol ol {
+      -   .xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-xl hr {
-      +   .xl\\\\:markdown-xl hr {
+      -   .xl\\\\:prose-xl :where(hr) {
+      +   .xl\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-xl hr + * {
-      +   .xl\\\\:markdown-xl hr + * {
+      -   .xl\\\\:prose-xl :where(hr + *) {
+      +   .xl\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h2 + * {
-      +   .xl\\\\:markdown-xl h2 + * {
+      -   .xl\\\\:prose-xl :where(h2 + *) {
+      +   .xl\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h3 + * {
-      +   .xl\\\\:markdown-xl h3 + * {
+      -   .xl\\\\:prose-xl :where(h3 + *) {
+      +   .xl\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl h4 + * {
-      +   .xl\\\\:markdown-xl h4 + * {
+      -   .xl\\\\:prose-xl :where(h4 + *) {
+      +   .xl\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-xl table {
-      +   .xl\\\\:markdown-xl table {
+      -   .xl\\\\:prose-xl :where(table) {
+      +   .xl\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th {
-      +   .xl\\\\:markdown-xl thead th {
+      -   .xl\\\\:prose-xl :where(thead th) {
+      +   .xl\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th:first-child {
-      +   .xl\\\\:markdown-xl thead th:first-child {
+      -   .xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .xl\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl thead th:last-child {
-      +   .xl\\\\:markdown-xl thead th:last-child {
+      -   .xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .xl\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td {
-      +   .xl\\\\:markdown-xl tbody td {
+      -   .xl\\\\:prose-xl :where(tbody td) {
+      +   .xl\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td:first-child {
-      +   .xl\\\\:markdown-xl tbody td:first-child {
+      -   .xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl tbody td:last-child {
-      +   .xl\\\\:markdown-xl tbody td:last-child {
+      -   .xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > :first-child {
-      +   .xl\\\\:markdown-xl > :first-child {
+      -   .xl\\\\:prose-xl :where(> :first-child) {
+      +   .xl\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-xl > :last-child {
-      +   .xl\\\\:markdown-xl > :last-child {
+      -   .xl\\\\:prose-xl :where(> :last-child) {
+      +   .xl\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -23857,278 +23857,278 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-2xl p {
-      +   .xl\\\\:markdown-2xl p {
+      -   .xl\\\\:prose-2xl :where(p) {
+      +   .xl\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .xl\\\\:prose-2xl [class~='lead'] {
-      +   .xl\\\\:markdown-2xl [class~='lead'] {
+      -   .xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .xl\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .xl\\\\:prose-2xl blockquote {
-      +   .xl\\\\:markdown-2xl blockquote {
+      -   .xl\\\\:prose-2xl :where(blockquote) {
+      +   .xl\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h1 {
-      +   .xl\\\\:markdown-2xl h1 {
+      -   .xl\\\\:prose-2xl :where(h1) {
+      +   .xl\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 {
-      +   .xl\\\\:markdown-2xl h2 {
+      -   .xl\\\\:prose-2xl :where(h2) {
+      +   .xl\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 {
-      +   .xl\\\\:markdown-2xl h3 {
+      -   .xl\\\\:prose-2xl :where(h3) {
+      +   .xl\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h4 {
-      +   .xl\\\\:markdown-2xl h4 {
+      -   .xl\\\\:prose-2xl :where(h4) {
+      +   .xl\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .xl\\\\:prose-2xl img {
-      +   .xl\\\\:markdown-2xl img {
+      -   .xl\\\\:prose-2xl :where(img) {
+      +   .xl\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .xl\\\\:prose-2xl video {
-      +   .xl\\\\:markdown-2xl video {
+      -   .xl\\\\:prose-2xl :where(video) {
+      +   .xl\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure {
-      +   .xl\\\\:markdown-2xl figure {
+      -   .xl\\\\:prose-2xl :where(figure) {
+      +   .xl\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure > * {
-      +   .xl\\\\:markdown-2xl figure > * {
+      -   .xl\\\\:prose-2xl :where(figure > *) {
+      +   .xl\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl figure figcaption {
-      +   .xl\\\\:markdown-2xl figure figcaption {
+      -   .xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .xl\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .xl\\\\:prose-2xl code {
-      +   .xl\\\\:markdown-2xl code {
+      -   .xl\\\\:prose-2xl :where(code) {
+      +   .xl\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 code {
-      +   .xl\\\\:markdown-2xl h2 code {
+      -   .xl\\\\:prose-2xl :where(h2 code) {
+      +   .xl\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 code {
-      +   .xl\\\\:markdown-2xl h3 code {
+      -   .xl\\\\:prose-2xl :where(h3 code) {
+      +   .xl\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .xl\\\\:prose-2xl pre {
-      +   .xl\\\\:markdown-2xl pre {
+      -   .xl\\\\:prose-2xl :where(pre) {
+      +   .xl\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol {
-      +   .xl\\\\:markdown-2xl ol {
+      -   .xl\\\\:prose-2xl :where(ol) {
+      +   .xl\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul {
-      +   .xl\\\\:markdown-2xl ul {
+      -   .xl\\\\:prose-2xl :where(ul) {
+      +   .xl\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .xl\\\\:prose-2xl li {
-      +   .xl\\\\:markdown-2xl li {
+      -   .xl\\\\:prose-2xl :where(li) {
+      +   .xl\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol > li {
-      +   .xl\\\\:markdown-2xl ol > li {
+      -   .xl\\\\:prose-2xl :where(ol > li) {
+      +   .xl\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ol > li::before {
-      +   .xl\\\\:markdown-2xl ol > li::before {
+      -   .xl\\\\:prose-2xl :where(ol > li::before) {
+      +   .xl\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul > li {
-      +   .xl\\\\:markdown-2xl ul > li {
+      -   .xl\\\\:prose-2xl :where(ul > li) {
+      +   .xl\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul > li::before {
-      +   .xl\\\\:markdown-2xl ul > li::before {
+      -   .xl\\\\:prose-2xl :where(ul > li::before) {
+      +   .xl\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li p {
-      +   .xl\\\\:markdown-2xl > ul > li p {
+      -   .xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li > *:first-child {
-      +   .xl\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ul > li > *:last-child {
-      +   .xl\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ol > li > *:first-child {
-      +   .xl\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > ol > li > *:last-child {
-      +   .xl\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl ul ul, .xl\\\\:prose-2xl ul ol, .xl\\\\:prose-2xl ol ul, .xl\\\\:prose-2xl ol ol {
-      +   .xl\\\\:markdown-2xl ul ul, .xl\\\\:markdown-2xl ul ol, .xl\\\\:markdown-2xl ol ul, .xl\\\\:markdown-2xl ol ol {
+      -   .xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .xl\\\\:prose-2xl hr {
-      +   .xl\\\\:markdown-2xl hr {
+      -   .xl\\\\:prose-2xl :where(hr) {
+      +   .xl\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .xl\\\\:prose-2xl hr + * {
-      +   .xl\\\\:markdown-2xl hr + * {
+      -   .xl\\\\:prose-2xl :where(hr + *) {
+      +   .xl\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h2 + * {
-      +   .xl\\\\:markdown-2xl h2 + * {
+      -   .xl\\\\:prose-2xl :where(h2 + *) {
+      +   .xl\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h3 + * {
-      +   .xl\\\\:markdown-2xl h3 + * {
+      -   .xl\\\\:prose-2xl :where(h3 + *) {
+      +   .xl\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl h4 + * {
-      +   .xl\\\\:markdown-2xl h4 + * {
+      -   .xl\\\\:prose-2xl :where(h4 + *) {
+      +   .xl\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .xl\\\\:prose-2xl table {
-      +   .xl\\\\:markdown-2xl table {
+      -   .xl\\\\:prose-2xl :where(table) {
+      +   .xl\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th {
-      +   .xl\\\\:markdown-2xl thead th {
+      -   .xl\\\\:prose-2xl :where(thead th) {
+      +   .xl\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th:first-child {
-      +   .xl\\\\:markdown-2xl thead th:first-child {
+      -   .xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .xl\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl thead th:last-child {
-      +   .xl\\\\:markdown-2xl thead th:last-child {
+      -   .xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .xl\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td {
-      +   .xl\\\\:markdown-2xl tbody td {
+      -   .xl\\\\:prose-2xl :where(tbody td) {
+      +   .xl\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td:first-child {
-      +   .xl\\\\:markdown-2xl tbody td:first-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .xl\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl tbody td:last-child {
-      +   .xl\\\\:markdown-2xl tbody td:last-child {
+      -   .xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .xl\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > :first-child {
-      +   .xl\\\\:markdown-2xl > :first-child {
+      -   .xl\\\\:prose-2xl :where(> :first-child) {
+      +   .xl\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .xl\\\\:prose-2xl > :last-child {
-      +   .xl\\\\:markdown-2xl > :last-child {
+      -   .xl\\\\:prose-2xl :where(> :last-child) {
+      +   .xl\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .xl\\\\:prose-red a {
+      -   .xl\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .xl\\\\:prose-red a code {
+      -   .xl\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .xl\\\\:prose-yellow a {
+      -   .xl\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .xl\\\\:prose-yellow a code {
+      -   .xl\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .xl\\\\:prose-green a {
+      -   .xl\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .xl\\\\:prose-green a code {
+      -   .xl\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .xl\\\\:prose-blue a {
+      -   .xl\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .xl\\\\:prose-blue a code {
+      -   .xl\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .xl\\\\:prose-indigo a {
+      -   .xl\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .xl\\\\:prose-indigo a code {
+      -   .xl\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .xl\\\\:prose-purple a {
+      -   .xl\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .xl\\\\:prose-purple a code {
+      -   .xl\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .xl\\\\:prose-pink a {
+      -   .xl\\\\:prose-pink :where(a) {
       -     color: #db2777;
 
       ---
 
       -
-      -   .xl\\\\:prose-pink a code {
+      -   .xl\\\\:prose-pink :where(a code) {
       -     color: #db2777;
       -   }
 
@@ -24139,218 +24139,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown [class~='lead'] {
+      -   .\\\\32xl\\\\:prose :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose a {
-      +   .\\\\32xl\\\\:markdown a {
+      -   .\\\\32xl\\\\:prose :where(a) {
+      +   .\\\\32xl\\\\:markdown :where(a) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose strong {
-      +   .\\\\32xl\\\\:markdown strong {
+      -   .\\\\32xl\\\\:prose :where(strong) {
+      +   .\\\\32xl\\\\:markdown :where(strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='A'] {
-      +   .\\\\32xl\\\\:markdown ol[type='A'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='A']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='A']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='a'] {
-      +   .\\\\32xl\\\\:markdown ol[type='a'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='a']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='a']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='A' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='A' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='A' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='A' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='a' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='a' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='a' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='a' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='I'] {
-      +   .\\\\32xl\\\\:markdown ol[type='I'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='I']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='I']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='i'] {
-      +   .\\\\32xl\\\\:markdown ol[type='i'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='i']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='i']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='I' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='I' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='I' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='I' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='i' s] {
-      +   .\\\\32xl\\\\:markdown ol[type='i' s] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='i' s]) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='i' s]) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol[type='1'] {
-      +   .\\\\32xl\\\\:markdown ol[type='1'] {
+      -   .\\\\32xl\\\\:prose :where(ol[type='1']) {
+      +   .\\\\32xl\\\\:markdown :where(ol[type='1']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol > li {
-      +   .\\\\32xl\\\\:markdown ol > li {
+      -   .\\\\32xl\\\\:prose :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol > li::before {
-      +   .\\\\32xl\\\\:markdown ol > li::before {
+      -   .\\\\32xl\\\\:prose :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul > li {
-      +   .\\\\32xl\\\\:markdown ul > li {
+      -   .\\\\32xl\\\\:prose :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul > li::before {
-      +   .\\\\32xl\\\\:markdown ul > li::before {
+      -   .\\\\32xl\\\\:prose :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose hr {
-      +   .\\\\32xl\\\\:markdown hr {
+      -   .\\\\32xl\\\\:prose :where(hr) {
+      +   .\\\\32xl\\\\:markdown :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote {
-      +   .\\\\32xl\\\\:markdown blockquote {
+      -   .\\\\32xl\\\\:prose :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote p:first-of-type::before {
-      +   .\\\\32xl\\\\:markdown blockquote p:first-of-type::before {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose blockquote p:last-of-type::after {
-      +   .\\\\32xl\\\\:markdown blockquote p:last-of-type::after {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h1 {
-      +   .\\\\32xl\\\\:markdown h1 {
+      -   .\\\\32xl\\\\:prose :where(h1) {
+      +   .\\\\32xl\\\\:markdown :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h1 strong {
-      +   .\\\\32xl\\\\:markdown h1 strong {
+      -   .\\\\32xl\\\\:prose :where(h1 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h1 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 {
-      +   .\\\\32xl\\\\:markdown h2 {
+      -   .\\\\32xl\\\\:prose :where(h2) {
+      +   .\\\\32xl\\\\:markdown :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 strong {
-      +   .\\\\32xl\\\\:markdown h2 strong {
+      -   .\\\\32xl\\\\:prose :where(h2 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h2 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 {
-      +   .\\\\32xl\\\\:markdown h3 {
+      -   .\\\\32xl\\\\:prose :where(h3) {
+      +   .\\\\32xl\\\\:markdown :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 strong {
-      +   .\\\\32xl\\\\:markdown h3 strong {
+      -   .\\\\32xl\\\\:prose :where(h3 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h3 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 {
-      +   .\\\\32xl\\\\:markdown h4 {
+      -   .\\\\32xl\\\\:prose :where(h4) {
+      +   .\\\\32xl\\\\:markdown :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 strong {
-      +   .\\\\32xl\\\\:markdown h4 strong {
+      -   .\\\\32xl\\\\:prose :where(h4 strong) {
+      +   .\\\\32xl\\\\:markdown :where(h4 strong) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure figcaption {
-      +   .\\\\32xl\\\\:markdown figure figcaption {
+      -   .\\\\32xl\\\\:prose :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code {
-      +   .\\\\32xl\\\\:markdown code {
+      -   .\\\\32xl\\\\:prose :where(code) {
+      +   .\\\\32xl\\\\:markdown :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code::before {
-      +   .\\\\32xl\\\\:markdown code::before {
+      -   .\\\\32xl\\\\:prose :where(code::before) {
+      +   .\\\\32xl\\\\:markdown :where(code::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose code::after {
-      +   .\\\\32xl\\\\:markdown code::after {
+      -   .\\\\32xl\\\\:prose :where(code::after) {
+      +   .\\\\32xl\\\\:markdown :where(code::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose a code {
-      +   .\\\\32xl\\\\:markdown a code {
+      -   .\\\\32xl\\\\:prose :where(a code) {
+      +   .\\\\32xl\\\\:markdown :where(a code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre {
-      +   .\\\\32xl\\\\:markdown pre {
+      -   .\\\\32xl\\\\:prose :where(pre) {
+      +   .\\\\32xl\\\\:markdown :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code {
-      +   .\\\\32xl\\\\:markdown pre code {
+      -   .\\\\32xl\\\\:prose :where(pre code) {
+      +   .\\\\32xl\\\\:markdown :where(pre code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code::before {
-      +   .\\\\32xl\\\\:markdown pre code::before {
+      -   .\\\\32xl\\\\:prose :where(pre code::before) {
+      +   .\\\\32xl\\\\:markdown :where(pre code::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose pre code::after {
-      +   .\\\\32xl\\\\:markdown pre code::after {
+      -   .\\\\32xl\\\\:prose :where(pre code::after) {
+      +   .\\\\32xl\\\\:markdown :where(pre code::after) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose table {
-      +   .\\\\32xl\\\\:markdown table {
+      -   .\\\\32xl\\\\:prose :where(table) {
+      +   .\\\\32xl\\\\:markdown :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead {
-      +   .\\\\32xl\\\\:markdown thead {
+      -   .\\\\32xl\\\\:prose :where(thead) {
+      +   .\\\\32xl\\\\:markdown :where(thead) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th {
-      +   .\\\\32xl\\\\:markdown thead th {
+      -   .\\\\32xl\\\\:prose :where(thead th) {
+      +   .\\\\32xl\\\\:markdown :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody tr {
-      +   .\\\\32xl\\\\:markdown tbody tr {
+      -   .\\\\32xl\\\\:prose :where(tbody tr) {
+      +   .\\\\32xl\\\\:markdown :where(tbody tr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody tr:last-child {
-      +   .\\\\32xl\\\\:markdown tbody tr:last-child {
+      -   .\\\\32xl\\\\:prose :where(tbody tr:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody tr:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td {
-      +   .\\\\32xl\\\\:markdown tbody td {
+      -   .\\\\32xl\\\\:prose :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td) {
 
       ---
 
@@ -24359,225 +24359,225 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose p {
-      +   .\\\\32xl\\\\:markdown p {
+      -   .\\\\32xl\\\\:prose :where(p) {
+      +   .\\\\32xl\\\\:markdown :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose img {
-      +   .\\\\32xl\\\\:markdown img {
+      -   .\\\\32xl\\\\:prose :where(img) {
+      +   .\\\\32xl\\\\:markdown :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose video {
-      +   .\\\\32xl\\\\:markdown video {
+      -   .\\\\32xl\\\\:prose :where(video) {
+      +   .\\\\32xl\\\\:markdown :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure {
-      +   .\\\\32xl\\\\:markdown figure {
+      -   .\\\\32xl\\\\:prose :where(figure) {
+      +   .\\\\32xl\\\\:markdown :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose figure > * {
-      +   .\\\\32xl\\\\:markdown figure > * {
+      -   .\\\\32xl\\\\:prose :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 code {
-      +   .\\\\32xl\\\\:markdown h2 code {
+      -   .\\\\32xl\\\\:prose :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 code {
-      +   .\\\\32xl\\\\:markdown h3 code {
+      -   .\\\\32xl\\\\:prose :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ol {
-      +   .\\\\32xl\\\\:markdown ol {
+      -   .\\\\32xl\\\\:prose :where(ol) {
+      +   .\\\\32xl\\\\:markdown :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul {
-      +   .\\\\32xl\\\\:markdown ul {
+      -   .\\\\32xl\\\\:prose :where(ul) {
+      +   .\\\\32xl\\\\:markdown :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose li {
-      +   .\\\\32xl\\\\:markdown li {
+      -   .\\\\32xl\\\\:prose :where(li) {
+      +   .\\\\32xl\\\\:markdown :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li p {
-      +   .\\\\32xl\\\\:markdown > ul > li p {
+      -   .\\\\32xl\\\\:prose :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose ul ul, .\\\\32xl\\\\:prose ul ol, .\\\\32xl\\\\:prose ol ul, .\\\\32xl\\\\:prose ol ol {
-      +   .\\\\32xl\\\\:markdown ul ul, .\\\\32xl\\\\:markdown ul ol, .\\\\32xl\\\\:markdown ol ul, .\\\\32xl\\\\:markdown ol ol {
+      -   .\\\\32xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose hr + * {
-      +   .\\\\32xl\\\\:markdown hr + * {
+      -   .\\\\32xl\\\\:prose :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h2 + * {
-      +   .\\\\32xl\\\\:markdown h2 + * {
+      -   .\\\\32xl\\\\:prose :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h3 + * {
-      +   .\\\\32xl\\\\:markdown h3 + * {
+      -   .\\\\32xl\\\\:prose :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose h4 + * {
-      +   .\\\\32xl\\\\:markdown h4 + * {
+      -   .\\\\32xl\\\\:prose :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th:first-child {
-      +   .\\\\32xl\\\\:markdown thead th:first-child {
+      -   .\\\\32xl\\\\:prose :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose thead th:last-child {
-      +   .\\\\32xl\\\\:markdown thead th:last-child {
+      -   .\\\\32xl\\\\:prose :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown tbody td:first-child {
+      -   .\\\\32xl\\\\:prose :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown tbody td:last-child {
+      -   .\\\\32xl\\\\:prose :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > :first-child {
-      +   .\\\\32xl\\\\:markdown > :first-child {
+      -   .\\\\32xl\\\\:prose :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose > :last-child {
-      +   .\\\\32xl\\\\:markdown > :last-child {
+      -   .\\\\32xl\\\\:prose :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown :where(> :last-child) {
 
       ---
 
       -   .\\\\32xl\\\\:prose-sm {
-      -     font-size: 0.875rem;
-      -     line-height: 1.7142857;
+      -     :where(font-size): 0.875rem;
+      -     :where(line-height): 1.7142857;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm p {
+      -   .\\\\32xl\\\\:prose-sm :where(p) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-sm :where([class~='lead']) {
       -     font-size: 1.2857143em;
       -     line-height: 1.5555556;
       -     margin-top: 0.8888889em;
       -     margin-bottom: 0.8888889em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm blockquote {
+      -   .\\\\32xl\\\\:prose-sm :where(blockquote) {
       -     margin-top: 1.3333333em;
       -     margin-bottom: 1.3333333em;
       -     padding-left: 1.1111111em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h1 {
+      -   .\\\\32xl\\\\:prose-sm :where(h1) {
       -     font-size: 2.1428571em;
       -     margin-top: 0;
       -     margin-bottom: 0.8em;
       -     line-height: 1.2;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h2 {
+      -   .\\\\32xl\\\\:prose-sm :where(h2) {
       -     font-size: 1.4285714em;
       -     margin-top: 1.6em;
       -     margin-bottom: 0.8em;
       -     line-height: 1.4;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h3 {
+      -   .\\\\32xl\\\\:prose-sm :where(h3) {
       -     font-size: 1.2857143em;
       -     margin-top: 1.5555556em;
       -     margin-bottom: 0.4444444em;
       -     line-height: 1.5555556;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h4 {
+      -   .\\\\32xl\\\\:prose-sm :where(h4) {
       -     margin-top: 1.4285714em;
       -     margin-bottom: 0.5714286em;
       -     line-height: 1.4285714;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm img {
+      -   .\\\\32xl\\\\:prose-sm :where(img) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm video {
+      -   .\\\\32xl\\\\:prose-sm :where(video) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm figure {
+      -   .\\\\32xl\\\\:prose-sm :where(figure) {
       -     margin-top: 1.7142857em;
       -     margin-bottom: 1.7142857em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm figure > * {
+      -   .\\\\32xl\\\\:prose-sm :where(figure > *) {
       -     margin-top: 0;
       -     margin-bottom: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm figure figcaption {
+      -   .\\\\32xl\\\\:prose-sm :where(figure figcaption) {
       -     font-size: 0.8571429em;
       -     line-height: 1.3333333;
       -     margin-top: 0.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm code {
+      -   .\\\\32xl\\\\:prose-sm :where(code) {
       -     font-size: 0.8571429em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h2 code {
+      -   .\\\\32xl\\\\:prose-sm :where(h2 code) {
       -     font-size: 0.9em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h3 code {
+      -   .\\\\32xl\\\\:prose-sm :where(h3 code) {
       -     font-size: 0.8888889em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm pre {
+      -   .\\\\32xl\\\\:prose-sm :where(pre) {
       -     font-size: 0.8571429em;
       -     line-height: 1.6666667;
       -     margin-top: 1.6666667em;
@@ -24589,126 +24589,126 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ol {
+      -   .\\\\32xl\\\\:prose-sm :where(ol) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ul {
+      -   .\\\\32xl\\\\:prose-sm :where(ul) {
       -     margin-top: 1.1428571em;
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm li {
+      -   .\\\\32xl\\\\:prose-sm :where(li) {
       -     margin-top: 0.2857143em;
       -     margin-bottom: 0.2857143em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ol > li {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ol > li::before {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
       -     left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ul > li {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li) {
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ul > li::before {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
       -     left: 0.2142857em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > ul > li p {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li p) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:first-child) {
       -     margin-top: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:last-child) {
       -     margin-bottom: 1.1428571em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm ul ul, .\\\\32xl\\\\:prose-sm ul ol, .\\\\32xl\\\\:prose-sm ol ul, .\\\\32xl\\\\:prose-sm ol ol {
+      -   .\\\\32xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
       -     margin-top: 0.5714286em;
       -     margin-bottom: 0.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm hr {
+      -   .\\\\32xl\\\\:prose-sm :where(hr) {
       -     margin-top: 2.8571429em;
       -     margin-bottom: 2.8571429em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm hr + * {
+      -   .\\\\32xl\\\\:prose-sm :where(hr + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h2 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h2 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h3 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h3 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm h4 + * {
+      -   .\\\\32xl\\\\:prose-sm :where(h4 + *) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm table {
+      -   .\\\\32xl\\\\:prose-sm :where(table) {
       -     font-size: 0.8571429em;
       -     line-height: 1.5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm thead th {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th) {
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm thead th:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm thead th:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm tbody td {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td) {
       -     padding-top: 0.6666667em;
       -     padding-right: 1em;
       -     padding-bottom: 0.6666667em;
       -     padding-left: 1em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:first-child) {
       -     padding-left: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:last-child) {
       -     padding-right: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > :first-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> :first-child) {
       -     margin-top: 0;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm > :last-child {
+      -   .\\\\32xl\\\\:prose-sm :where(> :last-child) {
       -     margin-bottom: 0;
       -   }
       -
@@ -24717,218 +24717,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg p {
-      +   .\\\\32xl\\\\:markdown-lg p {
+      -   .\\\\32xl\\\\:prose-lg :where(p) {
+      +   .\\\\32xl\\\\:markdown-lg :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-lg [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-lg :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-lg :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg blockquote {
-      +   .\\\\32xl\\\\:markdown-lg blockquote {
+      -   .\\\\32xl\\\\:prose-lg :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-lg :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h1 {
-      +   .\\\\32xl\\\\:markdown-lg h1 {
+      -   .\\\\32xl\\\\:prose-lg :where(h1) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 {
-      +   .\\\\32xl\\\\:markdown-lg h2 {
+      -   .\\\\32xl\\\\:prose-lg :where(h2) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 {
-      +   .\\\\32xl\\\\:markdown-lg h3 {
+      -   .\\\\32xl\\\\:prose-lg :where(h3) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h4 {
-      +   .\\\\32xl\\\\:markdown-lg h4 {
+      -   .\\\\32xl\\\\:prose-lg :where(h4) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg img {
-      +   .\\\\32xl\\\\:markdown-lg img {
+      -   .\\\\32xl\\\\:prose-lg :where(img) {
+      +   .\\\\32xl\\\\:markdown-lg :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg video {
-      +   .\\\\32xl\\\\:markdown-lg video {
+      -   .\\\\32xl\\\\:prose-lg :where(video) {
+      +   .\\\\32xl\\\\:markdown-lg :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure {
-      +   .\\\\32xl\\\\:markdown-lg figure {
+      -   .\\\\32xl\\\\:prose-lg :where(figure) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure > * {
-      +   .\\\\32xl\\\\:markdown-lg figure > * {
+      -   .\\\\32xl\\\\:prose-lg :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg figure figcaption {
-      +   .\\\\32xl\\\\:markdown-lg figure figcaption {
+      -   .\\\\32xl\\\\:prose-lg :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-lg :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg code {
-      +   .\\\\32xl\\\\:markdown-lg code {
+      -   .\\\\32xl\\\\:prose-lg :where(code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 code {
-      +   .\\\\32xl\\\\:markdown-lg h2 code {
+      -   .\\\\32xl\\\\:prose-lg :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 code {
-      +   .\\\\32xl\\\\:markdown-lg h3 code {
+      -   .\\\\32xl\\\\:prose-lg :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg pre {
-      +   .\\\\32xl\\\\:markdown-lg pre {
+      -   .\\\\32xl\\\\:prose-lg :where(pre) {
+      +   .\\\\32xl\\\\:markdown-lg :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol {
-      +   .\\\\32xl\\\\:markdown-lg ol {
+      -   .\\\\32xl\\\\:prose-lg :where(ol) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul {
-      +   .\\\\32xl\\\\:markdown-lg ul {
+      -   .\\\\32xl\\\\:prose-lg :where(ul) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg li {
-      +   .\\\\32xl\\\\:markdown-lg li {
+      -   .\\\\32xl\\\\:prose-lg :where(li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol > li {
-      +   .\\\\32xl\\\\:markdown-lg ol > li {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ol > li::before {
-      +   .\\\\32xl\\\\:markdown-lg ol > li::before {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul > li {
-      +   .\\\\32xl\\\\:markdown-lg ul > li {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul > li::before {
-      +   .\\\\32xl\\\\:markdown-lg ul > li::before {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li p {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li p {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-lg > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-lg > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-lg > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg ul ul, .\\\\32xl\\\\:prose-lg ul ol, .\\\\32xl\\\\:prose-lg ol ul, .\\\\32xl\\\\:prose-lg ol ol {
-      +   .\\\\32xl\\\\:markdown-lg ul ul, .\\\\32xl\\\\:markdown-lg ul ol, .\\\\32xl\\\\:markdown-lg ol ul, .\\\\32xl\\\\:markdown-lg ol ol {
+      -   .\\\\32xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg hr {
-      +   .\\\\32xl\\\\:markdown-lg hr {
+      -   .\\\\32xl\\\\:prose-lg :where(hr) {
+      +   .\\\\32xl\\\\:markdown-lg :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg hr + * {
-      +   .\\\\32xl\\\\:markdown-lg hr + * {
+      -   .\\\\32xl\\\\:prose-lg :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h2 + * {
-      +   .\\\\32xl\\\\:markdown-lg h2 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h3 + * {
-      +   .\\\\32xl\\\\:markdown-lg h3 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg h4 + * {
-      +   .\\\\32xl\\\\:markdown-lg h4 + * {
+      -   .\\\\32xl\\\\:prose-lg :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-lg :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg table {
-      +   .\\\\32xl\\\\:markdown-lg table {
+      -   .\\\\32xl\\\\:prose-lg :where(table) {
+      +   .\\\\32xl\\\\:markdown-lg :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th {
-      +   .\\\\32xl\\\\:markdown-lg thead th {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-lg thead th:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-lg thead th:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td {
-      +   .\\\\32xl\\\\:markdown-lg tbody td {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-lg tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-lg tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > :first-child {
-      +   .\\\\32xl\\\\:markdown-lg > :first-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg > :last-child {
-      +   .\\\\32xl\\\\:markdown-lg > :last-child {
+      -   .\\\\32xl\\\\:prose-lg :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-lg :where(> :last-child) {
 
       ---
 
@@ -24937,218 +24937,218 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl p {
-      +   .\\\\32xl\\\\:markdown-xl p {
+      -   .\\\\32xl\\\\:prose-xl :where(p) {
+      +   .\\\\32xl\\\\:markdown-xl :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-xl [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-xl :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl blockquote {
-      +   .\\\\32xl\\\\:markdown-xl blockquote {
+      -   .\\\\32xl\\\\:prose-xl :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-xl :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h1 {
-      +   .\\\\32xl\\\\:markdown-xl h1 {
+      -   .\\\\32xl\\\\:prose-xl :where(h1) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 {
-      +   .\\\\32xl\\\\:markdown-xl h2 {
+      -   .\\\\32xl\\\\:prose-xl :where(h2) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 {
-      +   .\\\\32xl\\\\:markdown-xl h3 {
+      -   .\\\\32xl\\\\:prose-xl :where(h3) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h4 {
-      +   .\\\\32xl\\\\:markdown-xl h4 {
+      -   .\\\\32xl\\\\:prose-xl :where(h4) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl img {
-      +   .\\\\32xl\\\\:markdown-xl img {
+      -   .\\\\32xl\\\\:prose-xl :where(img) {
+      +   .\\\\32xl\\\\:markdown-xl :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl video {
-      +   .\\\\32xl\\\\:markdown-xl video {
+      -   .\\\\32xl\\\\:prose-xl :where(video) {
+      +   .\\\\32xl\\\\:markdown-xl :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure {
-      +   .\\\\32xl\\\\:markdown-xl figure {
+      -   .\\\\32xl\\\\:prose-xl :where(figure) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure > * {
-      +   .\\\\32xl\\\\:markdown-xl figure > * {
+      -   .\\\\32xl\\\\:prose-xl :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl figure figcaption {
-      +   .\\\\32xl\\\\:markdown-xl figure figcaption {
+      -   .\\\\32xl\\\\:prose-xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-xl :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl code {
-      +   .\\\\32xl\\\\:markdown-xl code {
+      -   .\\\\32xl\\\\:prose-xl :where(code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 code {
-      +   .\\\\32xl\\\\:markdown-xl h2 code {
+      -   .\\\\32xl\\\\:prose-xl :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 code {
-      +   .\\\\32xl\\\\:markdown-xl h3 code {
+      -   .\\\\32xl\\\\:prose-xl :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl pre {
-      +   .\\\\32xl\\\\:markdown-xl pre {
+      -   .\\\\32xl\\\\:prose-xl :where(pre) {
+      +   .\\\\32xl\\\\:markdown-xl :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol {
-      +   .\\\\32xl\\\\:markdown-xl ol {
+      -   .\\\\32xl\\\\:prose-xl :where(ol) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul {
-      +   .\\\\32xl\\\\:markdown-xl ul {
+      -   .\\\\32xl\\\\:prose-xl :where(ul) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl li {
-      +   .\\\\32xl\\\\:markdown-xl li {
+      -   .\\\\32xl\\\\:prose-xl :where(li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol > li {
-      +   .\\\\32xl\\\\:markdown-xl ol > li {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ol > li::before {
-      +   .\\\\32xl\\\\:markdown-xl ol > li::before {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul > li {
-      +   .\\\\32xl\\\\:markdown-xl ul > li {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul > li::before {
-      +   .\\\\32xl\\\\:markdown-xl ul > li::before {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li p {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li p {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-xl > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-xl > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-xl > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl ul ul, .\\\\32xl\\\\:prose-xl ul ol, .\\\\32xl\\\\:prose-xl ol ul, .\\\\32xl\\\\:prose-xl ol ol {
-      +   .\\\\32xl\\\\:markdown-xl ul ul, .\\\\32xl\\\\:markdown-xl ul ol, .\\\\32xl\\\\:markdown-xl ol ul, .\\\\32xl\\\\:markdown-xl ol ol {
+      -   .\\\\32xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl hr {
-      +   .\\\\32xl\\\\:markdown-xl hr {
+      -   .\\\\32xl\\\\:prose-xl :where(hr) {
+      +   .\\\\32xl\\\\:markdown-xl :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl hr + * {
-      +   .\\\\32xl\\\\:markdown-xl hr + * {
+      -   .\\\\32xl\\\\:prose-xl :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h2 + * {
-      +   .\\\\32xl\\\\:markdown-xl h2 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h3 + * {
-      +   .\\\\32xl\\\\:markdown-xl h3 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl h4 + * {
-      +   .\\\\32xl\\\\:markdown-xl h4 + * {
+      -   .\\\\32xl\\\\:prose-xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-xl :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl table {
-      +   .\\\\32xl\\\\:markdown-xl table {
+      -   .\\\\32xl\\\\:prose-xl :where(table) {
+      +   .\\\\32xl\\\\:markdown-xl :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th {
-      +   .\\\\32xl\\\\:markdown-xl thead th {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-xl thead th:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-xl thead th:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td {
-      +   .\\\\32xl\\\\:markdown-xl tbody td {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-xl tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-xl tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > :first-child {
-      +   .\\\\32xl\\\\:markdown-xl > :first-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl > :last-child {
-      +   .\\\\32xl\\\\:markdown-xl > :last-child {
+      -   .\\\\32xl\\\\:prose-xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-xl :where(> :last-child) {
 
       ---
 
@@ -25157,276 +25157,276 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl p {
-      +   .\\\\32xl\\\\:markdown-2xl p {
+      -   .\\\\32xl\\\\:prose-2xl :where(p) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl [class~='lead'] {
-      +   .\\\\32xl\\\\:markdown-2xl [class~='lead'] {
+      -   .\\\\32xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:markdown-2xl :where([class~='lead']) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl blockquote {
-      +   .\\\\32xl\\\\:markdown-2xl blockquote {
+      -   .\\\\32xl\\\\:prose-2xl :where(blockquote) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(blockquote) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h1 {
-      +   .\\\\32xl\\\\:markdown-2xl h1 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h1) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h1) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 {
-      +   .\\\\32xl\\\\:markdown-2xl h2 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 {
-      +   .\\\\32xl\\\\:markdown-2xl h3 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h4 {
-      +   .\\\\32xl\\\\:markdown-2xl h4 {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h4) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl img {
-      +   .\\\\32xl\\\\:markdown-2xl img {
+      -   .\\\\32xl\\\\:prose-2xl :where(img) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(img) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl video {
-      +   .\\\\32xl\\\\:markdown-2xl video {
+      -   .\\\\32xl\\\\:prose-2xl :where(video) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(video) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure {
-      +   .\\\\32xl\\\\:markdown-2xl figure {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure > * {
-      +   .\\\\32xl\\\\:markdown-2xl figure > * {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure > *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure > *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl figure figcaption {
-      +   .\\\\32xl\\\\:markdown-2xl figure figcaption {
+      -   .\\\\32xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(figure figcaption) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl code {
-      +   .\\\\32xl\\\\:markdown-2xl code {
+      -   .\\\\32xl\\\\:prose-2xl :where(code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 code {
-      +   .\\\\32xl\\\\:markdown-2xl h2 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 code {
-      +   .\\\\32xl\\\\:markdown-2xl h3 code {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 code) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3 code) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl pre {
-      +   .\\\\32xl\\\\:markdown-2xl pre {
+      -   .\\\\32xl\\\\:prose-2xl :where(pre) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(pre) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol {
-      +   .\\\\32xl\\\\:markdown-2xl ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul {
-      +   .\\\\32xl\\\\:markdown-2xl ul {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl li {
-      +   .\\\\32xl\\\\:markdown-2xl li {
+      -   .\\\\32xl\\\\:prose-2xl :where(li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol > li {
-      +   .\\\\32xl\\\\:markdown-2xl ol > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ol > li::before {
-      +   .\\\\32xl\\\\:markdown-2xl ol > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul > li {
-      +   .\\\\32xl\\\\:markdown-2xl ul > li {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul > li::before {
-      +   .\\\\32xl\\\\:markdown-2xl ul > li::before {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li::before) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li p {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li p {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li p) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ul > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ul > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ul > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ol > li > *:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ol > li > *:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > ol > li > *:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > ol > li > *:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> ol > li > *:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl ul ul, .\\\\32xl\\\\:prose-2xl ul ol, .\\\\32xl\\\\:prose-2xl ol ul, .\\\\32xl\\\\:prose-2xl ol ol {
-      +   .\\\\32xl\\\\:markdown-2xl ul ul, .\\\\32xl\\\\:markdown-2xl ul ol, .\\\\32xl\\\\:markdown-2xl ol ul, .\\\\32xl\\\\:markdown-2xl ol ol {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul ul, ul ol, ol ul, ol ol) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl hr {
-      +   .\\\\32xl\\\\:markdown-2xl hr {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(hr) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl hr + * {
-      +   .\\\\32xl\\\\:markdown-2xl hr + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(hr + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(hr + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h2 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h2 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h2 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h3 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h3 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h3 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl h4 + * {
-      +   .\\\\32xl\\\\:markdown-2xl h4 + * {
+      -   .\\\\32xl\\\\:prose-2xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(h4 + *) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl table {
-      +   .\\\\32xl\\\\:markdown-2xl table {
+      -   .\\\\32xl\\\\:prose-2xl :where(table) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(table) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th {
-      +   .\\\\32xl\\\\:markdown-2xl thead th {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl thead th:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl thead th:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl thead th:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(thead th:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td:first-child {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td:first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td:first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl tbody td:last-child {
-      +   .\\\\32xl\\\\:markdown-2xl tbody td:last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(tbody td:last-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > :first-child {
-      +   .\\\\32xl\\\\:markdown-2xl > :first-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> :first-child) {
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl > :last-child {
-      +   .\\\\32xl\\\\:markdown-2xl > :last-child {
+      -   .\\\\32xl\\\\:prose-2xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:markdown-2xl :where(> :last-child) {
 
       ---
 
       -   }
       -
-      -   .\\\\32xl\\\\:prose-red a {
+      -   .\\\\32xl\\\\:prose-red :where(a) {
       -     color: #dc2626;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-red a code {
+      -   .\\\\32xl\\\\:prose-red :where(a code) {
       -     color: #dc2626;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-yellow a {
+      -   .\\\\32xl\\\\:prose-yellow :where(a) {
       -     color: #d97706;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-yellow a code {
+      -   .\\\\32xl\\\\:prose-yellow :where(a code) {
       -     color: #d97706;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-green a {
+      -   .\\\\32xl\\\\:prose-green :where(a) {
       -     color: #059669;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-green a code {
+      -   .\\\\32xl\\\\:prose-green :where(a code) {
       -     color: #059669;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-blue a {
+      -   .\\\\32xl\\\\:prose-blue :where(a) {
       -     color: #2563eb;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-blue a code {
+      -   .\\\\32xl\\\\:prose-blue :where(a code) {
       -     color: #2563eb;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-indigo a {
+      -   .\\\\32xl\\\\:prose-indigo :where(a) {
       -     color: #4f46e5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-indigo a code {
+      -   .\\\\32xl\\\\:prose-indigo :where(a code) {
       -     color: #4f46e5;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-purple a {
+      -   .\\\\32xl\\\\:prose-purple :where(a) {
       -     color: #7c3aed;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-purple a code {
+      -   .\\\\32xl\\\\:prose-purple :where(a code) {
       -     color: #7c3aed;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-pink a {
+      -   .\\\\32xl\\\\:prose-pink :where(a) {
       -     color: #db2777;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-pink a code {
+      -   .\\\\32xl\\\\:prose-pink :where(a code) {
       -     color: #db2777;
 
     "
@@ -25453,8 +25453,8 @@ it('should be possible to add a new variant', async () => {
     "
 
       + .prose-dark {
-      +   color: black;
-      +   max-width: 65ch;
+      +   :where(color): black;
+      +   :where(max-width): 65ch;
       + }
       +
 
@@ -25462,8 +25462,8 @@ it('should be possible to add a new variant', async () => {
 
       +
       +   .sm\\\\:prose-dark {
-      +     color: black;
-      +     max-width: 65ch;
+      +     :where(color): black;
+      +     :where(max-width): 65ch;
       +   }
 
       ---
@@ -25471,32 +25471,32 @@ it('should be possible to add a new variant', async () => {
       +   }
       +
       +   .md\\\\:prose-dark {
-      +     color: black;
-      +     max-width: 65ch;
+      +     :where(color): black;
+      +     :where(max-width): 65ch;
 
       ---
 
       +   }
       +
       +   .lg\\\\:prose-dark {
-      +     color: black;
-      +     max-width: 65ch;
+      +     :where(color): black;
+      +     :where(max-width): 65ch;
 
       ---
 
       +   }
       +
       +   .xl\\\\:prose-dark {
-      +     color: black;
-      +     max-width: 65ch;
+      +     :where(color): black;
+      +     :where(max-width): 65ch;
 
       ---
 
       +   }
       +
       +   .\\\\32xl\\\\:prose-dark {
-      +     color: black;
-      +     max-width: 65ch;
+      +     :where(color): black;
+      +     :where(max-width): 65ch;
 
     "
   `)
@@ -25791,11 +25791,11 @@ it('should be possible to add colors without 600 and still get default and custo
   ).toMatchInlineSnapshot(`
     "
 
-      + .prose-darkish-green a {
+      + .prose-darkish-green :where(a) {
       +   color: #55a855;
       + }
       +
-      + .prose-darkish-green a code {
+      + .prose-darkish-green :where(a code) {
       +   color: #55a855;
       + }
       +
@@ -25804,49 +25804,35 @@ it('should be possible to add colors without 600 and still get default and custo
 
       +   }
       +
-      +   .sm\\\\:prose-darkish-green a {
+      +   .sm\\\\:prose-darkish-green :where(a) {
       +     color: #55a855;
       +   }
       +
-      +   .sm\\\\:prose-darkish-green a code {
+      +   .sm\\\\:prose-darkish-green :where(a code) {
       +     color: #55a855;
 
       ---
 
       +   }
       +
-      +   .md\\\\:prose-darkish-green a {
+      +   .md\\\\:prose-darkish-green :where(a) {
       +     color: #55a855;
       +   }
       +
-      +   .md\\\\:prose-darkish-green a code {
+      +   .md\\\\:prose-darkish-green :where(a code) {
       +     color: #55a855;
 
       ---
 
       +   }
       +
-      +   .lg\\\\:prose-darkish-green a {
+      +   .lg\\\\:prose-darkish-green :where(a) {
       +     color: #55a855;
 
       ---
 
       +
-      +   .lg\\\\:prose-darkish-green a code {
-      +     color: #55a855;
-      +   }
-
-      ---
-
-      +   }
-      +
-      +   .xl\\\\:prose-darkish-green a {
-      +     color: #55a855;
-
-      ---
-
-      +
-      +   .xl\\\\:prose-darkish-green a code {
+      +   .lg\\\\:prose-darkish-green :where(a code) {
       +     color: #55a855;
       +   }
 
@@ -25854,11 +25840,25 @@ it('should be possible to add colors without 600 and still get default and custo
 
       +   }
       +
-      +   .\\\\32xl\\\\:prose-darkish-green a {
+      +   .xl\\\\:prose-darkish-green :where(a) {
+      +     color: #55a855;
+
+      ---
+
+      +
+      +   .xl\\\\:prose-darkish-green :where(a code) {
+      +     color: #55a855;
+      +   }
+
+      ---
+
+      +   }
+      +
+      +   .\\\\32xl\\\\:prose-darkish-green :where(a) {
       +     color: #55a855;
       +   }
       +
-      +   .\\\\32xl\\\\:prose-darkish-green a code {
+      +   .\\\\32xl\\\\:prose-darkish-green :where(a code) {
       +     color: #55a855;
 
     "

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -96,7 +96,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.75em;
     }
 
-    .prose :where(ol > li::before) {
+    .prose :where(ol > li)::before {
       content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
       position: absolute;
       font-weight: 400;
@@ -109,7 +109,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.75em;
     }
 
-    .prose :where(ul > li::before) {
+    .prose :where(ul > li)::before {
       content: \\"\\";
       position: absolute;
       background-color: #d1d5db;
@@ -139,11 +139,11 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1em;
     }
 
-    .prose :where(blockquote p:first-of-type::before) {
+    .prose :where(blockquote p:first-of-type)::before {
       content: open-quote;
     }
 
-    .prose :where(blockquote p:last-of-type::after) {
+    .prose :where(blockquote p:last-of-type)::after {
       content: close-quote;
     }
 
@@ -211,11 +211,11 @@ it('should generate the default classes for the typography components', async ()
       font-size: 0.875em;
     }
 
-    .prose :where(code::before) {
+    .prose :where(code)::before {
       content: \\"\`\\";
     }
 
-    .prose :where(code::after) {
+    .prose :where(code)::after {
       content: \\"\`\\";
     }
 
@@ -250,11 +250,11 @@ it('should generate the default classes for the typography components', async ()
       line-height: inherit;
     }
 
-    .prose :where(pre code::before) {
+    .prose :where(pre code)::before {
       content: none;
     }
 
-    .prose :where(pre code::after) {
+    .prose :where(pre code)::after {
       content: none;
     }
 
@@ -537,7 +537,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.5714286em;
     }
 
-    .prose-sm :where(ol > li::before) {
+    .prose-sm :where(ol > li)::before {
       left: 0;
     }
 
@@ -545,7 +545,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.5714286em;
     }
 
-    .prose-sm :where(ul > li::before) {
+    .prose-sm :where(ul > li)::before {
       height: 0.3571429em;
       width: 0.3571429em;
       top: calc(0.8571429em - 0.1785714em);
@@ -760,7 +760,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.6666667em;
     }
 
-    .prose-lg :where(ol > li::before) {
+    .prose-lg :where(ol > li)::before {
       left: 0;
     }
 
@@ -768,7 +768,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.6666667em;
     }
 
-    .prose-lg :where(ul > li::before) {
+    .prose-lg :where(ul > li)::before {
       width: 0.3333333em;
       height: 0.3333333em;
       top: calc(0.8888889em - 0.1666667em);
@@ -983,7 +983,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.8em;
     }
 
-    .prose-xl :where(ol > li::before) {
+    .prose-xl :where(ol > li)::before {
       left: 0;
     }
 
@@ -991,7 +991,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.8em;
     }
 
-    .prose-xl :where(ul > li::before) {
+    .prose-xl :where(ul > li)::before {
       width: 0.35em;
       height: 0.35em;
       top: calc(0.9em - 0.175em);
@@ -1206,7 +1206,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.6666667em;
     }
 
-    .prose-2xl :where(ol > li::before) {
+    .prose-2xl :where(ol > li)::before {
       left: 0;
     }
 
@@ -1214,7 +1214,7 @@ it('should generate the default classes for the typography components', async ()
       padding-left: 1.6666667em;
     }
 
-    .prose-2xl :where(ul > li::before) {
+    .prose-2xl :where(ul > li)::before {
       width: 0.3333333em;
       height: 0.3333333em;
       top: calc(0.8333333em - 0.1666667em);
@@ -1432,7 +1432,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .sm\\\\:prose :where(ol > li::before) {
+      .sm\\\\:prose :where(ol > li)::before {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -1445,7 +1445,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .sm\\\\:prose :where(ul > li::before) {
+      .sm\\\\:prose :where(ul > li)::before {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -1475,11 +1475,11 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .sm\\\\:prose :where(blockquote p:first-of-type::before) {
+      .sm\\\\:prose :where(blockquote p:first-of-type)::before {
         content: open-quote;
       }
 
-      .sm\\\\:prose :where(blockquote p:last-of-type::after) {
+      .sm\\\\:prose :where(blockquote p:last-of-type)::after {
         content: close-quote;
       }
 
@@ -1547,11 +1547,11 @@ it('should generate the default classes for the typography components', async ()
         font-size: 0.875em;
       }
 
-      .sm\\\\:prose :where(code::before) {
+      .sm\\\\:prose :where(code)::before {
         content: \\"\`\\";
       }
 
-      .sm\\\\:prose :where(code::after) {
+      .sm\\\\:prose :where(code)::after {
         content: \\"\`\\";
       }
 
@@ -1586,11 +1586,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .sm\\\\:prose :where(pre code::before) {
+      .sm\\\\:prose :where(pre code)::before {
         content: none;
       }
 
-      .sm\\\\:prose :where(pre code::after) {
+      .sm\\\\:prose :where(pre code)::after {
         content: none;
       }
 
@@ -1873,7 +1873,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .sm\\\\:prose-sm :where(ol > li::before) {
+      .sm\\\\:prose-sm :where(ol > li)::before {
         left: 0;
       }
 
@@ -1881,7 +1881,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .sm\\\\:prose-sm :where(ul > li::before) {
+      .sm\\\\:prose-sm :where(ul > li)::before {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
@@ -2096,7 +2096,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-lg :where(ol > li::before) {
+      .sm\\\\:prose-lg :where(ol > li)::before {
         left: 0;
       }
 
@@ -2104,7 +2104,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-lg :where(ul > li::before) {
+      .sm\\\\:prose-lg :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
@@ -2319,7 +2319,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .sm\\\\:prose-xl :where(ol > li::before) {
+      .sm\\\\:prose-xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -2327,7 +2327,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .sm\\\\:prose-xl :where(ul > li::before) {
+      .sm\\\\:prose-xl :where(ul > li)::before {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
@@ -2542,7 +2542,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-2xl :where(ol > li::before) {
+      .sm\\\\:prose-2xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -2550,7 +2550,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .sm\\\\:prose-2xl :where(ul > li::before) {
+      .sm\\\\:prose-2xl :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
@@ -2769,7 +2769,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .md\\\\:prose :where(ol > li::before) {
+      .md\\\\:prose :where(ol > li)::before {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -2782,7 +2782,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .md\\\\:prose :where(ul > li::before) {
+      .md\\\\:prose :where(ul > li)::before {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -2812,11 +2812,11 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .md\\\\:prose :where(blockquote p:first-of-type::before) {
+      .md\\\\:prose :where(blockquote p:first-of-type)::before {
         content: open-quote;
       }
 
-      .md\\\\:prose :where(blockquote p:last-of-type::after) {
+      .md\\\\:prose :where(blockquote p:last-of-type)::after {
         content: close-quote;
       }
 
@@ -2884,11 +2884,11 @@ it('should generate the default classes for the typography components', async ()
         font-size: 0.875em;
       }
 
-      .md\\\\:prose :where(code::before) {
+      .md\\\\:prose :where(code)::before {
         content: \\"\`\\";
       }
 
-      .md\\\\:prose :where(code::after) {
+      .md\\\\:prose :where(code)::after {
         content: \\"\`\\";
       }
 
@@ -2923,11 +2923,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .md\\\\:prose :where(pre code::before) {
+      .md\\\\:prose :where(pre code)::before {
         content: none;
       }
 
-      .md\\\\:prose :where(pre code::after) {
+      .md\\\\:prose :where(pre code)::after {
         content: none;
       }
 
@@ -3210,7 +3210,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .md\\\\:prose-sm :where(ol > li::before) {
+      .md\\\\:prose-sm :where(ol > li)::before {
         left: 0;
       }
 
@@ -3218,7 +3218,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .md\\\\:prose-sm :where(ul > li::before) {
+      .md\\\\:prose-sm :where(ul > li)::before {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
@@ -3433,7 +3433,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-lg :where(ol > li::before) {
+      .md\\\\:prose-lg :where(ol > li)::before {
         left: 0;
       }
 
@@ -3441,7 +3441,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-lg :where(ul > li::before) {
+      .md\\\\:prose-lg :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
@@ -3656,7 +3656,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .md\\\\:prose-xl :where(ol > li::before) {
+      .md\\\\:prose-xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -3664,7 +3664,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .md\\\\:prose-xl :where(ul > li::before) {
+      .md\\\\:prose-xl :where(ul > li)::before {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
@@ -3879,7 +3879,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-2xl :where(ol > li::before) {
+      .md\\\\:prose-2xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -3887,7 +3887,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .md\\\\:prose-2xl :where(ul > li::before) {
+      .md\\\\:prose-2xl :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
@@ -4106,7 +4106,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .lg\\\\:prose :where(ol > li::before) {
+      .lg\\\\:prose :where(ol > li)::before {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -4119,7 +4119,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .lg\\\\:prose :where(ul > li::before) {
+      .lg\\\\:prose :where(ul > li)::before {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -4149,11 +4149,11 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .lg\\\\:prose :where(blockquote p:first-of-type::before) {
+      .lg\\\\:prose :where(blockquote p:first-of-type)::before {
         content: open-quote;
       }
 
-      .lg\\\\:prose :where(blockquote p:last-of-type::after) {
+      .lg\\\\:prose :where(blockquote p:last-of-type)::after {
         content: close-quote;
       }
 
@@ -4221,11 +4221,11 @@ it('should generate the default classes for the typography components', async ()
         font-size: 0.875em;
       }
 
-      .lg\\\\:prose :where(code::before) {
+      .lg\\\\:prose :where(code)::before {
         content: \\"\`\\";
       }
 
-      .lg\\\\:prose :where(code::after) {
+      .lg\\\\:prose :where(code)::after {
         content: \\"\`\\";
       }
 
@@ -4260,11 +4260,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .lg\\\\:prose :where(pre code::before) {
+      .lg\\\\:prose :where(pre code)::before {
         content: none;
       }
 
-      .lg\\\\:prose :where(pre code::after) {
+      .lg\\\\:prose :where(pre code)::after {
         content: none;
       }
 
@@ -4547,7 +4547,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .lg\\\\:prose-sm :where(ol > li::before) {
+      .lg\\\\:prose-sm :where(ol > li)::before {
         left: 0;
       }
 
@@ -4555,7 +4555,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .lg\\\\:prose-sm :where(ul > li::before) {
+      .lg\\\\:prose-sm :where(ul > li)::before {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
@@ -4770,7 +4770,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-lg :where(ol > li::before) {
+      .lg\\\\:prose-lg :where(ol > li)::before {
         left: 0;
       }
 
@@ -4778,7 +4778,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-lg :where(ul > li::before) {
+      .lg\\\\:prose-lg :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
@@ -4993,7 +4993,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .lg\\\\:prose-xl :where(ol > li::before) {
+      .lg\\\\:prose-xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -5001,7 +5001,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .lg\\\\:prose-xl :where(ul > li::before) {
+      .lg\\\\:prose-xl :where(ul > li)::before {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
@@ -5216,7 +5216,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-2xl :where(ol > li::before) {
+      .lg\\\\:prose-2xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -5224,7 +5224,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .lg\\\\:prose-2xl :where(ul > li::before) {
+      .lg\\\\:prose-2xl :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
@@ -5443,7 +5443,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .xl\\\\:prose :where(ol > li::before) {
+      .xl\\\\:prose :where(ol > li)::before {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -5456,7 +5456,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .xl\\\\:prose :where(ul > li::before) {
+      .xl\\\\:prose :where(ul > li)::before {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -5486,11 +5486,11 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      .xl\\\\:prose :where(blockquote p:first-of-type)::before {
         content: open-quote;
       }
 
-      .xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      .xl\\\\:prose :where(blockquote p:last-of-type)::after {
         content: close-quote;
       }
 
@@ -5558,11 +5558,11 @@ it('should generate the default classes for the typography components', async ()
         font-size: 0.875em;
       }
 
-      .xl\\\\:prose :where(code::before) {
+      .xl\\\\:prose :where(code)::before {
         content: \\"\`\\";
       }
 
-      .xl\\\\:prose :where(code::after) {
+      .xl\\\\:prose :where(code)::after {
         content: \\"\`\\";
       }
 
@@ -5597,11 +5597,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .xl\\\\:prose :where(pre code::before) {
+      .xl\\\\:prose :where(pre code)::before {
         content: none;
       }
 
-      .xl\\\\:prose :where(pre code::after) {
+      .xl\\\\:prose :where(pre code)::after {
         content: none;
       }
 
@@ -5884,7 +5884,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .xl\\\\:prose-sm :where(ol > li::before) {
+      .xl\\\\:prose-sm :where(ol > li)::before {
         left: 0;
       }
 
@@ -5892,7 +5892,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .xl\\\\:prose-sm :where(ul > li::before) {
+      .xl\\\\:prose-sm :where(ul > li)::before {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
@@ -6107,7 +6107,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-lg :where(ol > li::before) {
+      .xl\\\\:prose-lg :where(ol > li)::before {
         left: 0;
       }
 
@@ -6115,7 +6115,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-lg :where(ul > li::before) {
+      .xl\\\\:prose-lg :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
@@ -6330,7 +6330,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .xl\\\\:prose-xl :where(ol > li::before) {
+      .xl\\\\:prose-xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -6338,7 +6338,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .xl\\\\:prose-xl :where(ul > li::before) {
+      .xl\\\\:prose-xl :where(ul > li)::before {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
@@ -6553,7 +6553,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-2xl :where(ol > li::before) {
+      .xl\\\\:prose-2xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -6561,7 +6561,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .xl\\\\:prose-2xl :where(ul > li::before) {
+      .xl\\\\:prose-2xl :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
@@ -6780,7 +6780,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .\\\\32xl\\\\:prose :where(ol > li::before) {
+      .\\\\32xl\\\\:prose :where(ol > li)::before {
         content: counter(list-item, var(--list-counter-style, decimal)) \\".\\";
         position: absolute;
         font-weight: 400;
@@ -6793,7 +6793,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.75em;
       }
 
-      .\\\\32xl\\\\:prose :where(ul > li::before) {
+      .\\\\32xl\\\\:prose :where(ul > li)::before {
         content: \\"\\";
         position: absolute;
         background-color: #d1d5db;
@@ -6823,11 +6823,11 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1em;
       }
 
-      .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
+      .\\\\32xl\\\\:prose :where(blockquote p:first-of-type)::before {
         content: open-quote;
       }
 
-      .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
+      .\\\\32xl\\\\:prose :where(blockquote p:last-of-type)::after {
         content: close-quote;
       }
 
@@ -6895,11 +6895,11 @@ it('should generate the default classes for the typography components', async ()
         font-size: 0.875em;
       }
 
-      .\\\\32xl\\\\:prose :where(code::before) {
+      .\\\\32xl\\\\:prose :where(code)::before {
         content: \\"\`\\";
       }
 
-      .\\\\32xl\\\\:prose :where(code::after) {
+      .\\\\32xl\\\\:prose :where(code)::after {
         content: \\"\`\\";
       }
 
@@ -6934,11 +6934,11 @@ it('should generate the default classes for the typography components', async ()
         line-height: inherit;
       }
 
-      .\\\\32xl\\\\:prose :where(pre code::before) {
+      .\\\\32xl\\\\:prose :where(pre code)::before {
         content: none;
       }
 
-      .\\\\32xl\\\\:prose :where(pre code::after) {
+      .\\\\32xl\\\\:prose :where(pre code)::after {
         content: none;
       }
 
@@ -7221,7 +7221,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
+      .\\\\32xl\\\\:prose-sm :where(ol > li)::before {
         left: 0;
       }
 
@@ -7229,7 +7229,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.5714286em;
       }
 
-      .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
+      .\\\\32xl\\\\:prose-sm :where(ul > li)::before {
         height: 0.3571429em;
         width: 0.3571429em;
         top: calc(0.8571429em - 0.1785714em);
@@ -7444,7 +7444,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
+      .\\\\32xl\\\\:prose-lg :where(ol > li)::before {
         left: 0;
       }
 
@@ -7452,7 +7452,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
+      .\\\\32xl\\\\:prose-lg :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8888889em - 0.1666667em);
@@ -7667,7 +7667,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
+      .\\\\32xl\\\\:prose-xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -7675,7 +7675,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.8em;
       }
 
-      .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
+      .\\\\32xl\\\\:prose-xl :where(ul > li)::before {
         width: 0.35em;
         height: 0.35em;
         top: calc(0.9em - 0.175em);
@@ -7890,7 +7890,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
+      .\\\\32xl\\\\:prose-2xl :where(ol > li)::before {
         left: 0;
       }
 
@@ -7898,7 +7898,7 @@ it('should generate the default classes for the typography components', async ()
         padding-left: 1.6666667em;
       }
 
-      .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
+      .\\\\32xl\\\\:prose-2xl :where(ul > li)::before {
         width: 0.3333333em;
         height: 0.3333333em;
         top: calc(0.8333333em - 0.1666667em);
@@ -8127,8 +8127,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose :where(ol > li::before) {
-      + .markdown :where(ol > li::before) {
+      - .prose :where(ol > li)::before {
+      + .markdown :where(ol > li)::before {
 
       ---
 
@@ -8137,8 +8137,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose :where(ul > li::before) {
-      + .markdown :where(ul > li::before) {
+      - .prose :where(ul > li)::before {
+      + .markdown :where(ul > li)::before {
 
       ---
 
@@ -8152,13 +8152,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose :where(blockquote p:first-of-type::before) {
-      + .markdown :where(blockquote p:first-of-type::before) {
+      - .prose :where(blockquote p:first-of-type)::before {
+      + .markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      - .prose :where(blockquote p:last-of-type::after) {
-      + .markdown :where(blockquote p:last-of-type::after) {
+      - .prose :where(blockquote p:last-of-type)::after {
+      + .markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -8212,13 +8212,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose :where(code::before) {
-      + .markdown :where(code::before) {
+      - .prose :where(code)::before {
+      + .markdown :where(code)::before {
 
       ---
 
-      - .prose :where(code::after) {
-      + .markdown :where(code::after) {
+      - .prose :where(code)::after {
+      + .markdown :where(code)::after {
 
       ---
 
@@ -8237,13 +8237,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose :where(pre code::before) {
-      + .markdown :where(pre code::before) {
+      - .prose :where(pre code)::before {
+      + .markdown :where(pre code)::before {
 
       ---
 
-      - .prose :where(pre code::after) {
-      + .markdown :where(pre code::after) {
+      - .prose :where(pre code)::after {
+      + .markdown :where(pre code)::after {
 
       ---
 
@@ -8517,8 +8517,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-sm :where(ol > li::before) {
-      + .markdown-sm :where(ol > li::before) {
+      - .prose-sm :where(ol > li)::before {
+      + .markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -8527,8 +8527,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-sm :where(ul > li::before) {
-      + .markdown-sm :where(ul > li::before) {
+      - .prose-sm :where(ul > li)::before {
+      + .markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -8737,8 +8737,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-lg :where(ol > li::before) {
-      + .markdown-lg :where(ol > li::before) {
+      - .prose-lg :where(ol > li)::before {
+      + .markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -8747,8 +8747,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-lg :where(ul > li::before) {
-      + .markdown-lg :where(ul > li::before) {
+      - .prose-lg :where(ul > li)::before {
+      + .markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -8957,8 +8957,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-xl :where(ol > li::before) {
-      + .markdown-xl :where(ol > li::before) {
+      - .prose-xl :where(ol > li)::before {
+      + .markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -8967,8 +8967,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-xl :where(ul > li::before) {
-      + .markdown-xl :where(ul > li::before) {
+      - .prose-xl :where(ul > li)::before {
+      + .markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -9177,8 +9177,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-2xl :where(ol > li::before) {
-      + .markdown-2xl :where(ol > li::before) {
+      - .prose-2xl :where(ol > li)::before {
+      + .markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -9187,8 +9187,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      - .prose-2xl :where(ul > li::before) {
-      + .markdown-2xl :where(ul > li::before) {
+      - .prose-2xl :where(ul > li)::before {
+      + .markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -9432,8 +9432,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose :where(ol > li::before) {
-      +   .sm\\\\:markdown :where(ol > li::before) {
+      -   .sm\\\\:prose :where(ol > li)::before {
+      +   .sm\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -9442,8 +9442,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose :where(ul > li::before) {
-      +   .sm\\\\:markdown :where(ul > li::before) {
+      -   .sm\\\\:prose :where(ul > li)::before {
+      +   .sm\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -9457,13 +9457,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .sm\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .sm\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .sm\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .sm\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .sm\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .sm\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -9517,13 +9517,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose :where(code::before) {
-      +   .sm\\\\:markdown :where(code::before) {
+      -   .sm\\\\:prose :where(code)::before {
+      +   .sm\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(code::after) {
-      +   .sm\\\\:markdown :where(code::after) {
+      -   .sm\\\\:prose :where(code)::after {
+      +   .sm\\\\:markdown :where(code)::after {
 
       ---
 
@@ -9542,13 +9542,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose :where(pre code::before) {
-      +   .sm\\\\:markdown :where(pre code::before) {
+      -   .sm\\\\:prose :where(pre code)::before {
+      +   .sm\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(pre code::after) {
-      +   .sm\\\\:markdown :where(pre code::after) {
+      -   .sm\\\\:prose :where(pre code)::after {
+      +   .sm\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -9822,8 +9822,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-sm :where(ol > li::before) {
-      +   .sm\\\\:markdown-sm :where(ol > li::before) {
+      -   .sm\\\\:prose-sm :where(ol > li)::before {
+      +   .sm\\\\:markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -9832,8 +9832,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-sm :where(ul > li::before) {
-      +   .sm\\\\:markdown-sm :where(ul > li::before) {
+      -   .sm\\\\:prose-sm :where(ul > li)::before {
+      +   .sm\\\\:markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -10042,8 +10042,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-lg :where(ol > li::before) {
-      +   .sm\\\\:markdown-lg :where(ol > li::before) {
+      -   .sm\\\\:prose-lg :where(ol > li)::before {
+      +   .sm\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -10052,8 +10052,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-lg :where(ul > li::before) {
-      +   .sm\\\\:markdown-lg :where(ul > li::before) {
+      -   .sm\\\\:prose-lg :where(ul > li)::before {
+      +   .sm\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -10262,8 +10262,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-xl :where(ol > li::before) {
-      +   .sm\\\\:markdown-xl :where(ol > li::before) {
+      -   .sm\\\\:prose-xl :where(ol > li)::before {
+      +   .sm\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -10272,8 +10272,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-xl :where(ul > li::before) {
-      +   .sm\\\\:markdown-xl :where(ul > li::before) {
+      -   .sm\\\\:prose-xl :where(ul > li)::before {
+      +   .sm\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -10482,8 +10482,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-2xl :where(ol > li::before) {
-      +   .sm\\\\:markdown-2xl :where(ol > li::before) {
+      -   .sm\\\\:prose-2xl :where(ol > li)::before {
+      +   .sm\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -10492,8 +10492,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .sm\\\\:prose-2xl :where(ul > li::before) {
-      +   .sm\\\\:markdown-2xl :where(ul > li::before) {
+      -   .sm\\\\:prose-2xl :where(ul > li)::before {
+      +   .sm\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -10737,8 +10737,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose :where(ol > li::before) {
-      +   .md\\\\:markdown :where(ol > li::before) {
+      -   .md\\\\:prose :where(ol > li)::before {
+      +   .md\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -10747,8 +10747,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose :where(ul > li::before) {
-      +   .md\\\\:markdown :where(ul > li::before) {
+      -   .md\\\\:prose :where(ul > li)::before {
+      +   .md\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -10762,13 +10762,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .md\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .md\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .md\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .md\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .md\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .md\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .md\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -10822,13 +10822,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose :where(code::before) {
-      +   .md\\\\:markdown :where(code::before) {
+      -   .md\\\\:prose :where(code)::before {
+      +   .md\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .md\\\\:prose :where(code::after) {
-      +   .md\\\\:markdown :where(code::after) {
+      -   .md\\\\:prose :where(code)::after {
+      +   .md\\\\:markdown :where(code)::after {
 
       ---
 
@@ -10847,13 +10847,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose :where(pre code::before) {
-      +   .md\\\\:markdown :where(pre code::before) {
+      -   .md\\\\:prose :where(pre code)::before {
+      +   .md\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .md\\\\:prose :where(pre code::after) {
-      +   .md\\\\:markdown :where(pre code::after) {
+      -   .md\\\\:prose :where(pre code)::after {
+      +   .md\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -11127,8 +11127,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-sm :where(ol > li::before) {
-      +   .md\\\\:markdown-sm :where(ol > li::before) {
+      -   .md\\\\:prose-sm :where(ol > li)::before {
+      +   .md\\\\:markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -11137,8 +11137,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-sm :where(ul > li::before) {
-      +   .md\\\\:markdown-sm :where(ul > li::before) {
+      -   .md\\\\:prose-sm :where(ul > li)::before {
+      +   .md\\\\:markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -11347,8 +11347,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-lg :where(ol > li::before) {
-      +   .md\\\\:markdown-lg :where(ol > li::before) {
+      -   .md\\\\:prose-lg :where(ol > li)::before {
+      +   .md\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -11357,8 +11357,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-lg :where(ul > li::before) {
-      +   .md\\\\:markdown-lg :where(ul > li::before) {
+      -   .md\\\\:prose-lg :where(ul > li)::before {
+      +   .md\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -11567,8 +11567,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-xl :where(ol > li::before) {
-      +   .md\\\\:markdown-xl :where(ol > li::before) {
+      -   .md\\\\:prose-xl :where(ol > li)::before {
+      +   .md\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -11577,8 +11577,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-xl :where(ul > li::before) {
-      +   .md\\\\:markdown-xl :where(ul > li::before) {
+      -   .md\\\\:prose-xl :where(ul > li)::before {
+      +   .md\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -11787,8 +11787,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-2xl :where(ol > li::before) {
-      +   .md\\\\:markdown-2xl :where(ol > li::before) {
+      -   .md\\\\:prose-2xl :where(ol > li)::before {
+      +   .md\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -11797,8 +11797,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .md\\\\:prose-2xl :where(ul > li::before) {
-      +   .md\\\\:markdown-2xl :where(ul > li::before) {
+      -   .md\\\\:prose-2xl :where(ul > li)::before {
+      +   .md\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -12042,8 +12042,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose :where(ol > li::before) {
-      +   .lg\\\\:markdown :where(ol > li::before) {
+      -   .lg\\\\:prose :where(ol > li)::before {
+      +   .lg\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -12052,8 +12052,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose :where(ul > li::before) {
-      +   .lg\\\\:markdown :where(ul > li::before) {
+      -   .lg\\\\:prose :where(ul > li)::before {
+      +   .lg\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -12067,13 +12067,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .lg\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .lg\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .lg\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .lg\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .lg\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .lg\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -12127,13 +12127,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose :where(code::before) {
-      +   .lg\\\\:markdown :where(code::before) {
+      -   .lg\\\\:prose :where(code)::before {
+      +   .lg\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(code::after) {
-      +   .lg\\\\:markdown :where(code::after) {
+      -   .lg\\\\:prose :where(code)::after {
+      +   .lg\\\\:markdown :where(code)::after {
 
       ---
 
@@ -12152,13 +12152,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose :where(pre code::before) {
-      +   .lg\\\\:markdown :where(pre code::before) {
+      -   .lg\\\\:prose :where(pre code)::before {
+      +   .lg\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(pre code::after) {
-      +   .lg\\\\:markdown :where(pre code::after) {
+      -   .lg\\\\:prose :where(pre code)::after {
+      +   .lg\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -12432,8 +12432,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-sm :where(ol > li::before) {
-      +   .lg\\\\:markdown-sm :where(ol > li::before) {
+      -   .lg\\\\:prose-sm :where(ol > li)::before {
+      +   .lg\\\\:markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -12442,8 +12442,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-sm :where(ul > li::before) {
-      +   .lg\\\\:markdown-sm :where(ul > li::before) {
+      -   .lg\\\\:prose-sm :where(ul > li)::before {
+      +   .lg\\\\:markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -12652,8 +12652,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-lg :where(ol > li::before) {
-      +   .lg\\\\:markdown-lg :where(ol > li::before) {
+      -   .lg\\\\:prose-lg :where(ol > li)::before {
+      +   .lg\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -12662,8 +12662,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-lg :where(ul > li::before) {
-      +   .lg\\\\:markdown-lg :where(ul > li::before) {
+      -   .lg\\\\:prose-lg :where(ul > li)::before {
+      +   .lg\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -12872,8 +12872,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-xl :where(ol > li::before) {
-      +   .lg\\\\:markdown-xl :where(ol > li::before) {
+      -   .lg\\\\:prose-xl :where(ol > li)::before {
+      +   .lg\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -12882,8 +12882,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-xl :where(ul > li::before) {
-      +   .lg\\\\:markdown-xl :where(ul > li::before) {
+      -   .lg\\\\:prose-xl :where(ul > li)::before {
+      +   .lg\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -13092,8 +13092,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-2xl :where(ol > li::before) {
-      +   .lg\\\\:markdown-2xl :where(ol > li::before) {
+      -   .lg\\\\:prose-2xl :where(ol > li)::before {
+      +   .lg\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -13102,8 +13102,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .lg\\\\:prose-2xl :where(ul > li::before) {
-      +   .lg\\\\:markdown-2xl :where(ul > li::before) {
+      -   .lg\\\\:prose-2xl :where(ul > li)::before {
+      +   .lg\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -13347,8 +13347,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose :where(ol > li::before) {
-      +   .xl\\\\:markdown :where(ol > li::before) {
+      -   .xl\\\\:prose :where(ol > li)::before {
+      +   .xl\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -13357,8 +13357,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose :where(ul > li::before) {
-      +   .xl\\\\:markdown :where(ul > li::before) {
+      -   .xl\\\\:prose :where(ul > li)::before {
+      +   .xl\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -13372,13 +13372,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .xl\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .xl\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .xl\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .xl\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -13432,13 +13432,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose :where(code::before) {
-      +   .xl\\\\:markdown :where(code::before) {
+      -   .xl\\\\:prose :where(code)::before {
+      +   .xl\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(code::after) {
-      +   .xl\\\\:markdown :where(code::after) {
+      -   .xl\\\\:prose :where(code)::after {
+      +   .xl\\\\:markdown :where(code)::after {
 
       ---
 
@@ -13457,13 +13457,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose :where(pre code::before) {
-      +   .xl\\\\:markdown :where(pre code::before) {
+      -   .xl\\\\:prose :where(pre code)::before {
+      +   .xl\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(pre code::after) {
-      +   .xl\\\\:markdown :where(pre code::after) {
+      -   .xl\\\\:prose :where(pre code)::after {
+      +   .xl\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -13737,8 +13737,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-sm :where(ol > li::before) {
-      +   .xl\\\\:markdown-sm :where(ol > li::before) {
+      -   .xl\\\\:prose-sm :where(ol > li)::before {
+      +   .xl\\\\:markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -13747,8 +13747,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-sm :where(ul > li::before) {
-      +   .xl\\\\:markdown-sm :where(ul > li::before) {
+      -   .xl\\\\:prose-sm :where(ul > li)::before {
+      +   .xl\\\\:markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -13957,8 +13957,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-lg :where(ol > li::before) {
-      +   .xl\\\\:markdown-lg :where(ol > li::before) {
+      -   .xl\\\\:prose-lg :where(ol > li)::before {
+      +   .xl\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -13967,8 +13967,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-lg :where(ul > li::before) {
-      +   .xl\\\\:markdown-lg :where(ul > li::before) {
+      -   .xl\\\\:prose-lg :where(ul > li)::before {
+      +   .xl\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -14177,8 +14177,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-xl :where(ol > li::before) {
-      +   .xl\\\\:markdown-xl :where(ol > li::before) {
+      -   .xl\\\\:prose-xl :where(ol > li)::before {
+      +   .xl\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -14187,8 +14187,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-xl :where(ul > li::before) {
-      +   .xl\\\\:markdown-xl :where(ul > li::before) {
+      -   .xl\\\\:prose-xl :where(ul > li)::before {
+      +   .xl\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -14397,8 +14397,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-2xl :where(ol > li::before) {
-      +   .xl\\\\:markdown-2xl :where(ol > li::before) {
+      -   .xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .xl\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -14407,8 +14407,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .xl\\\\:prose-2xl :where(ul > li::before) {
-      +   .xl\\\\:markdown-2xl :where(ul > li::before) {
+      -   .xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .xl\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -14652,8 +14652,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -14662,8 +14662,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -14677,13 +14677,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -14737,13 +14737,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(code::before) {
-      +   .\\\\32xl\\\\:markdown :where(code::before) {
+      -   .\\\\32xl\\\\:prose :where(code)::before {
+      +   .\\\\32xl\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(code::after) {
-      +   .\\\\32xl\\\\:markdown :where(code::after) {
+      -   .\\\\32xl\\\\:prose :where(code)::after {
+      +   .\\\\32xl\\\\:markdown :where(code)::after {
 
       ---
 
@@ -14762,13 +14762,13 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(pre code::before) {
-      +   .\\\\32xl\\\\:markdown :where(pre code::before) {
+      -   .\\\\32xl\\\\:prose :where(pre code)::before {
+      +   .\\\\32xl\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(pre code::after) {
-      +   .\\\\32xl\\\\:markdown :where(pre code::after) {
+      -   .\\\\32xl\\\\:prose :where(pre code)::after {
+      +   .\\\\32xl\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -15042,8 +15042,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-sm :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-sm :where(ol > li)::before {
 
       ---
 
@@ -15052,8 +15052,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-sm :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-sm :where(ul > li)::before {
 
       ---
 
@@ -15262,8 +15262,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-lg :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -15272,8 +15272,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-lg :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -15482,8 +15482,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-xl :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -15492,8 +15492,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-xl :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -15702,8 +15702,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -15712,8 +15712,8 @@ it('should be possible to change the default className from `prose` to `markdown
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -16012,7 +16012,7 @@ it('should be possible to change the default modifiers', async () => {
       -   padding-left: 1.6666667em;
       - }
       -
-      - .prose-2xl :where(ol > li::before) {
+      - .prose-2xl :where(ol > li)::before {
       -   left: 0;
       - }
       -
@@ -16020,7 +16020,7 @@ it('should be possible to change the default modifiers', async () => {
       -   padding-left: 1.6666667em;
       - }
       -
-      - .prose-2xl :where(ul > li::before) {
+      - .prose-2xl :where(ul > li)::before {
       -   width: 0.3333333em;
       -   height: 0.3333333em;
       -   top: calc(0.8333333em - 0.1666667em);
@@ -16299,7 +16299,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl :where(ol > li::before) {
+      -   .sm\\\\:prose-2xl :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -16307,7 +16307,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .sm\\\\:prose-2xl :where(ul > li::before) {
+      -   .sm\\\\:prose-2xl :where(ul > li)::before {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
@@ -16585,7 +16585,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl :where(ol > li::before) {
+      -   .md\\\\:prose-2xl :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -16593,7 +16593,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .md\\\\:prose-2xl :where(ul > li::before) {
+      -   .md\\\\:prose-2xl :where(ul > li)::before {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
@@ -16870,7 +16870,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl :where(ol > li::before) {
+      -   .lg\\\\:prose-2xl :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -16878,7 +16878,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .lg\\\\:prose-2xl :where(ul > li::before) {
+      -   .lg\\\\:prose-2xl :where(ul > li)::before {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
@@ -17158,7 +17158,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl :where(ol > li::before) {
+      -   .xl\\\\:prose-2xl :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -17166,7 +17166,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .xl\\\\:prose-2xl :where(ul > li::before) {
+      -   .xl\\\\:prose-2xl :where(ul > li)::before {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
@@ -17448,7 +17448,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -17456,7 +17456,7 @@ it('should be possible to change the default modifiers', async () => {
       -     padding-left: 1.6666667em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li)::before {
       -     width: 0.3333333em;
       -     height: 0.3333333em;
       -     top: calc(0.8333333em - 0.1666667em);
@@ -17686,8 +17686,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose :where(ol > li::before) {
-      + .markdown :where(ol > li::before) {
+      - .prose :where(ol > li)::before {
+      + .markdown :where(ol > li)::before {
 
       ---
 
@@ -17696,8 +17696,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose :where(ul > li::before) {
-      + .markdown :where(ul > li::before) {
+      - .prose :where(ul > li)::before {
+      + .markdown :where(ul > li)::before {
 
       ---
 
@@ -17711,13 +17711,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose :where(blockquote p:first-of-type::before) {
-      + .markdown :where(blockquote p:first-of-type::before) {
+      - .prose :where(blockquote p:first-of-type)::before {
+      + .markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      - .prose :where(blockquote p:last-of-type::after) {
-      + .markdown :where(blockquote p:last-of-type::after) {
+      - .prose :where(blockquote p:last-of-type)::after {
+      + .markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -17771,13 +17771,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose :where(code::before) {
-      + .markdown :where(code::before) {
+      - .prose :where(code)::before {
+      + .markdown :where(code)::before {
 
       ---
 
-      - .prose :where(code::after) {
-      + .markdown :where(code::after) {
+      - .prose :where(code)::after {
+      + .markdown :where(code)::after {
 
       ---
 
@@ -17796,13 +17796,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose :where(pre code::before) {
-      + .markdown :where(pre code::before) {
+      - .prose :where(pre code)::before {
+      + .markdown :where(pre code)::before {
 
       ---
 
-      - .prose :where(pre code::after) {
-      + .markdown :where(pre code::after) {
+      - .prose :where(pre code)::after {
+      + .markdown :where(pre code)::after {
 
       ---
 
@@ -18083,7 +18083,7 @@ it('should be possible to change the default modifiers and change the className'
       -   padding-left: 1.5714286em;
       - }
       -
-      - .prose-sm :where(ol > li::before) {
+      - .prose-sm :where(ol > li)::before {
       -   left: 0;
       - }
       -
@@ -18091,7 +18091,7 @@ it('should be possible to change the default modifiers and change the className'
       -   padding-left: 1.5714286em;
       - }
       -
-      - .prose-sm :where(ul > li::before) {
+      - .prose-sm :where(ul > li)::before {
       -   height: 0.3571429em;
       -   width: 0.3571429em;
       -   top: calc(0.8571429em - 0.1785714em);
@@ -18302,8 +18302,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-lg :where(ol > li::before) {
-      + .markdown-lg :where(ol > li::before) {
+      - .prose-lg :where(ol > li)::before {
+      + .markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -18312,8 +18312,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-lg :where(ul > li::before) {
-      + .markdown-lg :where(ul > li::before) {
+      - .prose-lg :where(ul > li)::before {
+      + .markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -18522,8 +18522,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-xl :where(ol > li::before) {
-      + .markdown-xl :where(ol > li::before) {
+      - .prose-xl :where(ol > li)::before {
+      + .markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -18532,8 +18532,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-xl :where(ul > li::before) {
-      + .markdown-xl :where(ul > li::before) {
+      - .prose-xl :where(ul > li)::before {
+      + .markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -18742,8 +18742,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-2xl :where(ol > li::before) {
-      + .markdown-2xl :where(ol > li::before) {
+      - .prose-2xl :where(ol > li)::before {
+      + .markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -18752,8 +18752,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      - .prose-2xl :where(ul > li::before) {
-      + .markdown-2xl :where(ul > li::before) {
+      - .prose-2xl :where(ul > li)::before {
+      + .markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -18989,8 +18989,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose :where(ol > li::before) {
-      +   .sm\\\\:markdown :where(ol > li::before) {
+      -   .sm\\\\:prose :where(ol > li)::before {
+      +   .sm\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -18999,8 +18999,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose :where(ul > li::before) {
-      +   .sm\\\\:markdown :where(ul > li::before) {
+      -   .sm\\\\:prose :where(ul > li)::before {
+      +   .sm\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -19014,13 +19014,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .sm\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .sm\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .sm\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .sm\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .sm\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .sm\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -19074,13 +19074,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose :where(code::before) {
-      +   .sm\\\\:markdown :where(code::before) {
+      -   .sm\\\\:prose :where(code)::before {
+      +   .sm\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(code::after) {
-      +   .sm\\\\:markdown :where(code::after) {
+      -   .sm\\\\:prose :where(code)::after {
+      +   .sm\\\\:markdown :where(code)::after {
 
       ---
 
@@ -19099,13 +19099,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose :where(pre code::before) {
-      +   .sm\\\\:markdown :where(pre code::before) {
+      -   .sm\\\\:prose :where(pre code)::before {
+      +   .sm\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .sm\\\\:prose :where(pre code::after) {
-      +   .sm\\\\:markdown :where(pre code::after) {
+      -   .sm\\\\:prose :where(pre code)::after {
+      +   .sm\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -19393,7 +19393,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm :where(ol > li::before) {
+      -   .sm\\\\:prose-sm :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -19401,7 +19401,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .sm\\\\:prose-sm :where(ul > li::before) {
+      -   .sm\\\\:prose-sm :where(ul > li)::before {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
@@ -19608,8 +19608,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-lg :where(ol > li::before) {
-      +   .sm\\\\:markdown-lg :where(ol > li::before) {
+      -   .sm\\\\:prose-lg :where(ol > li)::before {
+      +   .sm\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -19618,8 +19618,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-lg :where(ul > li::before) {
-      +   .sm\\\\:markdown-lg :where(ul > li::before) {
+      -   .sm\\\\:prose-lg :where(ul > li)::before {
+      +   .sm\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -19828,8 +19828,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-xl :where(ol > li::before) {
-      +   .sm\\\\:markdown-xl :where(ol > li::before) {
+      -   .sm\\\\:prose-xl :where(ol > li)::before {
+      +   .sm\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -19838,8 +19838,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-xl :where(ul > li::before) {
-      +   .sm\\\\:markdown-xl :where(ul > li::before) {
+      -   .sm\\\\:prose-xl :where(ul > li)::before {
+      +   .sm\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -20048,8 +20048,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-2xl :where(ol > li::before) {
-      +   .sm\\\\:markdown-2xl :where(ol > li::before) {
+      -   .sm\\\\:prose-2xl :where(ol > li)::before {
+      +   .sm\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -20058,8 +20058,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .sm\\\\:prose-2xl :where(ul > li::before) {
-      +   .sm\\\\:markdown-2xl :where(ul > li::before) {
+      -   .sm\\\\:prose-2xl :where(ul > li)::before {
+      +   .sm\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -20295,8 +20295,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose :where(ol > li::before) {
-      +   .md\\\\:markdown :where(ol > li::before) {
+      -   .md\\\\:prose :where(ol > li)::before {
+      +   .md\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -20305,8 +20305,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose :where(ul > li::before) {
-      +   .md\\\\:markdown :where(ul > li::before) {
+      -   .md\\\\:prose :where(ul > li)::before {
+      +   .md\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -20320,13 +20320,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .md\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .md\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .md\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .md\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .md\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .md\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .md\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -20380,13 +20380,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose :where(code::before) {
-      +   .md\\\\:markdown :where(code::before) {
+      -   .md\\\\:prose :where(code)::before {
+      +   .md\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .md\\\\:prose :where(code::after) {
-      +   .md\\\\:markdown :where(code::after) {
+      -   .md\\\\:prose :where(code)::after {
+      +   .md\\\\:markdown :where(code)::after {
 
       ---
 
@@ -20405,13 +20405,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose :where(pre code::before) {
-      +   .md\\\\:markdown :where(pre code::before) {
+      -   .md\\\\:prose :where(pre code)::before {
+      +   .md\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .md\\\\:prose :where(pre code::after) {
-      +   .md\\\\:markdown :where(pre code::after) {
+      -   .md\\\\:prose :where(pre code)::after {
+      +   .md\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -20697,7 +20697,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm :where(ol > li::before) {
+      -   .md\\\\:prose-sm :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -20705,7 +20705,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .md\\\\:prose-sm :where(ul > li::before) {
+      -   .md\\\\:prose-sm :where(ul > li)::before {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
@@ -20917,8 +20917,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-lg :where(ol > li::before) {
-      +   .md\\\\:markdown-lg :where(ol > li::before) {
+      -   .md\\\\:prose-lg :where(ol > li)::before {
+      +   .md\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -20927,8 +20927,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-lg :where(ul > li::before) {
-      +   .md\\\\:markdown-lg :where(ul > li::before) {
+      -   .md\\\\:prose-lg :where(ul > li)::before {
+      +   .md\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -21137,8 +21137,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-xl :where(ol > li::before) {
-      +   .md\\\\:markdown-xl :where(ol > li::before) {
+      -   .md\\\\:prose-xl :where(ol > li)::before {
+      +   .md\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -21147,8 +21147,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-xl :where(ul > li::before) {
-      +   .md\\\\:markdown-xl :where(ul > li::before) {
+      -   .md\\\\:prose-xl :where(ul > li)::before {
+      +   .md\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -21357,8 +21357,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-2xl :where(ol > li::before) {
-      +   .md\\\\:markdown-2xl :where(ol > li::before) {
+      -   .md\\\\:prose-2xl :where(ol > li)::before {
+      +   .md\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -21367,8 +21367,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .md\\\\:prose-2xl :where(ul > li::before) {
-      +   .md\\\\:markdown-2xl :where(ul > li::before) {
+      -   .md\\\\:prose-2xl :where(ul > li)::before {
+      +   .md\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -21601,8 +21601,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose :where(ol > li::before) {
-      +   .lg\\\\:markdown :where(ol > li::before) {
+      -   .lg\\\\:prose :where(ol > li)::before {
+      +   .lg\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -21611,8 +21611,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose :where(ul > li::before) {
-      +   .lg\\\\:markdown :where(ul > li::before) {
+      -   .lg\\\\:prose :where(ul > li)::before {
+      +   .lg\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -21626,13 +21626,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .lg\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .lg\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .lg\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .lg\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .lg\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .lg\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -21686,13 +21686,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose :where(code::before) {
-      +   .lg\\\\:markdown :where(code::before) {
+      -   .lg\\\\:prose :where(code)::before {
+      +   .lg\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(code::after) {
-      +   .lg\\\\:markdown :where(code::after) {
+      -   .lg\\\\:prose :where(code)::after {
+      +   .lg\\\\:markdown :where(code)::after {
 
       ---
 
@@ -21711,13 +21711,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose :where(pre code::before) {
-      +   .lg\\\\:markdown :where(pre code::before) {
+      -   .lg\\\\:prose :where(pre code)::before {
+      +   .lg\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .lg\\\\:prose :where(pre code::after) {
-      +   .lg\\\\:markdown :where(pre code::after) {
+      -   .lg\\\\:prose :where(pre code)::after {
+      +   .lg\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -21998,7 +21998,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm :where(ol > li::before) {
+      -   .lg\\\\:prose-sm :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -22006,7 +22006,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .lg\\\\:prose-sm :where(ul > li::before) {
+      -   .lg\\\\:prose-sm :where(ul > li)::before {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
@@ -22217,8 +22217,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-lg :where(ol > li::before) {
-      +   .lg\\\\:markdown-lg :where(ol > li::before) {
+      -   .lg\\\\:prose-lg :where(ol > li)::before {
+      +   .lg\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -22227,8 +22227,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-lg :where(ul > li::before) {
-      +   .lg\\\\:markdown-lg :where(ul > li::before) {
+      -   .lg\\\\:prose-lg :where(ul > li)::before {
+      +   .lg\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -22437,8 +22437,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-xl :where(ol > li::before) {
-      +   .lg\\\\:markdown-xl :where(ol > li::before) {
+      -   .lg\\\\:prose-xl :where(ol > li)::before {
+      +   .lg\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -22447,8 +22447,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-xl :where(ul > li::before) {
-      +   .lg\\\\:markdown-xl :where(ul > li::before) {
+      -   .lg\\\\:prose-xl :where(ul > li)::before {
+      +   .lg\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -22657,8 +22657,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-2xl :where(ol > li::before) {
-      +   .lg\\\\:markdown-2xl :where(ol > li::before) {
+      -   .lg\\\\:prose-2xl :where(ol > li)::before {
+      +   .lg\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -22667,8 +22667,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .lg\\\\:prose-2xl :where(ul > li::before) {
-      +   .lg\\\\:markdown-2xl :where(ul > li::before) {
+      -   .lg\\\\:prose-2xl :where(ul > li)::before {
+      +   .lg\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -22904,8 +22904,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose :where(ol > li::before) {
-      +   .xl\\\\:markdown :where(ol > li::before) {
+      -   .xl\\\\:prose :where(ol > li)::before {
+      +   .xl\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -22914,8 +22914,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose :where(ul > li::before) {
-      +   .xl\\\\:markdown :where(ul > li::before) {
+      -   .xl\\\\:prose :where(ul > li)::before {
+      +   .xl\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -22929,13 +22929,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .xl\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .xl\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .xl\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .xl\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -22989,13 +22989,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose :where(code::before) {
-      +   .xl\\\\:markdown :where(code::before) {
+      -   .xl\\\\:prose :where(code)::before {
+      +   .xl\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(code::after) {
-      +   .xl\\\\:markdown :where(code::after) {
+      -   .xl\\\\:prose :where(code)::after {
+      +   .xl\\\\:markdown :where(code)::after {
 
       ---
 
@@ -23014,13 +23014,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose :where(pre code::before) {
-      +   .xl\\\\:markdown :where(pre code::before) {
+      -   .xl\\\\:prose :where(pre code)::before {
+      +   .xl\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .xl\\\\:prose :where(pre code::after) {
-      +   .xl\\\\:markdown :where(pre code::after) {
+      -   .xl\\\\:prose :where(pre code)::after {
+      +   .xl\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -23308,7 +23308,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm :where(ol > li::before) {
+      -   .xl\\\\:prose-sm :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -23316,7 +23316,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .xl\\\\:prose-sm :where(ul > li::before) {
+      -   .xl\\\\:prose-sm :where(ul > li)::before {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
@@ -23517,8 +23517,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-lg :where(ol > li::before) {
-      +   .xl\\\\:markdown-lg :where(ol > li::before) {
+      -   .xl\\\\:prose-lg :where(ol > li)::before {
+      +   .xl\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -23527,8 +23527,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-lg :where(ul > li::before) {
-      +   .xl\\\\:markdown-lg :where(ul > li::before) {
+      -   .xl\\\\:prose-lg :where(ul > li)::before {
+      +   .xl\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -23737,8 +23737,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-xl :where(ol > li::before) {
-      +   .xl\\\\:markdown-xl :where(ol > li::before) {
+      -   .xl\\\\:prose-xl :where(ol > li)::before {
+      +   .xl\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -23747,8 +23747,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-xl :where(ul > li::before) {
-      +   .xl\\\\:markdown-xl :where(ul > li::before) {
+      -   .xl\\\\:prose-xl :where(ul > li)::before {
+      +   .xl\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -23957,8 +23957,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-2xl :where(ol > li::before) {
-      +   .xl\\\\:markdown-2xl :where(ol > li::before) {
+      -   .xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .xl\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -23967,8 +23967,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .xl\\\\:prose-2xl :where(ul > li::before) {
-      +   .xl\\\\:markdown-2xl :where(ul > li::before) {
+      -   .xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .xl\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 
@@ -24204,8 +24204,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown :where(ol > li)::before {
 
       ---
 
@@ -24214,8 +24214,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown :where(ul > li)::before {
 
       ---
 
@@ -24229,13 +24229,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type::before) {
-      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type::before) {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:first-of-type)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type::after) {
-      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type::after) {
+      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .\\\\32xl\\\\:markdown :where(blockquote p:last-of-type)::after {
 
       ---
 
@@ -24289,13 +24289,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(code::before) {
-      +   .\\\\32xl\\\\:markdown :where(code::before) {
+      -   .\\\\32xl\\\\:prose :where(code)::before {
+      +   .\\\\32xl\\\\:markdown :where(code)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(code::after) {
-      +   .\\\\32xl\\\\:markdown :where(code::after) {
+      -   .\\\\32xl\\\\:prose :where(code)::after {
+      +   .\\\\32xl\\\\:markdown :where(code)::after {
 
       ---
 
@@ -24314,13 +24314,13 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(pre code::before) {
-      +   .\\\\32xl\\\\:markdown :where(pre code::before) {
+      -   .\\\\32xl\\\\:prose :where(pre code)::before {
+      +   .\\\\32xl\\\\:markdown :where(pre code)::before {
 
       ---
 
-      -   .\\\\32xl\\\\:prose :where(pre code::after) {
-      +   .\\\\32xl\\\\:markdown :where(pre code::after) {
+      -   .\\\\32xl\\\\:prose :where(pre code)::after {
+      +   .\\\\32xl\\\\:markdown :where(pre code)::after {
 
       ---
 
@@ -24608,7 +24608,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li)::before {
       -     left: 0;
       -   }
       -
@@ -24616,7 +24616,7 @@ it('should be possible to change the default modifiers and change the className'
       -     padding-left: 1.5714286em;
       -   }
       -
-      -   .\\\\32xl\\\\:prose-sm :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li)::before {
       -     height: 0.3571429em;
       -     width: 0.3571429em;
       -     top: calc(0.8571429em - 0.1785714em);
@@ -24817,8 +24817,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-lg :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-lg :where(ol > li)::before {
 
       ---
 
@@ -24827,8 +24827,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-lg :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-lg :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-lg :where(ul > li)::before {
 
       ---
 
@@ -25037,8 +25037,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-xl :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-xl :where(ol > li)::before {
 
       ---
 
@@ -25047,8 +25047,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-xl :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-xl :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-xl :where(ul > li)::before {
 
       ---
 
@@ -25257,8 +25257,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl :where(ol > li::before) {
-      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ol > li)::before {
 
       ---
 
@@ -25267,8 +25267,8 @@ it('should be possible to change the default modifiers and change the className'
 
       ---
 
-      -   .\\\\32xl\\\\:prose-2xl :where(ul > li::before) {
-      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li::before) {
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:markdown-2xl :where(ul > li)::before {
 
       ---
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -32,8 +32,8 @@ async function diffOnly(options = {}, config = {}) {
 it('should generate the default classes for the typography components', async () => {
   expect(await run()).toMatchInlineSnapshot(`
     ".prose {
-      :where(color): #374151;
-      :where(max-width): 65ch;
+      color: #374151;
+      max-width: 65ch;
     }
 
     .prose :where([class~=\\"lead\\"]) {
@@ -300,8 +300,8 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose {
-      :where(font-size): 1rem;
-      :where(line-height): 1.75;
+      font-size: 1rem;
+      line-height: 1.75;
     }
 
     .prose :where(p) {
@@ -419,8 +419,8 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose-sm {
-      :where(font-size): 0.875rem;
-      :where(line-height): 1.7142857;
+      font-size: 0.875rem;
+      line-height: 1.7142857;
     }
 
     .prose-sm :where(p) {
@@ -642,8 +642,8 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose-lg {
-      :where(font-size): 1.125rem;
-      :where(line-height): 1.7777778;
+      font-size: 1.125rem;
+      line-height: 1.7777778;
     }
 
     .prose-lg :where(p) {
@@ -865,8 +865,8 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose-xl {
-      :where(font-size): 1.25rem;
-      :where(line-height): 1.8;
+      font-size: 1.25rem;
+      line-height: 1.8;
     }
 
     .prose-xl :where(p) {
@@ -1088,8 +1088,8 @@ it('should generate the default classes for the typography components', async ()
     }
 
     .prose-2xl {
-      :where(font-size): 1.5rem;
-      :where(line-height): 1.6666667;
+      font-size: 1.5rem;
+      line-height: 1.6666667;
     }
 
     .prose-2xl :where(p) {
@@ -1368,8 +1368,8 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 640px) {
       .sm\\\\:prose {
-        :where(color): #374151;
-        :where(max-width): 65ch;
+        color: #374151;
+        max-width: 65ch;
       }
 
       .sm\\\\:prose :where([class~=\\"lead\\"]) {
@@ -1636,8 +1636,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose {
-        :where(font-size): 1rem;
-        :where(line-height): 1.75;
+        font-size: 1rem;
+        line-height: 1.75;
       }
 
       .sm\\\\:prose :where(p) {
@@ -1755,8 +1755,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose-sm {
-        :where(font-size): 0.875rem;
-        :where(line-height): 1.7142857;
+        font-size: 0.875rem;
+        line-height: 1.7142857;
       }
 
       .sm\\\\:prose-sm :where(p) {
@@ -1978,8 +1978,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose-lg {
-        :where(font-size): 1.125rem;
-        :where(line-height): 1.7777778;
+        font-size: 1.125rem;
+        line-height: 1.7777778;
       }
 
       .sm\\\\:prose-lg :where(p) {
@@ -2201,8 +2201,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose-xl {
-        :where(font-size): 1.25rem;
-        :where(line-height): 1.8;
+        font-size: 1.25rem;
+        line-height: 1.8;
       }
 
       .sm\\\\:prose-xl :where(p) {
@@ -2424,8 +2424,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .sm\\\\:prose-2xl {
-        :where(font-size): 1.5rem;
-        :where(line-height): 1.6666667;
+        font-size: 1.5rem;
+        line-height: 1.6666667;
       }
 
       .sm\\\\:prose-2xl :where(p) {
@@ -2705,8 +2705,8 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 768px) {
       .md\\\\:prose {
-        :where(color): #374151;
-        :where(max-width): 65ch;
+        color: #374151;
+        max-width: 65ch;
       }
 
       .md\\\\:prose :where([class~=\\"lead\\"]) {
@@ -2973,8 +2973,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose {
-        :where(font-size): 1rem;
-        :where(line-height): 1.75;
+        font-size: 1rem;
+        line-height: 1.75;
       }
 
       .md\\\\:prose :where(p) {
@@ -3092,8 +3092,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose-sm {
-        :where(font-size): 0.875rem;
-        :where(line-height): 1.7142857;
+        font-size: 0.875rem;
+        line-height: 1.7142857;
       }
 
       .md\\\\:prose-sm :where(p) {
@@ -3315,8 +3315,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose-lg {
-        :where(font-size): 1.125rem;
-        :where(line-height): 1.7777778;
+        font-size: 1.125rem;
+        line-height: 1.7777778;
       }
 
       .md\\\\:prose-lg :where(p) {
@@ -3538,8 +3538,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose-xl {
-        :where(font-size): 1.25rem;
-        :where(line-height): 1.8;
+        font-size: 1.25rem;
+        line-height: 1.8;
       }
 
       .md\\\\:prose-xl :where(p) {
@@ -3761,8 +3761,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .md\\\\:prose-2xl {
-        :where(font-size): 1.5rem;
-        :where(line-height): 1.6666667;
+        font-size: 1.5rem;
+        line-height: 1.6666667;
       }
 
       .md\\\\:prose-2xl :where(p) {
@@ -4042,8 +4042,8 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1024px) {
       .lg\\\\:prose {
-        :where(color): #374151;
-        :where(max-width): 65ch;
+        color: #374151;
+        max-width: 65ch;
       }
 
       .lg\\\\:prose :where([class~=\\"lead\\"]) {
@@ -4310,8 +4310,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose {
-        :where(font-size): 1rem;
-        :where(line-height): 1.75;
+        font-size: 1rem;
+        line-height: 1.75;
       }
 
       .lg\\\\:prose :where(p) {
@@ -4429,8 +4429,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose-sm {
-        :where(font-size): 0.875rem;
-        :where(line-height): 1.7142857;
+        font-size: 0.875rem;
+        line-height: 1.7142857;
       }
 
       .lg\\\\:prose-sm :where(p) {
@@ -4652,8 +4652,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose-lg {
-        :where(font-size): 1.125rem;
-        :where(line-height): 1.7777778;
+        font-size: 1.125rem;
+        line-height: 1.7777778;
       }
 
       .lg\\\\:prose-lg :where(p) {
@@ -4875,8 +4875,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose-xl {
-        :where(font-size): 1.25rem;
-        :where(line-height): 1.8;
+        font-size: 1.25rem;
+        line-height: 1.8;
       }
 
       .lg\\\\:prose-xl :where(p) {
@@ -5098,8 +5098,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .lg\\\\:prose-2xl {
-        :where(font-size): 1.5rem;
-        :where(line-height): 1.6666667;
+        font-size: 1.5rem;
+        line-height: 1.6666667;
       }
 
       .lg\\\\:prose-2xl :where(p) {
@@ -5379,8 +5379,8 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1280px) {
       .xl\\\\:prose {
-        :where(color): #374151;
-        :where(max-width): 65ch;
+        color: #374151;
+        max-width: 65ch;
       }
 
       .xl\\\\:prose :where([class~=\\"lead\\"]) {
@@ -5647,8 +5647,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose {
-        :where(font-size): 1rem;
-        :where(line-height): 1.75;
+        font-size: 1rem;
+        line-height: 1.75;
       }
 
       .xl\\\\:prose :where(p) {
@@ -5766,8 +5766,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose-sm {
-        :where(font-size): 0.875rem;
-        :where(line-height): 1.7142857;
+        font-size: 0.875rem;
+        line-height: 1.7142857;
       }
 
       .xl\\\\:prose-sm :where(p) {
@@ -5989,8 +5989,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose-lg {
-        :where(font-size): 1.125rem;
-        :where(line-height): 1.7777778;
+        font-size: 1.125rem;
+        line-height: 1.7777778;
       }
 
       .xl\\\\:prose-lg :where(p) {
@@ -6212,8 +6212,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose-xl {
-        :where(font-size): 1.25rem;
-        :where(line-height): 1.8;
+        font-size: 1.25rem;
+        line-height: 1.8;
       }
 
       .xl\\\\:prose-xl :where(p) {
@@ -6435,8 +6435,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .xl\\\\:prose-2xl {
-        :where(font-size): 1.5rem;
-        :where(line-height): 1.6666667;
+        font-size: 1.5rem;
+        line-height: 1.6666667;
       }
 
       .xl\\\\:prose-2xl :where(p) {
@@ -6716,8 +6716,8 @@ it('should generate the default classes for the typography components', async ()
 
     @media (min-width: 1536px) {
       .\\\\32xl\\\\:prose {
-        :where(color): #374151;
-        :where(max-width): 65ch;
+        color: #374151;
+        max-width: 65ch;
       }
 
       .\\\\32xl\\\\:prose :where([class~=\\"lead\\"]) {
@@ -6984,8 +6984,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose {
-        :where(font-size): 1rem;
-        :where(line-height): 1.75;
+        font-size: 1rem;
+        line-height: 1.75;
       }
 
       .\\\\32xl\\\\:prose :where(p) {
@@ -7103,8 +7103,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose-sm {
-        :where(font-size): 0.875rem;
-        :where(line-height): 1.7142857;
+        font-size: 0.875rem;
+        line-height: 1.7142857;
       }
 
       .\\\\32xl\\\\:prose-sm :where(p) {
@@ -7326,8 +7326,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose-lg {
-        :where(font-size): 1.125rem;
-        :where(line-height): 1.7777778;
+        font-size: 1.125rem;
+        line-height: 1.7777778;
       }
 
       .\\\\32xl\\\\:prose-lg :where(p) {
@@ -7549,8 +7549,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose-xl {
-        :where(font-size): 1.25rem;
-        :where(line-height): 1.8;
+        font-size: 1.25rem;
+        line-height: 1.8;
       }
 
       .\\\\32xl\\\\:prose-xl :where(p) {
@@ -7772,8 +7772,8 @@ it('should generate the default classes for the typography components', async ()
       }
 
       .\\\\32xl\\\\:prose-2xl {
-        :where(font-size): 1.5rem;
-        :where(line-height): 1.6666667;
+        font-size: 1.5rem;
+        line-height: 1.6666667;
       }
 
       .\\\\32xl\\\\:prose-2xl :where(p) {
@@ -15894,8 +15894,8 @@ it('should be possible to change the default modifiers', async () => {
     "
 
       - .prose-2xl {
-      -   :where(font-size): 1.5rem;
-      -   :where(line-height): 1.6666667;
+      -   font-size: 1.5rem;
+      -   line-height: 1.6666667;
       - }
       -
       - .prose-2xl :where(p) {
@@ -16179,8 +16179,8 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .sm\\\\:prose-2xl {
-      -     :where(font-size): 1.5rem;
-      -     :where(line-height): 1.6666667;
+      -     font-size: 1.5rem;
+      -     line-height: 1.6666667;
       -   }
       -
       -   .sm\\\\:prose-2xl :where(p) {
@@ -16467,8 +16467,8 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .md\\\\:prose-2xl {
-      -     :where(font-size): 1.5rem;
-      -     :where(line-height): 1.6666667;
+      -     font-size: 1.5rem;
+      -     line-height: 1.6666667;
       -   }
       -
       -   .md\\\\:prose-2xl :where(p) {
@@ -16752,8 +16752,8 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .lg\\\\:prose-2xl {
-      -     :where(font-size): 1.5rem;
-      -     :where(line-height): 1.6666667;
+      -     font-size: 1.5rem;
+      -     line-height: 1.6666667;
       -   }
       -
       -   .lg\\\\:prose-2xl :where(p) {
@@ -17040,8 +17040,8 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .xl\\\\:prose-2xl {
-      -     :where(font-size): 1.5rem;
-      -     :where(line-height): 1.6666667;
+      -     font-size: 1.5rem;
+      -     line-height: 1.6666667;
       -   }
       -
       -   .xl\\\\:prose-2xl :where(p) {
@@ -17328,8 +17328,8 @@ it('should be possible to change the default modifiers', async () => {
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl {
-      -     :where(font-size): 1.5rem;
-      -     :where(line-height): 1.6666667;
+      -     font-size: 1.5rem;
+      -     line-height: 1.6666667;
       -   }
       -
       -   .\\\\32xl\\\\:prose-2xl :where(p) {
@@ -17964,8 +17964,8 @@ it('should be possible to change the default modifiers and change the className'
       - }
       -
       - .prose-sm {
-      -   :where(font-size): 0.875rem;
-      -   :where(line-height): 1.7142857;
+      -   font-size: 0.875rem;
+      -   line-height: 1.7142857;
       - }
       -
       - .prose-sm :where(p) {
@@ -19271,8 +19271,8 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .sm\\\\:prose-sm {
-      -     :where(font-size): 0.875rem;
-      -     :where(line-height): 1.7142857;
+      -     font-size: 0.875rem;
+      -     line-height: 1.7142857;
       -   }
       -
       -   .sm\\\\:prose-sm :where(p) {
@@ -20571,8 +20571,8 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .md\\\\:prose-sm {
-      -     :where(font-size): 0.875rem;
-      -     :where(line-height): 1.7142857;
+      -     font-size: 0.875rem;
+      -     line-height: 1.7142857;
       -   }
       -
       -   .md\\\\:prose-sm :where(p) {
@@ -21880,8 +21880,8 @@ it('should be possible to change the default modifiers and change the className'
       -   }
       -
       -   .lg\\\\:prose-sm {
-      -     :where(font-size): 0.875rem;
-      -     :where(line-height): 1.7142857;
+      -     font-size: 0.875rem;
+      -     line-height: 1.7142857;
       -   }
       -
       -   .lg\\\\:prose-sm :where(p) {
@@ -23190,8 +23190,8 @@ it('should be possible to change the default modifiers and change the className'
       ---
 
       -   .xl\\\\:prose-sm {
-      -     :where(font-size): 0.875rem;
-      -     :where(line-height): 1.7142857;
+      -     font-size: 0.875rem;
+      -     line-height: 1.7142857;
       -   }
       -
       -   .xl\\\\:prose-sm :where(p) {
@@ -24490,8 +24490,8 @@ it('should be possible to change the default modifiers and change the className'
       ---
 
       -   .\\\\32xl\\\\:prose-sm {
-      -     :where(font-size): 0.875rem;
-      -     :where(line-height): 1.7142857;
+      -     font-size: 0.875rem;
+      -     line-height: 1.7142857;
       -   }
       -
       -   .\\\\32xl\\\\:prose-sm :where(p) {
@@ -25453,8 +25453,8 @@ it('should be possible to add a new variant', async () => {
     "
 
       + .prose-dark {
-      +   :where(color): black;
-      +   :where(max-width): 65ch;
+      +   color: black;
+      +   max-width: 65ch;
       + }
       +
 
@@ -25462,8 +25462,8 @@ it('should be possible to add a new variant', async () => {
 
       +
       +   .sm\\\\:prose-dark {
-      +     :where(color): black;
-      +     :where(max-width): 65ch;
+      +     color: black;
+      +     max-width: 65ch;
       +   }
 
       ---
@@ -25471,32 +25471,32 @@ it('should be possible to add a new variant', async () => {
       +   }
       +
       +   .md\\\\:prose-dark {
-      +     :where(color): black;
-      +     :where(max-width): 65ch;
+      +     color: black;
+      +     max-width: 65ch;
 
       ---
 
       +   }
       +
       +   .lg\\\\:prose-dark {
-      +     :where(color): black;
-      +     :where(max-width): 65ch;
+      +     color: black;
+      +     max-width: 65ch;
 
       ---
 
       +   }
       +
       +   .xl\\\\:prose-dark {
-      +     :where(color): black;
-      +     :where(max-width): 65ch;
+      +     color: black;
+      +     max-width: 65ch;
 
       ---
 
       +   }
       +
       +   .\\\\32xl\\\\:prose-dark {
-      +     :where(color): black;
-      +     :where(max-width): 65ch;
+      +     color: black;
+      +     max-width: 65ch;
 
     "
   `)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -15889,6 +15889,7662 @@ it('should be possible to change the default className from `prose` to `markdown
   `)
 })
 
+it('should be possible to disable the use of :where() by setting `target` to `legacy`', async () => {
+  expect(await diffOnly({ target: 'legacy' })).toMatchInlineSnapshot(`
+    "
+
+      - .prose :where([class~='lead']) {
+      + .prose [class~='lead'] {
+
+      ---
+
+      - .prose :where(a) {
+      + .prose a {
+
+      ---
+
+      - .prose :where(strong) {
+      + .prose strong {
+
+      ---
+
+      - .prose :where(ol[type='A']) {
+      + .prose ol[type='A'] {
+
+      ---
+
+      - .prose :where(ol[type='a']) {
+      + .prose ol[type='a'] {
+
+      ---
+
+      - .prose :where(ol[type='A' s]) {
+      + .prose ol[type='A' s] {
+
+      ---
+
+      - .prose :where(ol[type='a' s]) {
+      + .prose ol[type='a' s] {
+
+      ---
+
+      - .prose :where(ol[type='I']) {
+      + .prose ol[type='I'] {
+
+      ---
+
+      - .prose :where(ol[type='i']) {
+      + .prose ol[type='i'] {
+
+      ---
+
+      - .prose :where(ol[type='I' s]) {
+      + .prose ol[type='I' s] {
+
+      ---
+
+      - .prose :where(ol[type='i' s]) {
+      + .prose ol[type='i' s] {
+
+      ---
+
+      - .prose :where(ol[type='1']) {
+      + .prose ol[type='1'] {
+
+      ---
+
+      - .prose :where(ol > li) {
+      + .prose ol > li {
+
+      ---
+
+      - .prose :where(ol > li)::before {
+      + .prose ol > li::before {
+
+      ---
+
+      - .prose :where(ul > li) {
+      + .prose ul > li {
+
+      ---
+
+      - .prose :where(ul > li)::before {
+      + .prose ul > li::before {
+
+      ---
+
+      - .prose :where(hr) {
+      + .prose hr {
+
+      ---
+
+      - .prose :where(blockquote) {
+      + .prose blockquote {
+
+      ---
+
+      - .prose :where(blockquote p:first-of-type)::before {
+      + .prose blockquote p:first-of-type::before {
+
+      ---
+
+      - .prose :where(blockquote p:last-of-type)::after {
+      + .prose blockquote p:last-of-type::after {
+
+      ---
+
+      - .prose :where(h1) {
+      + .prose h1 {
+
+      ---
+
+      - .prose :where(h1 strong) {
+      + .prose h1 strong {
+
+      ---
+
+      - .prose :where(h2) {
+      + .prose h2 {
+
+      ---
+
+      - .prose :where(h2 strong) {
+      + .prose h2 strong {
+
+      ---
+
+      - .prose :where(h3) {
+      + .prose h3 {
+
+      ---
+
+      - .prose :where(h3 strong) {
+      + .prose h3 strong {
+
+      ---
+
+      - .prose :where(h4) {
+      + .prose h4 {
+
+      ---
+
+      - .prose :where(h4 strong) {
+      + .prose h4 strong {
+
+      ---
+
+      - .prose :where(figure figcaption) {
+      + .prose figure figcaption {
+
+      ---
+
+      - .prose :where(code) {
+      + .prose code {
+
+      ---
+
+      - .prose :where(code)::before {
+      + .prose code::before {
+
+      ---
+
+      - .prose :where(code)::after {
+      + .prose code::after {
+
+      ---
+
+      - .prose :where(a code) {
+      + .prose a code {
+
+      ---
+
+      - .prose :where(pre) {
+      + .prose pre {
+
+      ---
+
+      - .prose :where(pre code) {
+      + .prose pre code {
+
+      ---
+
+      - .prose :where(pre code)::before {
+      + .prose pre code::before {
+
+      ---
+
+      - .prose :where(pre code)::after {
+      + .prose pre code::after {
+
+      ---
+
+      - .prose :where(table) {
+      + .prose table {
+
+      ---
+
+      - .prose :where(thead) {
+      + .prose thead {
+
+      ---
+
+      - .prose :where(thead th) {
+      + .prose thead th {
+
+      ---
+
+      - .prose :where(tbody tr) {
+      + .prose tbody tr {
+
+      ---
+
+      - .prose :where(tbody tr:last-child) {
+      + .prose tbody tr:last-child {
+
+      ---
+
+      - .prose :where(tbody td) {
+      + .prose tbody td {
+
+      ---
+
+      - .prose :where(p) {
+      + .prose p {
+
+      ---
+
+      - .prose :where(img) {
+      + .prose img {
+
+      ---
+
+      - .prose :where(video) {
+      + .prose video {
+
+      ---
+
+      - .prose :where(figure) {
+      + .prose figure {
+
+      ---
+
+      - .prose :where(figure > *) {
+      + .prose figure > * {
+
+      ---
+
+      - .prose :where(h2 code) {
+      + .prose h2 code {
+
+      ---
+
+      - .prose :where(h3 code) {
+      + .prose h3 code {
+
+      ---
+
+      - .prose :where(ol) {
+      + .prose ol {
+
+      ---
+
+      - .prose :where(ul) {
+      + .prose ul {
+
+      ---
+
+      - .prose :where(li) {
+      + .prose li {
+
+      ---
+
+      - .prose :where(> ul > li p) {
+      + .prose > ul > li p {
+
+      ---
+
+      - .prose :where(> ul > li > *:first-child) {
+      + .prose > ul > li > *:first-child {
+
+      ---
+
+      - .prose :where(> ul > li > *:last-child) {
+      + .prose > ul > li > *:last-child {
+
+      ---
+
+      - .prose :where(> ol > li > *:first-child) {
+      + .prose > ol > li > *:first-child {
+
+      ---
+
+      - .prose :where(> ol > li > *:last-child) {
+      + .prose > ol > li > *:last-child {
+
+      ---
+
+      - .prose :where(ul ul, ul ol, ol ul, ol ol) {
+      + .prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
+
+      ---
+
+      - .prose :where(hr + *) {
+      + .prose hr + * {
+
+      ---
+
+      - .prose :where(h2 + *) {
+      + .prose h2 + * {
+
+      ---
+
+      - .prose :where(h3 + *) {
+      + .prose h3 + * {
+
+      ---
+
+      - .prose :where(h4 + *) {
+      + .prose h4 + * {
+
+      ---
+
+      - .prose :where(thead th:first-child) {
+      + .prose thead th:first-child {
+
+      ---
+
+      - .prose :where(thead th:last-child) {
+      + .prose thead th:last-child {
+
+      ---
+
+      - .prose :where(tbody td:first-child) {
+      + .prose tbody td:first-child {
+
+      ---
+
+      - .prose :where(tbody td:last-child) {
+      + .prose tbody td:last-child {
+
+      ---
+
+      - .prose :where(> :first-child) {
+      + .prose > :first-child {
+
+      ---
+
+      - .prose :where(> :last-child) {
+      + .prose > :last-child {
+
+      ---
+
+      - .prose-sm :where(p) {
+      + .prose-sm p {
+
+      ---
+
+      - .prose-sm :where([class~='lead']) {
+      + .prose-sm [class~='lead'] {
+
+      ---
+
+      - .prose-sm :where(blockquote) {
+      + .prose-sm blockquote {
+
+      ---
+
+      - .prose-sm :where(h1) {
+      + .prose-sm h1 {
+
+      ---
+
+      - .prose-sm :where(h2) {
+      + .prose-sm h2 {
+
+      ---
+
+      - .prose-sm :where(h3) {
+      + .prose-sm h3 {
+
+      ---
+
+      - .prose-sm :where(h4) {
+      + .prose-sm h4 {
+
+      ---
+
+      - .prose-sm :where(img) {
+      + .prose-sm img {
+
+      ---
+
+      - .prose-sm :where(video) {
+      + .prose-sm video {
+
+      ---
+
+      - .prose-sm :where(figure) {
+      + .prose-sm figure {
+
+      ---
+
+      - .prose-sm :where(figure > *) {
+      + .prose-sm figure > * {
+
+      ---
+
+      - .prose-sm :where(figure figcaption) {
+      + .prose-sm figure figcaption {
+
+      ---
+
+      - .prose-sm :where(code) {
+      + .prose-sm code {
+
+      ---
+
+      - .prose-sm :where(h2 code) {
+      + .prose-sm h2 code {
+
+      ---
+
+      - .prose-sm :where(h3 code) {
+      + .prose-sm h3 code {
+
+      ---
+
+      - .prose-sm :where(pre) {
+      + .prose-sm pre {
+
+      ---
+
+      - .prose-sm :where(ol) {
+      + .prose-sm ol {
+
+      ---
+
+      - .prose-sm :where(ul) {
+      + .prose-sm ul {
+
+      ---
+
+      - .prose-sm :where(li) {
+      + .prose-sm li {
+
+      ---
+
+      - .prose-sm :where(ol > li) {
+      + .prose-sm ol > li {
+
+      ---
+
+      - .prose-sm :where(ol > li)::before {
+      + .prose-sm ol > li::before {
+
+      ---
+
+      - .prose-sm :where(ul > li) {
+      + .prose-sm ul > li {
+
+      ---
+
+      - .prose-sm :where(ul > li)::before {
+      + .prose-sm ul > li::before {
+
+      ---
+
+      - .prose-sm :where(> ul > li p) {
+      + .prose-sm > ul > li p {
+
+      ---
+
+      - .prose-sm :where(> ul > li > *:first-child) {
+      + .prose-sm > ul > li > *:first-child {
+
+      ---
+
+      - .prose-sm :where(> ul > li > *:last-child) {
+      + .prose-sm > ul > li > *:last-child {
+
+      ---
+
+      - .prose-sm :where(> ol > li > *:first-child) {
+      + .prose-sm > ol > li > *:first-child {
+
+      ---
+
+      - .prose-sm :where(> ol > li > *:last-child) {
+      + .prose-sm > ol > li > *:last-child {
+
+      ---
+
+      - .prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      + .prose-sm ul ul, .prose-sm ul ol, .prose-sm ol ul, .prose-sm ol ol {
+
+      ---
+
+      - .prose-sm :where(hr) {
+      + .prose-sm hr {
+
+      ---
+
+      - .prose-sm :where(hr + *) {
+      + .prose-sm hr + * {
+
+      ---
+
+      - .prose-sm :where(h2 + *) {
+      + .prose-sm h2 + * {
+
+      ---
+
+      - .prose-sm :where(h3 + *) {
+      + .prose-sm h3 + * {
+
+      ---
+
+      - .prose-sm :where(h4 + *) {
+      + .prose-sm h4 + * {
+
+      ---
+
+      - .prose-sm :where(table) {
+      + .prose-sm table {
+
+      ---
+
+      - .prose-sm :where(thead th) {
+      + .prose-sm thead th {
+
+      ---
+
+      - .prose-sm :where(thead th:first-child) {
+      + .prose-sm thead th:first-child {
+
+      ---
+
+      - .prose-sm :where(thead th:last-child) {
+      + .prose-sm thead th:last-child {
+
+      ---
+
+      - .prose-sm :where(tbody td) {
+      + .prose-sm tbody td {
+
+      ---
+
+      - .prose-sm :where(tbody td:first-child) {
+      + .prose-sm tbody td:first-child {
+
+      ---
+
+      - .prose-sm :where(tbody td:last-child) {
+      + .prose-sm tbody td:last-child {
+
+      ---
+
+      - .prose-sm :where(> :first-child) {
+      + .prose-sm > :first-child {
+
+      ---
+
+      - .prose-sm :where(> :last-child) {
+      + .prose-sm > :last-child {
+
+      ---
+
+      - .prose-lg :where(p) {
+      + .prose-lg p {
+
+      ---
+
+      - .prose-lg :where([class~='lead']) {
+      + .prose-lg [class~='lead'] {
+
+      ---
+
+      - .prose-lg :where(blockquote) {
+      + .prose-lg blockquote {
+
+      ---
+
+      - .prose-lg :where(h1) {
+      + .prose-lg h1 {
+
+      ---
+
+      - .prose-lg :where(h2) {
+      + .prose-lg h2 {
+
+      ---
+
+      - .prose-lg :where(h3) {
+      + .prose-lg h3 {
+
+      ---
+
+      - .prose-lg :where(h4) {
+      + .prose-lg h4 {
+
+      ---
+
+      - .prose-lg :where(img) {
+      + .prose-lg img {
+
+      ---
+
+      - .prose-lg :where(video) {
+      + .prose-lg video {
+
+      ---
+
+      - .prose-lg :where(figure) {
+      + .prose-lg figure {
+
+      ---
+
+      - .prose-lg :where(figure > *) {
+      + .prose-lg figure > * {
+
+      ---
+
+      - .prose-lg :where(figure figcaption) {
+      + .prose-lg figure figcaption {
+
+      ---
+
+      - .prose-lg :where(code) {
+      + .prose-lg code {
+
+      ---
+
+      - .prose-lg :where(h2 code) {
+      + .prose-lg h2 code {
+
+      ---
+
+      - .prose-lg :where(h3 code) {
+      + .prose-lg h3 code {
+
+      ---
+
+      - .prose-lg :where(pre) {
+      + .prose-lg pre {
+
+      ---
+
+      - .prose-lg :where(ol) {
+      + .prose-lg ol {
+
+      ---
+
+      - .prose-lg :where(ul) {
+      + .prose-lg ul {
+
+      ---
+
+      - .prose-lg :where(li) {
+      + .prose-lg li {
+
+      ---
+
+      - .prose-lg :where(ol > li) {
+      + .prose-lg ol > li {
+
+      ---
+
+      - .prose-lg :where(ol > li)::before {
+      + .prose-lg ol > li::before {
+
+      ---
+
+      - .prose-lg :where(ul > li) {
+      + .prose-lg ul > li {
+
+      ---
+
+      - .prose-lg :where(ul > li)::before {
+      + .prose-lg ul > li::before {
+
+      ---
+
+      - .prose-lg :where(> ul > li p) {
+      + .prose-lg > ul > li p {
+
+      ---
+
+      - .prose-lg :where(> ul > li > *:first-child) {
+      + .prose-lg > ul > li > *:first-child {
+
+      ---
+
+      - .prose-lg :where(> ul > li > *:last-child) {
+      + .prose-lg > ul > li > *:last-child {
+
+      ---
+
+      - .prose-lg :where(> ol > li > *:first-child) {
+      + .prose-lg > ol > li > *:first-child {
+
+      ---
+
+      - .prose-lg :where(> ol > li > *:last-child) {
+      + .prose-lg > ol > li > *:last-child {
+
+      ---
+
+      - .prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      + .prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
+
+      ---
+
+      - .prose-lg :where(hr) {
+      + .prose-lg hr {
+
+      ---
+
+      - .prose-lg :where(hr + *) {
+      + .prose-lg hr + * {
+
+      ---
+
+      - .prose-lg :where(h2 + *) {
+      + .prose-lg h2 + * {
+
+      ---
+
+      - .prose-lg :where(h3 + *) {
+      + .prose-lg h3 + * {
+
+      ---
+
+      - .prose-lg :where(h4 + *) {
+      + .prose-lg h4 + * {
+
+      ---
+
+      - .prose-lg :where(table) {
+      + .prose-lg table {
+
+      ---
+
+      - .prose-lg :where(thead th) {
+      + .prose-lg thead th {
+
+      ---
+
+      - .prose-lg :where(thead th:first-child) {
+      + .prose-lg thead th:first-child {
+
+      ---
+
+      - .prose-lg :where(thead th:last-child) {
+      + .prose-lg thead th:last-child {
+
+      ---
+
+      - .prose-lg :where(tbody td) {
+      + .prose-lg tbody td {
+
+      ---
+
+      - .prose-lg :where(tbody td:first-child) {
+      + .prose-lg tbody td:first-child {
+
+      ---
+
+      - .prose-lg :where(tbody td:last-child) {
+      + .prose-lg tbody td:last-child {
+
+      ---
+
+      - .prose-lg :where(> :first-child) {
+      + .prose-lg > :first-child {
+
+      ---
+
+      - .prose-lg :where(> :last-child) {
+      + .prose-lg > :last-child {
+
+      ---
+
+      - .prose-xl :where(p) {
+      + .prose-xl p {
+
+      ---
+
+      - .prose-xl :where([class~='lead']) {
+      + .prose-xl [class~='lead'] {
+
+      ---
+
+      - .prose-xl :where(blockquote) {
+      + .prose-xl blockquote {
+
+      ---
+
+      - .prose-xl :where(h1) {
+      + .prose-xl h1 {
+
+      ---
+
+      - .prose-xl :where(h2) {
+      + .prose-xl h2 {
+
+      ---
+
+      - .prose-xl :where(h3) {
+      + .prose-xl h3 {
+
+      ---
+
+      - .prose-xl :where(h4) {
+      + .prose-xl h4 {
+
+      ---
+
+      - .prose-xl :where(img) {
+      + .prose-xl img {
+
+      ---
+
+      - .prose-xl :where(video) {
+      + .prose-xl video {
+
+      ---
+
+      - .prose-xl :where(figure) {
+      + .prose-xl figure {
+
+      ---
+
+      - .prose-xl :where(figure > *) {
+      + .prose-xl figure > * {
+
+      ---
+
+      - .prose-xl :where(figure figcaption) {
+      + .prose-xl figure figcaption {
+
+      ---
+
+      - .prose-xl :where(code) {
+      + .prose-xl code {
+
+      ---
+
+      - .prose-xl :where(h2 code) {
+      + .prose-xl h2 code {
+
+      ---
+
+      - .prose-xl :where(h3 code) {
+      + .prose-xl h3 code {
+
+      ---
+
+      - .prose-xl :where(pre) {
+      + .prose-xl pre {
+
+      ---
+
+      - .prose-xl :where(ol) {
+      + .prose-xl ol {
+
+      ---
+
+      - .prose-xl :where(ul) {
+      + .prose-xl ul {
+
+      ---
+
+      - .prose-xl :where(li) {
+      + .prose-xl li {
+
+      ---
+
+      - .prose-xl :where(ol > li) {
+      + .prose-xl ol > li {
+
+      ---
+
+      - .prose-xl :where(ol > li)::before {
+      + .prose-xl ol > li::before {
+
+      ---
+
+      - .prose-xl :where(ul > li) {
+      + .prose-xl ul > li {
+
+      ---
+
+      - .prose-xl :where(ul > li)::before {
+      + .prose-xl ul > li::before {
+
+      ---
+
+      - .prose-xl :where(> ul > li p) {
+      + .prose-xl > ul > li p {
+
+      ---
+
+      - .prose-xl :where(> ul > li > *:first-child) {
+      + .prose-xl > ul > li > *:first-child {
+
+      ---
+
+      - .prose-xl :where(> ul > li > *:last-child) {
+      + .prose-xl > ul > li > *:last-child {
+
+      ---
+
+      - .prose-xl :where(> ol > li > *:first-child) {
+      + .prose-xl > ol > li > *:first-child {
+
+      ---
+
+      - .prose-xl :where(> ol > li > *:last-child) {
+      + .prose-xl > ol > li > *:last-child {
+
+      ---
+
+      - .prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .prose-xl ul ul, .prose-xl ul ol, .prose-xl ol ul, .prose-xl ol ol {
+
+      ---
+
+      - .prose-xl :where(hr) {
+      + .prose-xl hr {
+
+      ---
+
+      - .prose-xl :where(hr + *) {
+      + .prose-xl hr + * {
+
+      ---
+
+      - .prose-xl :where(h2 + *) {
+      + .prose-xl h2 + * {
+
+      ---
+
+      - .prose-xl :where(h3 + *) {
+      + .prose-xl h3 + * {
+
+      ---
+
+      - .prose-xl :where(h4 + *) {
+      + .prose-xl h4 + * {
+
+      ---
+
+      - .prose-xl :where(table) {
+      + .prose-xl table {
+
+      ---
+
+      - .prose-xl :where(thead th) {
+      + .prose-xl thead th {
+
+      ---
+
+      - .prose-xl :where(thead th:first-child) {
+      + .prose-xl thead th:first-child {
+
+      ---
+
+      - .prose-xl :where(thead th:last-child) {
+      + .prose-xl thead th:last-child {
+
+      ---
+
+      - .prose-xl :where(tbody td) {
+      + .prose-xl tbody td {
+
+      ---
+
+      - .prose-xl :where(tbody td:first-child) {
+      + .prose-xl tbody td:first-child {
+
+      ---
+
+      - .prose-xl :where(tbody td:last-child) {
+      + .prose-xl tbody td:last-child {
+
+      ---
+
+      - .prose-xl :where(> :first-child) {
+      + .prose-xl > :first-child {
+
+      ---
+
+      - .prose-xl :where(> :last-child) {
+      + .prose-xl > :last-child {
+
+      ---
+
+      - .prose-2xl :where(p) {
+      + .prose-2xl p {
+
+      ---
+
+      - .prose-2xl :where([class~='lead']) {
+      + .prose-2xl [class~='lead'] {
+
+      ---
+
+      - .prose-2xl :where(blockquote) {
+      + .prose-2xl blockquote {
+
+      ---
+
+      - .prose-2xl :where(h1) {
+      + .prose-2xl h1 {
+
+      ---
+
+      - .prose-2xl :where(h2) {
+      + .prose-2xl h2 {
+
+      ---
+
+      - .prose-2xl :where(h3) {
+      + .prose-2xl h3 {
+
+      ---
+
+      - .prose-2xl :where(h4) {
+      + .prose-2xl h4 {
+
+      ---
+
+      - .prose-2xl :where(img) {
+      + .prose-2xl img {
+
+      ---
+
+      - .prose-2xl :where(video) {
+      + .prose-2xl video {
+
+      ---
+
+      - .prose-2xl :where(figure) {
+      + .prose-2xl figure {
+
+      ---
+
+      - .prose-2xl :where(figure > *) {
+      + .prose-2xl figure > * {
+
+      ---
+
+      - .prose-2xl :where(figure figcaption) {
+      + .prose-2xl figure figcaption {
+
+      ---
+
+      - .prose-2xl :where(code) {
+      + .prose-2xl code {
+
+      ---
+
+      - .prose-2xl :where(h2 code) {
+      + .prose-2xl h2 code {
+
+      ---
+
+      - .prose-2xl :where(h3 code) {
+      + .prose-2xl h3 code {
+
+      ---
+
+      - .prose-2xl :where(pre) {
+      + .prose-2xl pre {
+
+      ---
+
+      - .prose-2xl :where(ol) {
+      + .prose-2xl ol {
+
+      ---
+
+      - .prose-2xl :where(ul) {
+      + .prose-2xl ul {
+
+      ---
+
+      - .prose-2xl :where(li) {
+      + .prose-2xl li {
+
+      ---
+
+      - .prose-2xl :where(ol > li) {
+      + .prose-2xl ol > li {
+
+      ---
+
+      - .prose-2xl :where(ol > li)::before {
+      + .prose-2xl ol > li::before {
+
+      ---
+
+      - .prose-2xl :where(ul > li) {
+      + .prose-2xl ul > li {
+
+      ---
+
+      - .prose-2xl :where(ul > li)::before {
+      + .prose-2xl ul > li::before {
+
+      ---
+
+      - .prose-2xl :where(> ul > li p) {
+      + .prose-2xl > ul > li p {
+
+      ---
+
+      - .prose-2xl :where(> ul > li > *:first-child) {
+      + .prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      - .prose-2xl :where(> ul > li > *:last-child) {
+      + .prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      - .prose-2xl :where(> ol > li > *:first-child) {
+      + .prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      - .prose-2xl :where(> ol > li > *:last-child) {
+      + .prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      - .prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      + .prose-2xl ul ul, .prose-2xl ul ol, .prose-2xl ol ul, .prose-2xl ol ol {
+
+      ---
+
+      - .prose-2xl :where(hr) {
+      + .prose-2xl hr {
+
+      ---
+
+      - .prose-2xl :where(hr + *) {
+      + .prose-2xl hr + * {
+
+      ---
+
+      - .prose-2xl :where(h2 + *) {
+      + .prose-2xl h2 + * {
+
+      ---
+
+      - .prose-2xl :where(h3 + *) {
+      + .prose-2xl h3 + * {
+
+      ---
+
+      - .prose-2xl :where(h4 + *) {
+      + .prose-2xl h4 + * {
+
+      ---
+
+      - .prose-2xl :where(table) {
+      + .prose-2xl table {
+
+      ---
+
+      - .prose-2xl :where(thead th) {
+      + .prose-2xl thead th {
+
+      ---
+
+      - .prose-2xl :where(thead th:first-child) {
+      + .prose-2xl thead th:first-child {
+
+      ---
+
+      - .prose-2xl :where(thead th:last-child) {
+      + .prose-2xl thead th:last-child {
+
+      ---
+
+      - .prose-2xl :where(tbody td) {
+      + .prose-2xl tbody td {
+
+      ---
+
+      - .prose-2xl :where(tbody td:first-child) {
+      + .prose-2xl tbody td:first-child {
+
+      ---
+
+      - .prose-2xl :where(tbody td:last-child) {
+      + .prose-2xl tbody td:last-child {
+
+      ---
+
+      - .prose-2xl :where(> :first-child) {
+      + .prose-2xl > :first-child {
+
+      ---
+
+      - .prose-2xl :where(> :last-child) {
+      + .prose-2xl > :last-child {
+
+      ---
+
+      - .prose-red :where(a) {
+      + .prose-red a {
+
+      ---
+
+      - .prose-red :where(a code) {
+      + .prose-red a code {
+
+      ---
+
+      - .prose-yellow :where(a) {
+      + .prose-yellow a {
+
+      ---
+
+      - .prose-yellow :where(a code) {
+      + .prose-yellow a code {
+
+      ---
+
+      - .prose-green :where(a) {
+      + .prose-green a {
+
+      ---
+
+      - .prose-green :where(a code) {
+      + .prose-green a code {
+
+      ---
+
+      - .prose-blue :where(a) {
+      + .prose-blue a {
+
+      ---
+
+      - .prose-blue :where(a code) {
+      + .prose-blue a code {
+
+      ---
+
+      - .prose-indigo :where(a) {
+      + .prose-indigo a {
+
+      ---
+
+      - .prose-indigo :where(a code) {
+      + .prose-indigo a code {
+
+      ---
+
+      - .prose-purple :where(a) {
+      + .prose-purple a {
+
+      ---
+
+      - .prose-purple :where(a code) {
+      + .prose-purple a code {
+
+      ---
+
+      - .prose-pink :where(a) {
+      + .prose-pink a {
+
+      ---
+
+      - .prose-pink :where(a code) {
+      + .prose-pink a code {
+
+      ---
+
+      -   .sm\\\\:prose :where([class~='lead']) {
+      +   .sm\\\\:prose [class~='lead'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(a) {
+      +   .sm\\\\:prose a {
+
+      ---
+
+      -   .sm\\\\:prose :where(strong) {
+      +   .sm\\\\:prose strong {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='A']) {
+      +   .sm\\\\:prose ol[type='A'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='a']) {
+      +   .sm\\\\:prose ol[type='a'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='A' s]) {
+      +   .sm\\\\:prose ol[type='A' s] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='a' s]) {
+      +   .sm\\\\:prose ol[type='a' s] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='I']) {
+      +   .sm\\\\:prose ol[type='I'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='i']) {
+      +   .sm\\\\:prose ol[type='i'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='I' s]) {
+      +   .sm\\\\:prose ol[type='I' s] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='i' s]) {
+      +   .sm\\\\:prose ol[type='i' s] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol[type='1']) {
+      +   .sm\\\\:prose ol[type='1'] {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol > li) {
+      +   .sm\\\\:prose ol > li {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol > li)::before {
+      +   .sm\\\\:prose ol > li::before {
+
+      ---
+
+      -   .sm\\\\:prose :where(ul > li) {
+      +   .sm\\\\:prose ul > li {
+
+      ---
+
+      -   .sm\\\\:prose :where(ul > li)::before {
+      +   .sm\\\\:prose ul > li::before {
+
+      ---
+
+      -   .sm\\\\:prose :where(hr) {
+      +   .sm\\\\:prose hr {
+
+      ---
+
+      -   .sm\\\\:prose :where(blockquote) {
+      +   .sm\\\\:prose blockquote {
+
+      ---
+
+      -   .sm\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .sm\\\\:prose blockquote p:first-of-type::before {
+
+      ---
+
+      -   .sm\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .sm\\\\:prose blockquote p:last-of-type::after {
+
+      ---
+
+      -   .sm\\\\:prose :where(h1) {
+      +   .sm\\\\:prose h1 {
+
+      ---
+
+      -   .sm\\\\:prose :where(h1 strong) {
+      +   .sm\\\\:prose h1 strong {
+
+      ---
+
+      -   .sm\\\\:prose :where(h2) {
+      +   .sm\\\\:prose h2 {
+
+      ---
+
+      -   .sm\\\\:prose :where(h2 strong) {
+      +   .sm\\\\:prose h2 strong {
+
+      ---
+
+      -   .sm\\\\:prose :where(h3) {
+      +   .sm\\\\:prose h3 {
+
+      ---
+
+      -   .sm\\\\:prose :where(h3 strong) {
+      +   .sm\\\\:prose h3 strong {
+
+      ---
+
+      -   .sm\\\\:prose :where(h4) {
+      +   .sm\\\\:prose h4 {
+
+      ---
+
+      -   .sm\\\\:prose :where(h4 strong) {
+      +   .sm\\\\:prose h4 strong {
+
+      ---
+
+      -   .sm\\\\:prose :where(figure figcaption) {
+      +   .sm\\\\:prose figure figcaption {
+
+      ---
+
+      -   .sm\\\\:prose :where(code) {
+      +   .sm\\\\:prose code {
+
+      ---
+
+      -   .sm\\\\:prose :where(code)::before {
+      +   .sm\\\\:prose code::before {
+
+      ---
+
+      -   .sm\\\\:prose :where(code)::after {
+      +   .sm\\\\:prose code::after {
+
+      ---
+
+      -   .sm\\\\:prose :where(a code) {
+      +   .sm\\\\:prose a code {
+
+      ---
+
+      -   .sm\\\\:prose :where(pre) {
+      +   .sm\\\\:prose pre {
+
+      ---
+
+      -   .sm\\\\:prose :where(pre code) {
+      +   .sm\\\\:prose pre code {
+
+      ---
+
+      -   .sm\\\\:prose :where(pre code)::before {
+      +   .sm\\\\:prose pre code::before {
+
+      ---
+
+      -   .sm\\\\:prose :where(pre code)::after {
+      +   .sm\\\\:prose pre code::after {
+
+      ---
+
+      -   .sm\\\\:prose :where(table) {
+      +   .sm\\\\:prose table {
+
+      ---
+
+      -   .sm\\\\:prose :where(thead) {
+      +   .sm\\\\:prose thead {
+
+      ---
+
+      -   .sm\\\\:prose :where(thead th) {
+      +   .sm\\\\:prose thead th {
+
+      ---
+
+      -   .sm\\\\:prose :where(tbody tr) {
+      +   .sm\\\\:prose tbody tr {
+
+      ---
+
+      -   .sm\\\\:prose :where(tbody tr:last-child) {
+      +   .sm\\\\:prose tbody tr:last-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(tbody td) {
+      +   .sm\\\\:prose tbody td {
+
+      ---
+
+      -   .sm\\\\:prose :where(p) {
+      +   .sm\\\\:prose p {
+
+      ---
+
+      -   .sm\\\\:prose :where(img) {
+      +   .sm\\\\:prose img {
+
+      ---
+
+      -   .sm\\\\:prose :where(video) {
+      +   .sm\\\\:prose video {
+
+      ---
+
+      -   .sm\\\\:prose :where(figure) {
+      +   .sm\\\\:prose figure {
+
+      ---
+
+      -   .sm\\\\:prose :where(figure > *) {
+      +   .sm\\\\:prose figure > * {
+
+      ---
+
+      -   .sm\\\\:prose :where(h2 code) {
+      +   .sm\\\\:prose h2 code {
+
+      ---
+
+      -   .sm\\\\:prose :where(h3 code) {
+      +   .sm\\\\:prose h3 code {
+
+      ---
+
+      -   .sm\\\\:prose :where(ol) {
+      +   .sm\\\\:prose ol {
+
+      ---
+
+      -   .sm\\\\:prose :where(ul) {
+      +   .sm\\\\:prose ul {
+
+      ---
+
+      -   .sm\\\\:prose :where(li) {
+      +   .sm\\\\:prose li {
+
+      ---
+
+      -   .sm\\\\:prose :where(> ul > li p) {
+      +   .sm\\\\:prose > ul > li p {
+
+      ---
+
+      -   .sm\\\\:prose :where(> ul > li > *:first-child) {
+      +   .sm\\\\:prose > ul > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(> ul > li > *:last-child) {
+      +   .sm\\\\:prose > ul > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(> ol > li > *:first-child) {
+      +   .sm\\\\:prose > ol > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(> ol > li > *:last-child) {
+      +   .sm\\\\:prose > ol > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:prose ul ul, .sm\\\\:prose ul ol, .sm\\\\:prose ol ul, .sm\\\\:prose ol ol {
+
+      ---
+
+      -   .sm\\\\:prose :where(hr + *) {
+      +   .sm\\\\:prose hr + * {
+
+      ---
+
+      -   .sm\\\\:prose :where(h2 + *) {
+      +   .sm\\\\:prose h2 + * {
+
+      ---
+
+      -   .sm\\\\:prose :where(h3 + *) {
+      +   .sm\\\\:prose h3 + * {
+
+      ---
+
+      -   .sm\\\\:prose :where(h4 + *) {
+      +   .sm\\\\:prose h4 + * {
+
+      ---
+
+      -   .sm\\\\:prose :where(thead th:first-child) {
+      +   .sm\\\\:prose thead th:first-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(thead th:last-child) {
+      +   .sm\\\\:prose thead th:last-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(tbody td:first-child) {
+      +   .sm\\\\:prose tbody td:first-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(tbody td:last-child) {
+      +   .sm\\\\:prose tbody td:last-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(> :first-child) {
+      +   .sm\\\\:prose > :first-child {
+
+      ---
+
+      -   .sm\\\\:prose :where(> :last-child) {
+      +   .sm\\\\:prose > :last-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(p) {
+      +   .sm\\\\:prose-sm p {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where([class~='lead']) {
+      +   .sm\\\\:prose-sm [class~='lead'] {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(blockquote) {
+      +   .sm\\\\:prose-sm blockquote {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h1) {
+      +   .sm\\\\:prose-sm h1 {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h2) {
+      +   .sm\\\\:prose-sm h2 {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h3) {
+      +   .sm\\\\:prose-sm h3 {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h4) {
+      +   .sm\\\\:prose-sm h4 {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(img) {
+      +   .sm\\\\:prose-sm img {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(video) {
+      +   .sm\\\\:prose-sm video {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(figure) {
+      +   .sm\\\\:prose-sm figure {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(figure > *) {
+      +   .sm\\\\:prose-sm figure > * {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(figure figcaption) {
+      +   .sm\\\\:prose-sm figure figcaption {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(code) {
+      +   .sm\\\\:prose-sm code {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h2 code) {
+      +   .sm\\\\:prose-sm h2 code {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h3 code) {
+      +   .sm\\\\:prose-sm h3 code {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(pre) {
+      +   .sm\\\\:prose-sm pre {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ol) {
+      +   .sm\\\\:prose-sm ol {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ul) {
+      +   .sm\\\\:prose-sm ul {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(li) {
+      +   .sm\\\\:prose-sm li {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ol > li) {
+      +   .sm\\\\:prose-sm ol > li {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ol > li)::before {
+      +   .sm\\\\:prose-sm ol > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ul > li) {
+      +   .sm\\\\:prose-sm ul > li {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ul > li)::before {
+      +   .sm\\\\:prose-sm ul > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> ul > li p) {
+      +   .sm\\\\:prose-sm > ul > li p {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .sm\\\\:prose-sm > ul > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .sm\\\\:prose-sm > ul > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .sm\\\\:prose-sm > ol > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .sm\\\\:prose-sm > ol > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:prose-sm ul ul, .sm\\\\:prose-sm ul ol, .sm\\\\:prose-sm ol ul, .sm\\\\:prose-sm ol ol {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(hr) {
+      +   .sm\\\\:prose-sm hr {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(hr + *) {
+      +   .sm\\\\:prose-sm hr + * {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h2 + *) {
+      +   .sm\\\\:prose-sm h2 + * {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h3 + *) {
+      +   .sm\\\\:prose-sm h3 + * {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(h4 + *) {
+      +   .sm\\\\:prose-sm h4 + * {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(table) {
+      +   .sm\\\\:prose-sm table {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(thead th) {
+      +   .sm\\\\:prose-sm thead th {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(thead th:first-child) {
+      +   .sm\\\\:prose-sm thead th:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(thead th:last-child) {
+      +   .sm\\\\:prose-sm thead th:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(tbody td) {
+      +   .sm\\\\:prose-sm tbody td {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(tbody td:first-child) {
+      +   .sm\\\\:prose-sm tbody td:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(tbody td:last-child) {
+      +   .sm\\\\:prose-sm tbody td:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> :first-child) {
+      +   .sm\\\\:prose-sm > :first-child {
+
+      ---
+
+      -   .sm\\\\:prose-sm :where(> :last-child) {
+      +   .sm\\\\:prose-sm > :last-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(p) {
+      +   .sm\\\\:prose-lg p {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where([class~='lead']) {
+      +   .sm\\\\:prose-lg [class~='lead'] {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(blockquote) {
+      +   .sm\\\\:prose-lg blockquote {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h1) {
+      +   .sm\\\\:prose-lg h1 {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h2) {
+      +   .sm\\\\:prose-lg h2 {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h3) {
+      +   .sm\\\\:prose-lg h3 {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h4) {
+      +   .sm\\\\:prose-lg h4 {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(img) {
+      +   .sm\\\\:prose-lg img {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(video) {
+      +   .sm\\\\:prose-lg video {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(figure) {
+      +   .sm\\\\:prose-lg figure {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(figure > *) {
+      +   .sm\\\\:prose-lg figure > * {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(figure figcaption) {
+      +   .sm\\\\:prose-lg figure figcaption {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(code) {
+      +   .sm\\\\:prose-lg code {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h2 code) {
+      +   .sm\\\\:prose-lg h2 code {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h3 code) {
+      +   .sm\\\\:prose-lg h3 code {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(pre) {
+      +   .sm\\\\:prose-lg pre {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ol) {
+      +   .sm\\\\:prose-lg ol {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ul) {
+      +   .sm\\\\:prose-lg ul {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(li) {
+      +   .sm\\\\:prose-lg li {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ol > li) {
+      +   .sm\\\\:prose-lg ol > li {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ol > li)::before {
+      +   .sm\\\\:prose-lg ol > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ul > li) {
+      +   .sm\\\\:prose-lg ul > li {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ul > li)::before {
+      +   .sm\\\\:prose-lg ul > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> ul > li p) {
+      +   .sm\\\\:prose-lg > ul > li p {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .sm\\\\:prose-lg > ul > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .sm\\\\:prose-lg > ul > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .sm\\\\:prose-lg > ol > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .sm\\\\:prose-lg > ol > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:prose-lg ul ul, .sm\\\\:prose-lg ul ol, .sm\\\\:prose-lg ol ul, .sm\\\\:prose-lg ol ol {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(hr) {
+      +   .sm\\\\:prose-lg hr {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(hr + *) {
+      +   .sm\\\\:prose-lg hr + * {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h2 + *) {
+      +   .sm\\\\:prose-lg h2 + * {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h3 + *) {
+      +   .sm\\\\:prose-lg h3 + * {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(h4 + *) {
+      +   .sm\\\\:prose-lg h4 + * {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(table) {
+      +   .sm\\\\:prose-lg table {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(thead th) {
+      +   .sm\\\\:prose-lg thead th {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(thead th:first-child) {
+      +   .sm\\\\:prose-lg thead th:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(thead th:last-child) {
+      +   .sm\\\\:prose-lg thead th:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(tbody td) {
+      +   .sm\\\\:prose-lg tbody td {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(tbody td:first-child) {
+      +   .sm\\\\:prose-lg tbody td:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(tbody td:last-child) {
+      +   .sm\\\\:prose-lg tbody td:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> :first-child) {
+      +   .sm\\\\:prose-lg > :first-child {
+
+      ---
+
+      -   .sm\\\\:prose-lg :where(> :last-child) {
+      +   .sm\\\\:prose-lg > :last-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(p) {
+      +   .sm\\\\:prose-xl p {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where([class~='lead']) {
+      +   .sm\\\\:prose-xl [class~='lead'] {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(blockquote) {
+      +   .sm\\\\:prose-xl blockquote {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h1) {
+      +   .sm\\\\:prose-xl h1 {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h2) {
+      +   .sm\\\\:prose-xl h2 {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h3) {
+      +   .sm\\\\:prose-xl h3 {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h4) {
+      +   .sm\\\\:prose-xl h4 {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(img) {
+      +   .sm\\\\:prose-xl img {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(video) {
+      +   .sm\\\\:prose-xl video {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(figure) {
+      +   .sm\\\\:prose-xl figure {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(figure > *) {
+      +   .sm\\\\:prose-xl figure > * {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(figure figcaption) {
+      +   .sm\\\\:prose-xl figure figcaption {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(code) {
+      +   .sm\\\\:prose-xl code {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h2 code) {
+      +   .sm\\\\:prose-xl h2 code {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h3 code) {
+      +   .sm\\\\:prose-xl h3 code {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(pre) {
+      +   .sm\\\\:prose-xl pre {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ol) {
+      +   .sm\\\\:prose-xl ol {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ul) {
+      +   .sm\\\\:prose-xl ul {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(li) {
+      +   .sm\\\\:prose-xl li {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ol > li) {
+      +   .sm\\\\:prose-xl ol > li {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ol > li)::before {
+      +   .sm\\\\:prose-xl ol > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ul > li) {
+      +   .sm\\\\:prose-xl ul > li {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ul > li)::before {
+      +   .sm\\\\:prose-xl ul > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> ul > li p) {
+      +   .sm\\\\:prose-xl > ul > li p {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:prose-xl > ul > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:prose-xl > ul > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:prose-xl > ol > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:prose-xl > ol > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:prose-xl ul ul, .sm\\\\:prose-xl ul ol, .sm\\\\:prose-xl ol ul, .sm\\\\:prose-xl ol ol {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(hr) {
+      +   .sm\\\\:prose-xl hr {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(hr + *) {
+      +   .sm\\\\:prose-xl hr + * {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h2 + *) {
+      +   .sm\\\\:prose-xl h2 + * {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h3 + *) {
+      +   .sm\\\\:prose-xl h3 + * {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(h4 + *) {
+      +   .sm\\\\:prose-xl h4 + * {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(table) {
+      +   .sm\\\\:prose-xl table {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(thead th) {
+      +   .sm\\\\:prose-xl thead th {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(thead th:first-child) {
+      +   .sm\\\\:prose-xl thead th:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(thead th:last-child) {
+      +   .sm\\\\:prose-xl thead th:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(tbody td) {
+      +   .sm\\\\:prose-xl tbody td {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(tbody td:first-child) {
+      +   .sm\\\\:prose-xl tbody td:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(tbody td:last-child) {
+      +   .sm\\\\:prose-xl tbody td:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> :first-child) {
+      +   .sm\\\\:prose-xl > :first-child {
+
+      ---
+
+      -   .sm\\\\:prose-xl :where(> :last-child) {
+      +   .sm\\\\:prose-xl > :last-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(p) {
+      +   .sm\\\\:prose-2xl p {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where([class~='lead']) {
+      +   .sm\\\\:prose-2xl [class~='lead'] {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(blockquote) {
+      +   .sm\\\\:prose-2xl blockquote {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h1) {
+      +   .sm\\\\:prose-2xl h1 {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h2) {
+      +   .sm\\\\:prose-2xl h2 {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h3) {
+      +   .sm\\\\:prose-2xl h3 {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h4) {
+      +   .sm\\\\:prose-2xl h4 {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(img) {
+      +   .sm\\\\:prose-2xl img {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(video) {
+      +   .sm\\\\:prose-2xl video {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(figure) {
+      +   .sm\\\\:prose-2xl figure {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(figure > *) {
+      +   .sm\\\\:prose-2xl figure > * {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(figure figcaption) {
+      +   .sm\\\\:prose-2xl figure figcaption {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(code) {
+      +   .sm\\\\:prose-2xl code {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h2 code) {
+      +   .sm\\\\:prose-2xl h2 code {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h3 code) {
+      +   .sm\\\\:prose-2xl h3 code {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(pre) {
+      +   .sm\\\\:prose-2xl pre {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ol) {
+      +   .sm\\\\:prose-2xl ol {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ul) {
+      +   .sm\\\\:prose-2xl ul {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(li) {
+      +   .sm\\\\:prose-2xl li {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ol > li) {
+      +   .sm\\\\:prose-2xl ol > li {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ol > li)::before {
+      +   .sm\\\\:prose-2xl ol > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ul > li) {
+      +   .sm\\\\:prose-2xl ul > li {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ul > li)::before {
+      +   .sm\\\\:prose-2xl ul > li::before {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> ul > li p) {
+      +   .sm\\\\:prose-2xl > ul > li p {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .sm\\\\:prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .sm\\\\:prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .sm\\\\:prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .sm\\\\:prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .sm\\\\:prose-2xl ul ul, .sm\\\\:prose-2xl ul ol, .sm\\\\:prose-2xl ol ul, .sm\\\\:prose-2xl ol ol {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(hr) {
+      +   .sm\\\\:prose-2xl hr {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(hr + *) {
+      +   .sm\\\\:prose-2xl hr + * {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h2 + *) {
+      +   .sm\\\\:prose-2xl h2 + * {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h3 + *) {
+      +   .sm\\\\:prose-2xl h3 + * {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(h4 + *) {
+      +   .sm\\\\:prose-2xl h4 + * {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(table) {
+      +   .sm\\\\:prose-2xl table {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(thead th) {
+      +   .sm\\\\:prose-2xl thead th {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(thead th:first-child) {
+      +   .sm\\\\:prose-2xl thead th:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(thead th:last-child) {
+      +   .sm\\\\:prose-2xl thead th:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(tbody td) {
+      +   .sm\\\\:prose-2xl tbody td {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .sm\\\\:prose-2xl tbody td:first-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .sm\\\\:prose-2xl tbody td:last-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> :first-child) {
+      +   .sm\\\\:prose-2xl > :first-child {
+
+      ---
+
+      -   .sm\\\\:prose-2xl :where(> :last-child) {
+      +   .sm\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   .sm\\\\:prose-red :where(a) {
+      +   .sm\\\\:prose-red a {
+
+      ---
+
+      -   .sm\\\\:prose-red :where(a code) {
+      +   .sm\\\\:prose-red a code {
+
+      ---
+
+      -   .sm\\\\:prose-yellow :where(a) {
+      +   .sm\\\\:prose-yellow a {
+
+      ---
+
+      -   .sm\\\\:prose-yellow :where(a code) {
+      +   .sm\\\\:prose-yellow a code {
+
+      ---
+
+      -   .sm\\\\:prose-green :where(a) {
+      +   .sm\\\\:prose-green a {
+
+      ---
+
+      -   .sm\\\\:prose-green :where(a code) {
+      +   .sm\\\\:prose-green a code {
+
+      ---
+
+      -   .sm\\\\:prose-blue :where(a) {
+      +   .sm\\\\:prose-blue a {
+
+      ---
+
+      -   .sm\\\\:prose-blue :where(a code) {
+      +   .sm\\\\:prose-blue a code {
+
+      ---
+
+      -   .sm\\\\:prose-indigo :where(a) {
+      +   .sm\\\\:prose-indigo a {
+
+      ---
+
+      -   .sm\\\\:prose-indigo :where(a code) {
+      +   .sm\\\\:prose-indigo a code {
+
+      ---
+
+      -   .sm\\\\:prose-purple :where(a) {
+      +   .sm\\\\:prose-purple a {
+
+      ---
+
+      -   .sm\\\\:prose-purple :where(a code) {
+      +   .sm\\\\:prose-purple a code {
+
+      ---
+
+      -   .sm\\\\:prose-pink :where(a) {
+      +   .sm\\\\:prose-pink a {
+
+      ---
+
+      -   .sm\\\\:prose-pink :where(a code) {
+      +   .sm\\\\:prose-pink a code {
+
+      ---
+
+      -   .md\\\\:prose :where([class~='lead']) {
+      +   .md\\\\:prose [class~='lead'] {
+
+      ---
+
+      -   .md\\\\:prose :where(a) {
+      +   .md\\\\:prose a {
+
+      ---
+
+      -   .md\\\\:prose :where(strong) {
+      +   .md\\\\:prose strong {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='A']) {
+      +   .md\\\\:prose ol[type='A'] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='a']) {
+      +   .md\\\\:prose ol[type='a'] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='A' s]) {
+      +   .md\\\\:prose ol[type='A' s] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='a' s]) {
+      +   .md\\\\:prose ol[type='a' s] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='I']) {
+      +   .md\\\\:prose ol[type='I'] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='i']) {
+      +   .md\\\\:prose ol[type='i'] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='I' s]) {
+      +   .md\\\\:prose ol[type='I' s] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='i' s]) {
+      +   .md\\\\:prose ol[type='i' s] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol[type='1']) {
+      +   .md\\\\:prose ol[type='1'] {
+
+      ---
+
+      -   .md\\\\:prose :where(ol > li) {
+      +   .md\\\\:prose ol > li {
+
+      ---
+
+      -   .md\\\\:prose :where(ol > li)::before {
+      +   .md\\\\:prose ol > li::before {
+
+      ---
+
+      -   .md\\\\:prose :where(ul > li) {
+      +   .md\\\\:prose ul > li {
+
+      ---
+
+      -   .md\\\\:prose :where(ul > li)::before {
+      +   .md\\\\:prose ul > li::before {
+
+      ---
+
+      -   .md\\\\:prose :where(hr) {
+      +   .md\\\\:prose hr {
+
+      ---
+
+      -   .md\\\\:prose :where(blockquote) {
+      +   .md\\\\:prose blockquote {
+
+      ---
+
+      -   .md\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .md\\\\:prose blockquote p:first-of-type::before {
+
+      ---
+
+      -   .md\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .md\\\\:prose blockquote p:last-of-type::after {
+
+      ---
+
+      -   .md\\\\:prose :where(h1) {
+      +   .md\\\\:prose h1 {
+
+      ---
+
+      -   .md\\\\:prose :where(h1 strong) {
+      +   .md\\\\:prose h1 strong {
+
+      ---
+
+      -   .md\\\\:prose :where(h2) {
+      +   .md\\\\:prose h2 {
+
+      ---
+
+      -   .md\\\\:prose :where(h2 strong) {
+      +   .md\\\\:prose h2 strong {
+
+      ---
+
+      -   .md\\\\:prose :where(h3) {
+      +   .md\\\\:prose h3 {
+
+      ---
+
+      -   .md\\\\:prose :where(h3 strong) {
+      +   .md\\\\:prose h3 strong {
+
+      ---
+
+      -   .md\\\\:prose :where(h4) {
+      +   .md\\\\:prose h4 {
+
+      ---
+
+      -   .md\\\\:prose :where(h4 strong) {
+      +   .md\\\\:prose h4 strong {
+
+      ---
+
+      -   .md\\\\:prose :where(figure figcaption) {
+      +   .md\\\\:prose figure figcaption {
+
+      ---
+
+      -   .md\\\\:prose :where(code) {
+      +   .md\\\\:prose code {
+
+      ---
+
+      -   .md\\\\:prose :where(code)::before {
+      +   .md\\\\:prose code::before {
+
+      ---
+
+      -   .md\\\\:prose :where(code)::after {
+      +   .md\\\\:prose code::after {
+
+      ---
+
+      -   .md\\\\:prose :where(a code) {
+      +   .md\\\\:prose a code {
+
+      ---
+
+      -   .md\\\\:prose :where(pre) {
+      +   .md\\\\:prose pre {
+
+      ---
+
+      -   .md\\\\:prose :where(pre code) {
+      +   .md\\\\:prose pre code {
+
+      ---
+
+      -   .md\\\\:prose :where(pre code)::before {
+      +   .md\\\\:prose pre code::before {
+
+      ---
+
+      -   .md\\\\:prose :where(pre code)::after {
+      +   .md\\\\:prose pre code::after {
+
+      ---
+
+      -   .md\\\\:prose :where(table) {
+      +   .md\\\\:prose table {
+
+      ---
+
+      -   .md\\\\:prose :where(thead) {
+      +   .md\\\\:prose thead {
+
+      ---
+
+      -   .md\\\\:prose :where(thead th) {
+      +   .md\\\\:prose thead th {
+
+      ---
+
+      -   .md\\\\:prose :where(tbody tr) {
+      +   .md\\\\:prose tbody tr {
+
+      ---
+
+      -   .md\\\\:prose :where(tbody tr:last-child) {
+      +   .md\\\\:prose tbody tr:last-child {
+
+      ---
+
+      -   .md\\\\:prose :where(tbody td) {
+      +   .md\\\\:prose tbody td {
+
+      ---
+
+      -   .md\\\\:prose :where(p) {
+      +   .md\\\\:prose p {
+
+      ---
+
+      -   .md\\\\:prose :where(img) {
+      +   .md\\\\:prose img {
+
+      ---
+
+      -   .md\\\\:prose :where(video) {
+      +   .md\\\\:prose video {
+
+      ---
+
+      -   .md\\\\:prose :where(figure) {
+      +   .md\\\\:prose figure {
+
+      ---
+
+      -   .md\\\\:prose :where(figure > *) {
+      +   .md\\\\:prose figure > * {
+
+      ---
+
+      -   .md\\\\:prose :where(h2 code) {
+      +   .md\\\\:prose h2 code {
+
+      ---
+
+      -   .md\\\\:prose :where(h3 code) {
+      +   .md\\\\:prose h3 code {
+
+      ---
+
+      -   .md\\\\:prose :where(ol) {
+      +   .md\\\\:prose ol {
+
+      ---
+
+      -   .md\\\\:prose :where(ul) {
+      +   .md\\\\:prose ul {
+
+      ---
+
+      -   .md\\\\:prose :where(li) {
+      +   .md\\\\:prose li {
+
+      ---
+
+      -   .md\\\\:prose :where(> ul > li p) {
+      +   .md\\\\:prose > ul > li p {
+
+      ---
+
+      -   .md\\\\:prose :where(> ul > li > *:first-child) {
+      +   .md\\\\:prose > ul > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose :where(> ul > li > *:last-child) {
+      +   .md\\\\:prose > ul > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose :where(> ol > li > *:first-child) {
+      +   .md\\\\:prose > ol > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose :where(> ol > li > *:last-child) {
+      +   .md\\\\:prose > ol > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:prose ul ul, .md\\\\:prose ul ol, .md\\\\:prose ol ul, .md\\\\:prose ol ol {
+
+      ---
+
+      -   .md\\\\:prose :where(hr + *) {
+      +   .md\\\\:prose hr + * {
+
+      ---
+
+      -   .md\\\\:prose :where(h2 + *) {
+      +   .md\\\\:prose h2 + * {
+
+      ---
+
+      -   .md\\\\:prose :where(h3 + *) {
+      +   .md\\\\:prose h3 + * {
+
+      ---
+
+      -   .md\\\\:prose :where(h4 + *) {
+      +   .md\\\\:prose h4 + * {
+
+      ---
+
+      -   .md\\\\:prose :where(thead th:first-child) {
+      +   .md\\\\:prose thead th:first-child {
+
+      ---
+
+      -   .md\\\\:prose :where(thead th:last-child) {
+      +   .md\\\\:prose thead th:last-child {
+
+      ---
+
+      -   .md\\\\:prose :where(tbody td:first-child) {
+      +   .md\\\\:prose tbody td:first-child {
+
+      ---
+
+      -   .md\\\\:prose :where(tbody td:last-child) {
+      +   .md\\\\:prose tbody td:last-child {
+
+      ---
+
+      -   .md\\\\:prose :where(> :first-child) {
+      +   .md\\\\:prose > :first-child {
+
+      ---
+
+      -   .md\\\\:prose :where(> :last-child) {
+      +   .md\\\\:prose > :last-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(p) {
+      +   .md\\\\:prose-sm p {
+
+      ---
+
+      -   .md\\\\:prose-sm :where([class~='lead']) {
+      +   .md\\\\:prose-sm [class~='lead'] {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(blockquote) {
+      +   .md\\\\:prose-sm blockquote {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h1) {
+      +   .md\\\\:prose-sm h1 {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h2) {
+      +   .md\\\\:prose-sm h2 {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h3) {
+      +   .md\\\\:prose-sm h3 {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h4) {
+      +   .md\\\\:prose-sm h4 {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(img) {
+      +   .md\\\\:prose-sm img {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(video) {
+      +   .md\\\\:prose-sm video {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(figure) {
+      +   .md\\\\:prose-sm figure {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(figure > *) {
+      +   .md\\\\:prose-sm figure > * {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(figure figcaption) {
+      +   .md\\\\:prose-sm figure figcaption {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(code) {
+      +   .md\\\\:prose-sm code {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h2 code) {
+      +   .md\\\\:prose-sm h2 code {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h3 code) {
+      +   .md\\\\:prose-sm h3 code {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(pre) {
+      +   .md\\\\:prose-sm pre {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ol) {
+      +   .md\\\\:prose-sm ol {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ul) {
+      +   .md\\\\:prose-sm ul {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(li) {
+      +   .md\\\\:prose-sm li {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ol > li) {
+      +   .md\\\\:prose-sm ol > li {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ol > li)::before {
+      +   .md\\\\:prose-sm ol > li::before {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ul > li) {
+      +   .md\\\\:prose-sm ul > li {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ul > li)::before {
+      +   .md\\\\:prose-sm ul > li::before {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> ul > li p) {
+      +   .md\\\\:prose-sm > ul > li p {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .md\\\\:prose-sm > ul > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .md\\\\:prose-sm > ul > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .md\\\\:prose-sm > ol > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .md\\\\:prose-sm > ol > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:prose-sm ul ul, .md\\\\:prose-sm ul ol, .md\\\\:prose-sm ol ul, .md\\\\:prose-sm ol ol {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(hr) {
+      +   .md\\\\:prose-sm hr {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(hr + *) {
+      +   .md\\\\:prose-sm hr + * {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h2 + *) {
+      +   .md\\\\:prose-sm h2 + * {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h3 + *) {
+      +   .md\\\\:prose-sm h3 + * {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(h4 + *) {
+      +   .md\\\\:prose-sm h4 + * {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(table) {
+      +   .md\\\\:prose-sm table {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(thead th) {
+      +   .md\\\\:prose-sm thead th {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(thead th:first-child) {
+      +   .md\\\\:prose-sm thead th:first-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(thead th:last-child) {
+      +   .md\\\\:prose-sm thead th:last-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(tbody td) {
+      +   .md\\\\:prose-sm tbody td {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(tbody td:first-child) {
+      +   .md\\\\:prose-sm tbody td:first-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(tbody td:last-child) {
+      +   .md\\\\:prose-sm tbody td:last-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> :first-child) {
+      +   .md\\\\:prose-sm > :first-child {
+
+      ---
+
+      -   .md\\\\:prose-sm :where(> :last-child) {
+      +   .md\\\\:prose-sm > :last-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(p) {
+      +   .md\\\\:prose-lg p {
+
+      ---
+
+      -   .md\\\\:prose-lg :where([class~='lead']) {
+      +   .md\\\\:prose-lg [class~='lead'] {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(blockquote) {
+      +   .md\\\\:prose-lg blockquote {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h1) {
+      +   .md\\\\:prose-lg h1 {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h2) {
+      +   .md\\\\:prose-lg h2 {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h3) {
+      +   .md\\\\:prose-lg h3 {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h4) {
+      +   .md\\\\:prose-lg h4 {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(img) {
+      +   .md\\\\:prose-lg img {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(video) {
+      +   .md\\\\:prose-lg video {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(figure) {
+      +   .md\\\\:prose-lg figure {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(figure > *) {
+      +   .md\\\\:prose-lg figure > * {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(figure figcaption) {
+      +   .md\\\\:prose-lg figure figcaption {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(code) {
+      +   .md\\\\:prose-lg code {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h2 code) {
+      +   .md\\\\:prose-lg h2 code {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h3 code) {
+      +   .md\\\\:prose-lg h3 code {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(pre) {
+      +   .md\\\\:prose-lg pre {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ol) {
+      +   .md\\\\:prose-lg ol {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ul) {
+      +   .md\\\\:prose-lg ul {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(li) {
+      +   .md\\\\:prose-lg li {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ol > li) {
+      +   .md\\\\:prose-lg ol > li {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ol > li)::before {
+      +   .md\\\\:prose-lg ol > li::before {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ul > li) {
+      +   .md\\\\:prose-lg ul > li {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ul > li)::before {
+      +   .md\\\\:prose-lg ul > li::before {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> ul > li p) {
+      +   .md\\\\:prose-lg > ul > li p {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .md\\\\:prose-lg > ul > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .md\\\\:prose-lg > ul > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .md\\\\:prose-lg > ol > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .md\\\\:prose-lg > ol > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:prose-lg ul ul, .md\\\\:prose-lg ul ol, .md\\\\:prose-lg ol ul, .md\\\\:prose-lg ol ol {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(hr) {
+      +   .md\\\\:prose-lg hr {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(hr + *) {
+      +   .md\\\\:prose-lg hr + * {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h2 + *) {
+      +   .md\\\\:prose-lg h2 + * {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h3 + *) {
+      +   .md\\\\:prose-lg h3 + * {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(h4 + *) {
+      +   .md\\\\:prose-lg h4 + * {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(table) {
+      +   .md\\\\:prose-lg table {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(thead th) {
+      +   .md\\\\:prose-lg thead th {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(thead th:first-child) {
+      +   .md\\\\:prose-lg thead th:first-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(thead th:last-child) {
+      +   .md\\\\:prose-lg thead th:last-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(tbody td) {
+      +   .md\\\\:prose-lg tbody td {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(tbody td:first-child) {
+      +   .md\\\\:prose-lg tbody td:first-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(tbody td:last-child) {
+      +   .md\\\\:prose-lg tbody td:last-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> :first-child) {
+      +   .md\\\\:prose-lg > :first-child {
+
+      ---
+
+      -   .md\\\\:prose-lg :where(> :last-child) {
+      +   .md\\\\:prose-lg > :last-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(p) {
+      +   .md\\\\:prose-xl p {
+
+      ---
+
+      -   .md\\\\:prose-xl :where([class~='lead']) {
+      +   .md\\\\:prose-xl [class~='lead'] {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(blockquote) {
+      +   .md\\\\:prose-xl blockquote {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h1) {
+      +   .md\\\\:prose-xl h1 {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h2) {
+      +   .md\\\\:prose-xl h2 {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h3) {
+      +   .md\\\\:prose-xl h3 {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h4) {
+      +   .md\\\\:prose-xl h4 {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(img) {
+      +   .md\\\\:prose-xl img {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(video) {
+      +   .md\\\\:prose-xl video {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(figure) {
+      +   .md\\\\:prose-xl figure {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(figure > *) {
+      +   .md\\\\:prose-xl figure > * {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(figure figcaption) {
+      +   .md\\\\:prose-xl figure figcaption {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(code) {
+      +   .md\\\\:prose-xl code {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h2 code) {
+      +   .md\\\\:prose-xl h2 code {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h3 code) {
+      +   .md\\\\:prose-xl h3 code {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(pre) {
+      +   .md\\\\:prose-xl pre {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ol) {
+      +   .md\\\\:prose-xl ol {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ul) {
+      +   .md\\\\:prose-xl ul {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(li) {
+      +   .md\\\\:prose-xl li {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ol > li) {
+      +   .md\\\\:prose-xl ol > li {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ol > li)::before {
+      +   .md\\\\:prose-xl ol > li::before {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ul > li) {
+      +   .md\\\\:prose-xl ul > li {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ul > li)::before {
+      +   .md\\\\:prose-xl ul > li::before {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> ul > li p) {
+      +   .md\\\\:prose-xl > ul > li p {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:prose-xl > ul > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:prose-xl > ul > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:prose-xl > ol > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:prose-xl > ol > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:prose-xl ul ul, .md\\\\:prose-xl ul ol, .md\\\\:prose-xl ol ul, .md\\\\:prose-xl ol ol {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(hr) {
+      +   .md\\\\:prose-xl hr {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(hr + *) {
+      +   .md\\\\:prose-xl hr + * {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h2 + *) {
+      +   .md\\\\:prose-xl h2 + * {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h3 + *) {
+      +   .md\\\\:prose-xl h3 + * {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(h4 + *) {
+      +   .md\\\\:prose-xl h4 + * {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(table) {
+      +   .md\\\\:prose-xl table {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(thead th) {
+      +   .md\\\\:prose-xl thead th {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(thead th:first-child) {
+      +   .md\\\\:prose-xl thead th:first-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(thead th:last-child) {
+      +   .md\\\\:prose-xl thead th:last-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(tbody td) {
+      +   .md\\\\:prose-xl tbody td {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(tbody td:first-child) {
+      +   .md\\\\:prose-xl tbody td:first-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(tbody td:last-child) {
+      +   .md\\\\:prose-xl tbody td:last-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> :first-child) {
+      +   .md\\\\:prose-xl > :first-child {
+
+      ---
+
+      -   .md\\\\:prose-xl :where(> :last-child) {
+      +   .md\\\\:prose-xl > :last-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(p) {
+      +   .md\\\\:prose-2xl p {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where([class~='lead']) {
+      +   .md\\\\:prose-2xl [class~='lead'] {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(blockquote) {
+      +   .md\\\\:prose-2xl blockquote {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h1) {
+      +   .md\\\\:prose-2xl h1 {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h2) {
+      +   .md\\\\:prose-2xl h2 {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h3) {
+      +   .md\\\\:prose-2xl h3 {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h4) {
+      +   .md\\\\:prose-2xl h4 {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(img) {
+      +   .md\\\\:prose-2xl img {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(video) {
+      +   .md\\\\:prose-2xl video {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(figure) {
+      +   .md\\\\:prose-2xl figure {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(figure > *) {
+      +   .md\\\\:prose-2xl figure > * {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(figure figcaption) {
+      +   .md\\\\:prose-2xl figure figcaption {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(code) {
+      +   .md\\\\:prose-2xl code {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h2 code) {
+      +   .md\\\\:prose-2xl h2 code {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h3 code) {
+      +   .md\\\\:prose-2xl h3 code {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(pre) {
+      +   .md\\\\:prose-2xl pre {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ol) {
+      +   .md\\\\:prose-2xl ol {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ul) {
+      +   .md\\\\:prose-2xl ul {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(li) {
+      +   .md\\\\:prose-2xl li {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ol > li) {
+      +   .md\\\\:prose-2xl ol > li {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ol > li)::before {
+      +   .md\\\\:prose-2xl ol > li::before {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ul > li) {
+      +   .md\\\\:prose-2xl ul > li {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ul > li)::before {
+      +   .md\\\\:prose-2xl ul > li::before {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> ul > li p) {
+      +   .md\\\\:prose-2xl > ul > li p {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .md\\\\:prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .md\\\\:prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .md\\\\:prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .md\\\\:prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .md\\\\:prose-2xl ul ul, .md\\\\:prose-2xl ul ol, .md\\\\:prose-2xl ol ul, .md\\\\:prose-2xl ol ol {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(hr) {
+      +   .md\\\\:prose-2xl hr {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(hr + *) {
+      +   .md\\\\:prose-2xl hr + * {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h2 + *) {
+      +   .md\\\\:prose-2xl h2 + * {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h3 + *) {
+      +   .md\\\\:prose-2xl h3 + * {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(h4 + *) {
+      +   .md\\\\:prose-2xl h4 + * {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(table) {
+      +   .md\\\\:prose-2xl table {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(thead th) {
+      +   .md\\\\:prose-2xl thead th {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(thead th:first-child) {
+      +   .md\\\\:prose-2xl thead th:first-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(thead th:last-child) {
+      +   .md\\\\:prose-2xl thead th:last-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(tbody td) {
+      +   .md\\\\:prose-2xl tbody td {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .md\\\\:prose-2xl tbody td:first-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .md\\\\:prose-2xl tbody td:last-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> :first-child) {
+      +   .md\\\\:prose-2xl > :first-child {
+
+      ---
+
+      -   .md\\\\:prose-2xl :where(> :last-child) {
+      +   .md\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   .md\\\\:prose-red :where(a) {
+      +   .md\\\\:prose-red a {
+
+      ---
+
+      -   .md\\\\:prose-red :where(a code) {
+      +   .md\\\\:prose-red a code {
+
+      ---
+
+      -   .md\\\\:prose-yellow :where(a) {
+      +   .md\\\\:prose-yellow a {
+
+      ---
+
+      -   .md\\\\:prose-yellow :where(a code) {
+      +   .md\\\\:prose-yellow a code {
+
+      ---
+
+      -   .md\\\\:prose-green :where(a) {
+      +   .md\\\\:prose-green a {
+
+      ---
+
+      -   .md\\\\:prose-green :where(a code) {
+      +   .md\\\\:prose-green a code {
+
+      ---
+
+      -   .md\\\\:prose-blue :where(a) {
+      +   .md\\\\:prose-blue a {
+
+      ---
+
+      -   .md\\\\:prose-blue :where(a code) {
+      +   .md\\\\:prose-blue a code {
+
+      ---
+
+      -   .md\\\\:prose-indigo :where(a) {
+      +   .md\\\\:prose-indigo a {
+
+      ---
+
+      -   .md\\\\:prose-indigo :where(a code) {
+      +   .md\\\\:prose-indigo a code {
+
+      ---
+
+      -   .md\\\\:prose-purple :where(a) {
+      +   .md\\\\:prose-purple a {
+
+      ---
+
+      -   .md\\\\:prose-purple :where(a code) {
+      +   .md\\\\:prose-purple a code {
+
+      ---
+
+      -   .md\\\\:prose-pink :where(a) {
+      +   .md\\\\:prose-pink a {
+
+      ---
+
+      -   .md\\\\:prose-pink :where(a code) {
+      +   .md\\\\:prose-pink a code {
+
+      ---
+
+      -   .lg\\\\:prose :where([class~='lead']) {
+      +   .lg\\\\:prose [class~='lead'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(a) {
+      +   .lg\\\\:prose a {
+
+      ---
+
+      -   .lg\\\\:prose :where(strong) {
+      +   .lg\\\\:prose strong {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='A']) {
+      +   .lg\\\\:prose ol[type='A'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='a']) {
+      +   .lg\\\\:prose ol[type='a'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='A' s]) {
+      +   .lg\\\\:prose ol[type='A' s] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='a' s]) {
+      +   .lg\\\\:prose ol[type='a' s] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='I']) {
+      +   .lg\\\\:prose ol[type='I'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='i']) {
+      +   .lg\\\\:prose ol[type='i'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='I' s]) {
+      +   .lg\\\\:prose ol[type='I' s] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='i' s]) {
+      +   .lg\\\\:prose ol[type='i' s] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol[type='1']) {
+      +   .lg\\\\:prose ol[type='1'] {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol > li) {
+      +   .lg\\\\:prose ol > li {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol > li)::before {
+      +   .lg\\\\:prose ol > li::before {
+
+      ---
+
+      -   .lg\\\\:prose :where(ul > li) {
+      +   .lg\\\\:prose ul > li {
+
+      ---
+
+      -   .lg\\\\:prose :where(ul > li)::before {
+      +   .lg\\\\:prose ul > li::before {
+
+      ---
+
+      -   .lg\\\\:prose :where(hr) {
+      +   .lg\\\\:prose hr {
+
+      ---
+
+      -   .lg\\\\:prose :where(blockquote) {
+      +   .lg\\\\:prose blockquote {
+
+      ---
+
+      -   .lg\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .lg\\\\:prose blockquote p:first-of-type::before {
+
+      ---
+
+      -   .lg\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .lg\\\\:prose blockquote p:last-of-type::after {
+
+      ---
+
+      -   .lg\\\\:prose :where(h1) {
+      +   .lg\\\\:prose h1 {
+
+      ---
+
+      -   .lg\\\\:prose :where(h1 strong) {
+      +   .lg\\\\:prose h1 strong {
+
+      ---
+
+      -   .lg\\\\:prose :where(h2) {
+      +   .lg\\\\:prose h2 {
+
+      ---
+
+      -   .lg\\\\:prose :where(h2 strong) {
+      +   .lg\\\\:prose h2 strong {
+
+      ---
+
+      -   .lg\\\\:prose :where(h3) {
+      +   .lg\\\\:prose h3 {
+
+      ---
+
+      -   .lg\\\\:prose :where(h3 strong) {
+      +   .lg\\\\:prose h3 strong {
+
+      ---
+
+      -   .lg\\\\:prose :where(h4) {
+      +   .lg\\\\:prose h4 {
+
+      ---
+
+      -   .lg\\\\:prose :where(h4 strong) {
+      +   .lg\\\\:prose h4 strong {
+
+      ---
+
+      -   .lg\\\\:prose :where(figure figcaption) {
+      +   .lg\\\\:prose figure figcaption {
+
+      ---
+
+      -   .lg\\\\:prose :where(code) {
+      +   .lg\\\\:prose code {
+
+      ---
+
+      -   .lg\\\\:prose :where(code)::before {
+      +   .lg\\\\:prose code::before {
+
+      ---
+
+      -   .lg\\\\:prose :where(code)::after {
+      +   .lg\\\\:prose code::after {
+
+      ---
+
+      -   .lg\\\\:prose :where(a code) {
+      +   .lg\\\\:prose a code {
+
+      ---
+
+      -   .lg\\\\:prose :where(pre) {
+      +   .lg\\\\:prose pre {
+
+      ---
+
+      -   .lg\\\\:prose :where(pre code) {
+      +   .lg\\\\:prose pre code {
+
+      ---
+
+      -   .lg\\\\:prose :where(pre code)::before {
+      +   .lg\\\\:prose pre code::before {
+
+      ---
+
+      -   .lg\\\\:prose :where(pre code)::after {
+      +   .lg\\\\:prose pre code::after {
+
+      ---
+
+      -   .lg\\\\:prose :where(table) {
+      +   .lg\\\\:prose table {
+
+      ---
+
+      -   .lg\\\\:prose :where(thead) {
+      +   .lg\\\\:prose thead {
+
+      ---
+
+      -   .lg\\\\:prose :where(thead th) {
+      +   .lg\\\\:prose thead th {
+
+      ---
+
+      -   .lg\\\\:prose :where(tbody tr) {
+      +   .lg\\\\:prose tbody tr {
+
+      ---
+
+      -   .lg\\\\:prose :where(tbody tr:last-child) {
+      +   .lg\\\\:prose tbody tr:last-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(tbody td) {
+      +   .lg\\\\:prose tbody td {
+
+      ---
+
+      -   .lg\\\\:prose :where(p) {
+      +   .lg\\\\:prose p {
+
+      ---
+
+      -   .lg\\\\:prose :where(img) {
+      +   .lg\\\\:prose img {
+
+      ---
+
+      -   .lg\\\\:prose :where(video) {
+      +   .lg\\\\:prose video {
+
+      ---
+
+      -   .lg\\\\:prose :where(figure) {
+      +   .lg\\\\:prose figure {
+
+      ---
+
+      -   .lg\\\\:prose :where(figure > *) {
+      +   .lg\\\\:prose figure > * {
+
+      ---
+
+      -   .lg\\\\:prose :where(h2 code) {
+      +   .lg\\\\:prose h2 code {
+
+      ---
+
+      -   .lg\\\\:prose :where(h3 code) {
+      +   .lg\\\\:prose h3 code {
+
+      ---
+
+      -   .lg\\\\:prose :where(ol) {
+      +   .lg\\\\:prose ol {
+
+      ---
+
+      -   .lg\\\\:prose :where(ul) {
+      +   .lg\\\\:prose ul {
+
+      ---
+
+      -   .lg\\\\:prose :where(li) {
+      +   .lg\\\\:prose li {
+
+      ---
+
+      -   .lg\\\\:prose :where(> ul > li p) {
+      +   .lg\\\\:prose > ul > li p {
+
+      ---
+
+      -   .lg\\\\:prose :where(> ul > li > *:first-child) {
+      +   .lg\\\\:prose > ul > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(> ul > li > *:last-child) {
+      +   .lg\\\\:prose > ul > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(> ol > li > *:first-child) {
+      +   .lg\\\\:prose > ol > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(> ol > li > *:last-child) {
+      +   .lg\\\\:prose > ol > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:prose ul ul, .lg\\\\:prose ul ol, .lg\\\\:prose ol ul, .lg\\\\:prose ol ol {
+
+      ---
+
+      -   .lg\\\\:prose :where(hr + *) {
+      +   .lg\\\\:prose hr + * {
+
+      ---
+
+      -   .lg\\\\:prose :where(h2 + *) {
+      +   .lg\\\\:prose h2 + * {
+
+      ---
+
+      -   .lg\\\\:prose :where(h3 + *) {
+      +   .lg\\\\:prose h3 + * {
+
+      ---
+
+      -   .lg\\\\:prose :where(h4 + *) {
+      +   .lg\\\\:prose h4 + * {
+
+      ---
+
+      -   .lg\\\\:prose :where(thead th:first-child) {
+      +   .lg\\\\:prose thead th:first-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(thead th:last-child) {
+      +   .lg\\\\:prose thead th:last-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(tbody td:first-child) {
+      +   .lg\\\\:prose tbody td:first-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(tbody td:last-child) {
+      +   .lg\\\\:prose tbody td:last-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(> :first-child) {
+      +   .lg\\\\:prose > :first-child {
+
+      ---
+
+      -   .lg\\\\:prose :where(> :last-child) {
+      +   .lg\\\\:prose > :last-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(p) {
+      +   .lg\\\\:prose-sm p {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where([class~='lead']) {
+      +   .lg\\\\:prose-sm [class~='lead'] {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(blockquote) {
+      +   .lg\\\\:prose-sm blockquote {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h1) {
+      +   .lg\\\\:prose-sm h1 {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h2) {
+      +   .lg\\\\:prose-sm h2 {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h3) {
+      +   .lg\\\\:prose-sm h3 {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h4) {
+      +   .lg\\\\:prose-sm h4 {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(img) {
+      +   .lg\\\\:prose-sm img {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(video) {
+      +   .lg\\\\:prose-sm video {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(figure) {
+      +   .lg\\\\:prose-sm figure {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(figure > *) {
+      +   .lg\\\\:prose-sm figure > * {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(figure figcaption) {
+      +   .lg\\\\:prose-sm figure figcaption {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(code) {
+      +   .lg\\\\:prose-sm code {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h2 code) {
+      +   .lg\\\\:prose-sm h2 code {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h3 code) {
+      +   .lg\\\\:prose-sm h3 code {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(pre) {
+      +   .lg\\\\:prose-sm pre {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ol) {
+      +   .lg\\\\:prose-sm ol {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ul) {
+      +   .lg\\\\:prose-sm ul {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(li) {
+      +   .lg\\\\:prose-sm li {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ol > li) {
+      +   .lg\\\\:prose-sm ol > li {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ol > li)::before {
+      +   .lg\\\\:prose-sm ol > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ul > li) {
+      +   .lg\\\\:prose-sm ul > li {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ul > li)::before {
+      +   .lg\\\\:prose-sm ul > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> ul > li p) {
+      +   .lg\\\\:prose-sm > ul > li p {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .lg\\\\:prose-sm > ul > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .lg\\\\:prose-sm > ul > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .lg\\\\:prose-sm > ol > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .lg\\\\:prose-sm > ol > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:prose-sm ul ul, .lg\\\\:prose-sm ul ol, .lg\\\\:prose-sm ol ul, .lg\\\\:prose-sm ol ol {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(hr) {
+      +   .lg\\\\:prose-sm hr {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(hr + *) {
+      +   .lg\\\\:prose-sm hr + * {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h2 + *) {
+      +   .lg\\\\:prose-sm h2 + * {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h3 + *) {
+      +   .lg\\\\:prose-sm h3 + * {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(h4 + *) {
+      +   .lg\\\\:prose-sm h4 + * {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(table) {
+      +   .lg\\\\:prose-sm table {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(thead th) {
+      +   .lg\\\\:prose-sm thead th {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(thead th:first-child) {
+      +   .lg\\\\:prose-sm thead th:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(thead th:last-child) {
+      +   .lg\\\\:prose-sm thead th:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(tbody td) {
+      +   .lg\\\\:prose-sm tbody td {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(tbody td:first-child) {
+      +   .lg\\\\:prose-sm tbody td:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(tbody td:last-child) {
+      +   .lg\\\\:prose-sm tbody td:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> :first-child) {
+      +   .lg\\\\:prose-sm > :first-child {
+
+      ---
+
+      -   .lg\\\\:prose-sm :where(> :last-child) {
+      +   .lg\\\\:prose-sm > :last-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(p) {
+      +   .lg\\\\:prose-lg p {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where([class~='lead']) {
+      +   .lg\\\\:prose-lg [class~='lead'] {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(blockquote) {
+      +   .lg\\\\:prose-lg blockquote {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h1) {
+      +   .lg\\\\:prose-lg h1 {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h2) {
+      +   .lg\\\\:prose-lg h2 {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h3) {
+      +   .lg\\\\:prose-lg h3 {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h4) {
+      +   .lg\\\\:prose-lg h4 {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(img) {
+      +   .lg\\\\:prose-lg img {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(video) {
+      +   .lg\\\\:prose-lg video {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(figure) {
+      +   .lg\\\\:prose-lg figure {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(figure > *) {
+      +   .lg\\\\:prose-lg figure > * {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(figure figcaption) {
+      +   .lg\\\\:prose-lg figure figcaption {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(code) {
+      +   .lg\\\\:prose-lg code {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h2 code) {
+      +   .lg\\\\:prose-lg h2 code {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h3 code) {
+      +   .lg\\\\:prose-lg h3 code {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(pre) {
+      +   .lg\\\\:prose-lg pre {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ol) {
+      +   .lg\\\\:prose-lg ol {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ul) {
+      +   .lg\\\\:prose-lg ul {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(li) {
+      +   .lg\\\\:prose-lg li {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ol > li) {
+      +   .lg\\\\:prose-lg ol > li {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ol > li)::before {
+      +   .lg\\\\:prose-lg ol > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ul > li) {
+      +   .lg\\\\:prose-lg ul > li {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ul > li)::before {
+      +   .lg\\\\:prose-lg ul > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> ul > li p) {
+      +   .lg\\\\:prose-lg > ul > li p {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .lg\\\\:prose-lg > ul > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .lg\\\\:prose-lg > ul > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .lg\\\\:prose-lg > ol > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .lg\\\\:prose-lg > ol > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:prose-lg ul ul, .lg\\\\:prose-lg ul ol, .lg\\\\:prose-lg ol ul, .lg\\\\:prose-lg ol ol {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(hr) {
+      +   .lg\\\\:prose-lg hr {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(hr + *) {
+      +   .lg\\\\:prose-lg hr + * {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h2 + *) {
+      +   .lg\\\\:prose-lg h2 + * {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h3 + *) {
+      +   .lg\\\\:prose-lg h3 + * {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(h4 + *) {
+      +   .lg\\\\:prose-lg h4 + * {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(table) {
+      +   .lg\\\\:prose-lg table {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(thead th) {
+      +   .lg\\\\:prose-lg thead th {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(thead th:first-child) {
+      +   .lg\\\\:prose-lg thead th:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(thead th:last-child) {
+      +   .lg\\\\:prose-lg thead th:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(tbody td) {
+      +   .lg\\\\:prose-lg tbody td {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(tbody td:first-child) {
+      +   .lg\\\\:prose-lg tbody td:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(tbody td:last-child) {
+      +   .lg\\\\:prose-lg tbody td:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> :first-child) {
+      +   .lg\\\\:prose-lg > :first-child {
+
+      ---
+
+      -   .lg\\\\:prose-lg :where(> :last-child) {
+      +   .lg\\\\:prose-lg > :last-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(p) {
+      +   .lg\\\\:prose-xl p {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where([class~='lead']) {
+      +   .lg\\\\:prose-xl [class~='lead'] {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(blockquote) {
+      +   .lg\\\\:prose-xl blockquote {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h1) {
+      +   .lg\\\\:prose-xl h1 {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h2) {
+      +   .lg\\\\:prose-xl h2 {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h3) {
+      +   .lg\\\\:prose-xl h3 {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h4) {
+      +   .lg\\\\:prose-xl h4 {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(img) {
+      +   .lg\\\\:prose-xl img {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(video) {
+      +   .lg\\\\:prose-xl video {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(figure) {
+      +   .lg\\\\:prose-xl figure {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(figure > *) {
+      +   .lg\\\\:prose-xl figure > * {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(figure figcaption) {
+      +   .lg\\\\:prose-xl figure figcaption {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(code) {
+      +   .lg\\\\:prose-xl code {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h2 code) {
+      +   .lg\\\\:prose-xl h2 code {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h3 code) {
+      +   .lg\\\\:prose-xl h3 code {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(pre) {
+      +   .lg\\\\:prose-xl pre {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ol) {
+      +   .lg\\\\:prose-xl ol {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ul) {
+      +   .lg\\\\:prose-xl ul {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(li) {
+      +   .lg\\\\:prose-xl li {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ol > li) {
+      +   .lg\\\\:prose-xl ol > li {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ol > li)::before {
+      +   .lg\\\\:prose-xl ol > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ul > li) {
+      +   .lg\\\\:prose-xl ul > li {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ul > li)::before {
+      +   .lg\\\\:prose-xl ul > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> ul > li p) {
+      +   .lg\\\\:prose-xl > ul > li p {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:prose-xl > ul > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:prose-xl > ul > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:prose-xl > ol > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:prose-xl > ol > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:prose-xl ul ul, .lg\\\\:prose-xl ul ol, .lg\\\\:prose-xl ol ul, .lg\\\\:prose-xl ol ol {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(hr) {
+      +   .lg\\\\:prose-xl hr {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(hr + *) {
+      +   .lg\\\\:prose-xl hr + * {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h2 + *) {
+      +   .lg\\\\:prose-xl h2 + * {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h3 + *) {
+      +   .lg\\\\:prose-xl h3 + * {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(h4 + *) {
+      +   .lg\\\\:prose-xl h4 + * {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(table) {
+      +   .lg\\\\:prose-xl table {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(thead th) {
+      +   .lg\\\\:prose-xl thead th {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(thead th:first-child) {
+      +   .lg\\\\:prose-xl thead th:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(thead th:last-child) {
+      +   .lg\\\\:prose-xl thead th:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(tbody td) {
+      +   .lg\\\\:prose-xl tbody td {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(tbody td:first-child) {
+      +   .lg\\\\:prose-xl tbody td:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(tbody td:last-child) {
+      +   .lg\\\\:prose-xl tbody td:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> :first-child) {
+      +   .lg\\\\:prose-xl > :first-child {
+
+      ---
+
+      -   .lg\\\\:prose-xl :where(> :last-child) {
+      +   .lg\\\\:prose-xl > :last-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(p) {
+      +   .lg\\\\:prose-2xl p {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where([class~='lead']) {
+      +   .lg\\\\:prose-2xl [class~='lead'] {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(blockquote) {
+      +   .lg\\\\:prose-2xl blockquote {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h1) {
+      +   .lg\\\\:prose-2xl h1 {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h2) {
+      +   .lg\\\\:prose-2xl h2 {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h3) {
+      +   .lg\\\\:prose-2xl h3 {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h4) {
+      +   .lg\\\\:prose-2xl h4 {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(img) {
+      +   .lg\\\\:prose-2xl img {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(video) {
+      +   .lg\\\\:prose-2xl video {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(figure) {
+      +   .lg\\\\:prose-2xl figure {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(figure > *) {
+      +   .lg\\\\:prose-2xl figure > * {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(figure figcaption) {
+      +   .lg\\\\:prose-2xl figure figcaption {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(code) {
+      +   .lg\\\\:prose-2xl code {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h2 code) {
+      +   .lg\\\\:prose-2xl h2 code {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h3 code) {
+      +   .lg\\\\:prose-2xl h3 code {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(pre) {
+      +   .lg\\\\:prose-2xl pre {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ol) {
+      +   .lg\\\\:prose-2xl ol {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ul) {
+      +   .lg\\\\:prose-2xl ul {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(li) {
+      +   .lg\\\\:prose-2xl li {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ol > li) {
+      +   .lg\\\\:prose-2xl ol > li {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ol > li)::before {
+      +   .lg\\\\:prose-2xl ol > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ul > li) {
+      +   .lg\\\\:prose-2xl ul > li {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ul > li)::before {
+      +   .lg\\\\:prose-2xl ul > li::before {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> ul > li p) {
+      +   .lg\\\\:prose-2xl > ul > li p {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .lg\\\\:prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .lg\\\\:prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .lg\\\\:prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .lg\\\\:prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .lg\\\\:prose-2xl ul ul, .lg\\\\:prose-2xl ul ol, .lg\\\\:prose-2xl ol ul, .lg\\\\:prose-2xl ol ol {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(hr) {
+      +   .lg\\\\:prose-2xl hr {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(hr + *) {
+      +   .lg\\\\:prose-2xl hr + * {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h2 + *) {
+      +   .lg\\\\:prose-2xl h2 + * {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h3 + *) {
+      +   .lg\\\\:prose-2xl h3 + * {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(h4 + *) {
+      +   .lg\\\\:prose-2xl h4 + * {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(table) {
+      +   .lg\\\\:prose-2xl table {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(thead th) {
+      +   .lg\\\\:prose-2xl thead th {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(thead th:first-child) {
+      +   .lg\\\\:prose-2xl thead th:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(thead th:last-child) {
+      +   .lg\\\\:prose-2xl thead th:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(tbody td) {
+      +   .lg\\\\:prose-2xl tbody td {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .lg\\\\:prose-2xl tbody td:first-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .lg\\\\:prose-2xl tbody td:last-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> :first-child) {
+      +   .lg\\\\:prose-2xl > :first-child {
+
+      ---
+
+      -   .lg\\\\:prose-2xl :where(> :last-child) {
+      +   .lg\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   .lg\\\\:prose-red :where(a) {
+      +   .lg\\\\:prose-red a {
+
+      ---
+
+      -   .lg\\\\:prose-red :where(a code) {
+      +   .lg\\\\:prose-red a code {
+
+      ---
+
+      -   .lg\\\\:prose-yellow :where(a) {
+      +   .lg\\\\:prose-yellow a {
+
+      ---
+
+      -   .lg\\\\:prose-yellow :where(a code) {
+      +   .lg\\\\:prose-yellow a code {
+
+      ---
+
+      -   .lg\\\\:prose-green :where(a) {
+      +   .lg\\\\:prose-green a {
+
+      ---
+
+      -   .lg\\\\:prose-green :where(a code) {
+      +   .lg\\\\:prose-green a code {
+
+      ---
+
+      -   .lg\\\\:prose-blue :where(a) {
+      +   .lg\\\\:prose-blue a {
+
+      ---
+
+      -   .lg\\\\:prose-blue :where(a code) {
+      +   .lg\\\\:prose-blue a code {
+
+      ---
+
+      -   .lg\\\\:prose-indigo :where(a) {
+      +   .lg\\\\:prose-indigo a {
+
+      ---
+
+      -   .lg\\\\:prose-indigo :where(a code) {
+      +   .lg\\\\:prose-indigo a code {
+
+      ---
+
+      -   .lg\\\\:prose-purple :where(a) {
+      +   .lg\\\\:prose-purple a {
+
+      ---
+
+      -   .lg\\\\:prose-purple :where(a code) {
+      +   .lg\\\\:prose-purple a code {
+
+      ---
+
+      -   .lg\\\\:prose-pink :where(a) {
+      +   .lg\\\\:prose-pink a {
+
+      ---
+
+      -   .lg\\\\:prose-pink :where(a code) {
+      +   .lg\\\\:prose-pink a code {
+
+      ---
+
+      -   .xl\\\\:prose :where([class~='lead']) {
+      +   .xl\\\\:prose [class~='lead'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(a) {
+      +   .xl\\\\:prose a {
+
+      ---
+
+      -   .xl\\\\:prose :where(strong) {
+      +   .xl\\\\:prose strong {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='A']) {
+      +   .xl\\\\:prose ol[type='A'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='a']) {
+      +   .xl\\\\:prose ol[type='a'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='A' s]) {
+      +   .xl\\\\:prose ol[type='A' s] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='a' s]) {
+      +   .xl\\\\:prose ol[type='a' s] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='I']) {
+      +   .xl\\\\:prose ol[type='I'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='i']) {
+      +   .xl\\\\:prose ol[type='i'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='I' s]) {
+      +   .xl\\\\:prose ol[type='I' s] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='i' s]) {
+      +   .xl\\\\:prose ol[type='i' s] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol[type='1']) {
+      +   .xl\\\\:prose ol[type='1'] {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol > li) {
+      +   .xl\\\\:prose ol > li {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol > li)::before {
+      +   .xl\\\\:prose ol > li::before {
+
+      ---
+
+      -   .xl\\\\:prose :where(ul > li) {
+      +   .xl\\\\:prose ul > li {
+
+      ---
+
+      -   .xl\\\\:prose :where(ul > li)::before {
+      +   .xl\\\\:prose ul > li::before {
+
+      ---
+
+      -   .xl\\\\:prose :where(hr) {
+      +   .xl\\\\:prose hr {
+
+      ---
+
+      -   .xl\\\\:prose :where(blockquote) {
+      +   .xl\\\\:prose blockquote {
+
+      ---
+
+      -   .xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .xl\\\\:prose blockquote p:first-of-type::before {
+
+      ---
+
+      -   .xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .xl\\\\:prose blockquote p:last-of-type::after {
+
+      ---
+
+      -   .xl\\\\:prose :where(h1) {
+      +   .xl\\\\:prose h1 {
+
+      ---
+
+      -   .xl\\\\:prose :where(h1 strong) {
+      +   .xl\\\\:prose h1 strong {
+
+      ---
+
+      -   .xl\\\\:prose :where(h2) {
+      +   .xl\\\\:prose h2 {
+
+      ---
+
+      -   .xl\\\\:prose :where(h2 strong) {
+      +   .xl\\\\:prose h2 strong {
+
+      ---
+
+      -   .xl\\\\:prose :where(h3) {
+      +   .xl\\\\:prose h3 {
+
+      ---
+
+      -   .xl\\\\:prose :where(h3 strong) {
+      +   .xl\\\\:prose h3 strong {
+
+      ---
+
+      -   .xl\\\\:prose :where(h4) {
+      +   .xl\\\\:prose h4 {
+
+      ---
+
+      -   .xl\\\\:prose :where(h4 strong) {
+      +   .xl\\\\:prose h4 strong {
+
+      ---
+
+      -   .xl\\\\:prose :where(figure figcaption) {
+      +   .xl\\\\:prose figure figcaption {
+
+      ---
+
+      -   .xl\\\\:prose :where(code) {
+      +   .xl\\\\:prose code {
+
+      ---
+
+      -   .xl\\\\:prose :where(code)::before {
+      +   .xl\\\\:prose code::before {
+
+      ---
+
+      -   .xl\\\\:prose :where(code)::after {
+      +   .xl\\\\:prose code::after {
+
+      ---
+
+      -   .xl\\\\:prose :where(a code) {
+      +   .xl\\\\:prose a code {
+
+      ---
+
+      -   .xl\\\\:prose :where(pre) {
+      +   .xl\\\\:prose pre {
+
+      ---
+
+      -   .xl\\\\:prose :where(pre code) {
+      +   .xl\\\\:prose pre code {
+
+      ---
+
+      -   .xl\\\\:prose :where(pre code)::before {
+      +   .xl\\\\:prose pre code::before {
+
+      ---
+
+      -   .xl\\\\:prose :where(pre code)::after {
+      +   .xl\\\\:prose pre code::after {
+
+      ---
+
+      -   .xl\\\\:prose :where(table) {
+      +   .xl\\\\:prose table {
+
+      ---
+
+      -   .xl\\\\:prose :where(thead) {
+      +   .xl\\\\:prose thead {
+
+      ---
+
+      -   .xl\\\\:prose :where(thead th) {
+      +   .xl\\\\:prose thead th {
+
+      ---
+
+      -   .xl\\\\:prose :where(tbody tr) {
+      +   .xl\\\\:prose tbody tr {
+
+      ---
+
+      -   .xl\\\\:prose :where(tbody tr:last-child) {
+      +   .xl\\\\:prose tbody tr:last-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(tbody td) {
+      +   .xl\\\\:prose tbody td {
+
+      ---
+
+      -   .xl\\\\:prose :where(p) {
+      +   .xl\\\\:prose p {
+
+      ---
+
+      -   .xl\\\\:prose :where(img) {
+      +   .xl\\\\:prose img {
+
+      ---
+
+      -   .xl\\\\:prose :where(video) {
+      +   .xl\\\\:prose video {
+
+      ---
+
+      -   .xl\\\\:prose :where(figure) {
+      +   .xl\\\\:prose figure {
+
+      ---
+
+      -   .xl\\\\:prose :where(figure > *) {
+      +   .xl\\\\:prose figure > * {
+
+      ---
+
+      -   .xl\\\\:prose :where(h2 code) {
+      +   .xl\\\\:prose h2 code {
+
+      ---
+
+      -   .xl\\\\:prose :where(h3 code) {
+      +   .xl\\\\:prose h3 code {
+
+      ---
+
+      -   .xl\\\\:prose :where(ol) {
+      +   .xl\\\\:prose ol {
+
+      ---
+
+      -   .xl\\\\:prose :where(ul) {
+      +   .xl\\\\:prose ul {
+
+      ---
+
+      -   .xl\\\\:prose :where(li) {
+      +   .xl\\\\:prose li {
+
+      ---
+
+      -   .xl\\\\:prose :where(> ul > li p) {
+      +   .xl\\\\:prose > ul > li p {
+
+      ---
+
+      -   .xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .xl\\\\:prose > ul > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .xl\\\\:prose > ul > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .xl\\\\:prose > ol > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .xl\\\\:prose > ol > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:prose ul ul, .xl\\\\:prose ul ol, .xl\\\\:prose ol ul, .xl\\\\:prose ol ol {
+
+      ---
+
+      -   .xl\\\\:prose :where(hr + *) {
+      +   .xl\\\\:prose hr + * {
+
+      ---
+
+      -   .xl\\\\:prose :where(h2 + *) {
+      +   .xl\\\\:prose h2 + * {
+
+      ---
+
+      -   .xl\\\\:prose :where(h3 + *) {
+      +   .xl\\\\:prose h3 + * {
+
+      ---
+
+      -   .xl\\\\:prose :where(h4 + *) {
+      +   .xl\\\\:prose h4 + * {
+
+      ---
+
+      -   .xl\\\\:prose :where(thead th:first-child) {
+      +   .xl\\\\:prose thead th:first-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(thead th:last-child) {
+      +   .xl\\\\:prose thead th:last-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(tbody td:first-child) {
+      +   .xl\\\\:prose tbody td:first-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(tbody td:last-child) {
+      +   .xl\\\\:prose tbody td:last-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(> :first-child) {
+      +   .xl\\\\:prose > :first-child {
+
+      ---
+
+      -   .xl\\\\:prose :where(> :last-child) {
+      +   .xl\\\\:prose > :last-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(p) {
+      +   .xl\\\\:prose-sm p {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where([class~='lead']) {
+      +   .xl\\\\:prose-sm [class~='lead'] {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(blockquote) {
+      +   .xl\\\\:prose-sm blockquote {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h1) {
+      +   .xl\\\\:prose-sm h1 {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h2) {
+      +   .xl\\\\:prose-sm h2 {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h3) {
+      +   .xl\\\\:prose-sm h3 {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h4) {
+      +   .xl\\\\:prose-sm h4 {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(img) {
+      +   .xl\\\\:prose-sm img {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(video) {
+      +   .xl\\\\:prose-sm video {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(figure) {
+      +   .xl\\\\:prose-sm figure {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(figure > *) {
+      +   .xl\\\\:prose-sm figure > * {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(figure figcaption) {
+      +   .xl\\\\:prose-sm figure figcaption {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(code) {
+      +   .xl\\\\:prose-sm code {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h2 code) {
+      +   .xl\\\\:prose-sm h2 code {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h3 code) {
+      +   .xl\\\\:prose-sm h3 code {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(pre) {
+      +   .xl\\\\:prose-sm pre {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ol) {
+      +   .xl\\\\:prose-sm ol {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ul) {
+      +   .xl\\\\:prose-sm ul {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(li) {
+      +   .xl\\\\:prose-sm li {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ol > li) {
+      +   .xl\\\\:prose-sm ol > li {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ol > li)::before {
+      +   .xl\\\\:prose-sm ol > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ul > li) {
+      +   .xl\\\\:prose-sm ul > li {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ul > li)::before {
+      +   .xl\\\\:prose-sm ul > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> ul > li p) {
+      +   .xl\\\\:prose-sm > ul > li p {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .xl\\\\:prose-sm > ul > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .xl\\\\:prose-sm > ul > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .xl\\\\:prose-sm > ol > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .xl\\\\:prose-sm > ol > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:prose-sm ul ul, .xl\\\\:prose-sm ul ol, .xl\\\\:prose-sm ol ul, .xl\\\\:prose-sm ol ol {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(hr) {
+      +   .xl\\\\:prose-sm hr {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(hr + *) {
+      +   .xl\\\\:prose-sm hr + * {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h2 + *) {
+      +   .xl\\\\:prose-sm h2 + * {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h3 + *) {
+      +   .xl\\\\:prose-sm h3 + * {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(h4 + *) {
+      +   .xl\\\\:prose-sm h4 + * {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(table) {
+      +   .xl\\\\:prose-sm table {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(thead th) {
+      +   .xl\\\\:prose-sm thead th {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(thead th:first-child) {
+      +   .xl\\\\:prose-sm thead th:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(thead th:last-child) {
+      +   .xl\\\\:prose-sm thead th:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(tbody td) {
+      +   .xl\\\\:prose-sm tbody td {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(tbody td:first-child) {
+      +   .xl\\\\:prose-sm tbody td:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(tbody td:last-child) {
+      +   .xl\\\\:prose-sm tbody td:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> :first-child) {
+      +   .xl\\\\:prose-sm > :first-child {
+
+      ---
+
+      -   .xl\\\\:prose-sm :where(> :last-child) {
+      +   .xl\\\\:prose-sm > :last-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(p) {
+      +   .xl\\\\:prose-lg p {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where([class~='lead']) {
+      +   .xl\\\\:prose-lg [class~='lead'] {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(blockquote) {
+      +   .xl\\\\:prose-lg blockquote {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h1) {
+      +   .xl\\\\:prose-lg h1 {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h2) {
+      +   .xl\\\\:prose-lg h2 {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h3) {
+      +   .xl\\\\:prose-lg h3 {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h4) {
+      +   .xl\\\\:prose-lg h4 {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(img) {
+      +   .xl\\\\:prose-lg img {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(video) {
+      +   .xl\\\\:prose-lg video {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(figure) {
+      +   .xl\\\\:prose-lg figure {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(figure > *) {
+      +   .xl\\\\:prose-lg figure > * {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(figure figcaption) {
+      +   .xl\\\\:prose-lg figure figcaption {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(code) {
+      +   .xl\\\\:prose-lg code {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h2 code) {
+      +   .xl\\\\:prose-lg h2 code {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h3 code) {
+      +   .xl\\\\:prose-lg h3 code {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(pre) {
+      +   .xl\\\\:prose-lg pre {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ol) {
+      +   .xl\\\\:prose-lg ol {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ul) {
+      +   .xl\\\\:prose-lg ul {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(li) {
+      +   .xl\\\\:prose-lg li {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ol > li) {
+      +   .xl\\\\:prose-lg ol > li {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ol > li)::before {
+      +   .xl\\\\:prose-lg ol > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ul > li) {
+      +   .xl\\\\:prose-lg ul > li {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ul > li)::before {
+      +   .xl\\\\:prose-lg ul > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> ul > li p) {
+      +   .xl\\\\:prose-lg > ul > li p {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .xl\\\\:prose-lg > ul > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .xl\\\\:prose-lg > ul > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .xl\\\\:prose-lg > ol > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .xl\\\\:prose-lg > ol > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:prose-lg ul ul, .xl\\\\:prose-lg ul ol, .xl\\\\:prose-lg ol ul, .xl\\\\:prose-lg ol ol {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(hr) {
+      +   .xl\\\\:prose-lg hr {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(hr + *) {
+      +   .xl\\\\:prose-lg hr + * {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h2 + *) {
+      +   .xl\\\\:prose-lg h2 + * {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h3 + *) {
+      +   .xl\\\\:prose-lg h3 + * {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(h4 + *) {
+      +   .xl\\\\:prose-lg h4 + * {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(table) {
+      +   .xl\\\\:prose-lg table {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(thead th) {
+      +   .xl\\\\:prose-lg thead th {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .xl\\\\:prose-lg thead th:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .xl\\\\:prose-lg thead th:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(tbody td) {
+      +   .xl\\\\:prose-lg tbody td {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .xl\\\\:prose-lg tbody td:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .xl\\\\:prose-lg tbody td:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> :first-child) {
+      +   .xl\\\\:prose-lg > :first-child {
+
+      ---
+
+      -   .xl\\\\:prose-lg :where(> :last-child) {
+      +   .xl\\\\:prose-lg > :last-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(p) {
+      +   .xl\\\\:prose-xl p {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where([class~='lead']) {
+      +   .xl\\\\:prose-xl [class~='lead'] {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(blockquote) {
+      +   .xl\\\\:prose-xl blockquote {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h1) {
+      +   .xl\\\\:prose-xl h1 {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h2) {
+      +   .xl\\\\:prose-xl h2 {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h3) {
+      +   .xl\\\\:prose-xl h3 {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h4) {
+      +   .xl\\\\:prose-xl h4 {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(img) {
+      +   .xl\\\\:prose-xl img {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(video) {
+      +   .xl\\\\:prose-xl video {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(figure) {
+      +   .xl\\\\:prose-xl figure {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(figure > *) {
+      +   .xl\\\\:prose-xl figure > * {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(figure figcaption) {
+      +   .xl\\\\:prose-xl figure figcaption {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(code) {
+      +   .xl\\\\:prose-xl code {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h2 code) {
+      +   .xl\\\\:prose-xl h2 code {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h3 code) {
+      +   .xl\\\\:prose-xl h3 code {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(pre) {
+      +   .xl\\\\:prose-xl pre {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ol) {
+      +   .xl\\\\:prose-xl ol {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ul) {
+      +   .xl\\\\:prose-xl ul {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(li) {
+      +   .xl\\\\:prose-xl li {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ol > li) {
+      +   .xl\\\\:prose-xl ol > li {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ol > li)::before {
+      +   .xl\\\\:prose-xl ol > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ul > li) {
+      +   .xl\\\\:prose-xl ul > li {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ul > li)::before {
+      +   .xl\\\\:prose-xl ul > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> ul > li p) {
+      +   .xl\\\\:prose-xl > ul > li p {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:prose-xl > ul > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:prose-xl > ul > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:prose-xl > ol > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:prose-xl > ol > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:prose-xl ul ul, .xl\\\\:prose-xl ul ol, .xl\\\\:prose-xl ol ul, .xl\\\\:prose-xl ol ol {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(hr) {
+      +   .xl\\\\:prose-xl hr {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(hr + *) {
+      +   .xl\\\\:prose-xl hr + * {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h2 + *) {
+      +   .xl\\\\:prose-xl h2 + * {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h3 + *) {
+      +   .xl\\\\:prose-xl h3 + * {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(h4 + *) {
+      +   .xl\\\\:prose-xl h4 + * {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(table) {
+      +   .xl\\\\:prose-xl table {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(thead th) {
+      +   .xl\\\\:prose-xl thead th {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .xl\\\\:prose-xl thead th:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .xl\\\\:prose-xl thead th:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(tbody td) {
+      +   .xl\\\\:prose-xl tbody td {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .xl\\\\:prose-xl tbody td:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .xl\\\\:prose-xl tbody td:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> :first-child) {
+      +   .xl\\\\:prose-xl > :first-child {
+
+      ---
+
+      -   .xl\\\\:prose-xl :where(> :last-child) {
+      +   .xl\\\\:prose-xl > :last-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(p) {
+      +   .xl\\\\:prose-2xl p {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .xl\\\\:prose-2xl [class~='lead'] {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(blockquote) {
+      +   .xl\\\\:prose-2xl blockquote {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h1) {
+      +   .xl\\\\:prose-2xl h1 {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h2) {
+      +   .xl\\\\:prose-2xl h2 {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h3) {
+      +   .xl\\\\:prose-2xl h3 {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h4) {
+      +   .xl\\\\:prose-2xl h4 {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(img) {
+      +   .xl\\\\:prose-2xl img {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(video) {
+      +   .xl\\\\:prose-2xl video {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(figure) {
+      +   .xl\\\\:prose-2xl figure {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(figure > *) {
+      +   .xl\\\\:prose-2xl figure > * {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .xl\\\\:prose-2xl figure figcaption {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(code) {
+      +   .xl\\\\:prose-2xl code {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h2 code) {
+      +   .xl\\\\:prose-2xl h2 code {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h3 code) {
+      +   .xl\\\\:prose-2xl h3 code {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(pre) {
+      +   .xl\\\\:prose-2xl pre {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ol) {
+      +   .xl\\\\:prose-2xl ol {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ul) {
+      +   .xl\\\\:prose-2xl ul {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(li) {
+      +   .xl\\\\:prose-2xl li {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ol > li) {
+      +   .xl\\\\:prose-2xl ol > li {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .xl\\\\:prose-2xl ol > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ul > li) {
+      +   .xl\\\\:prose-2xl ul > li {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .xl\\\\:prose-2xl ul > li::before {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .xl\\\\:prose-2xl > ul > li p {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .xl\\\\:prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .xl\\\\:prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .xl\\\\:prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .xl\\\\:prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .xl\\\\:prose-2xl ul ul, .xl\\\\:prose-2xl ul ol, .xl\\\\:prose-2xl ol ul, .xl\\\\:prose-2xl ol ol {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(hr) {
+      +   .xl\\\\:prose-2xl hr {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(hr + *) {
+      +   .xl\\\\:prose-2xl hr + * {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h2 + *) {
+      +   .xl\\\\:prose-2xl h2 + * {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h3 + *) {
+      +   .xl\\\\:prose-2xl h3 + * {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(h4 + *) {
+      +   .xl\\\\:prose-2xl h4 + * {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(table) {
+      +   .xl\\\\:prose-2xl table {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(thead th) {
+      +   .xl\\\\:prose-2xl thead th {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .xl\\\\:prose-2xl thead th:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .xl\\\\:prose-2xl thead th:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(tbody td) {
+      +   .xl\\\\:prose-2xl tbody td {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .xl\\\\:prose-2xl tbody td:first-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .xl\\\\:prose-2xl tbody td:last-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> :first-child) {
+      +   .xl\\\\:prose-2xl > :first-child {
+
+      ---
+
+      -   .xl\\\\:prose-2xl :where(> :last-child) {
+      +   .xl\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   .xl\\\\:prose-red :where(a) {
+      +   .xl\\\\:prose-red a {
+
+      ---
+
+      -   .xl\\\\:prose-red :where(a code) {
+      +   .xl\\\\:prose-red a code {
+
+      ---
+
+      -   .xl\\\\:prose-yellow :where(a) {
+      +   .xl\\\\:prose-yellow a {
+
+      ---
+
+      -   .xl\\\\:prose-yellow :where(a code) {
+      +   .xl\\\\:prose-yellow a code {
+
+      ---
+
+      -   .xl\\\\:prose-green :where(a) {
+      +   .xl\\\\:prose-green a {
+
+      ---
+
+      -   .xl\\\\:prose-green :where(a code) {
+      +   .xl\\\\:prose-green a code {
+
+      ---
+
+      -   .xl\\\\:prose-blue :where(a) {
+      +   .xl\\\\:prose-blue a {
+
+      ---
+
+      -   .xl\\\\:prose-blue :where(a code) {
+      +   .xl\\\\:prose-blue a code {
+
+      ---
+
+      -   .xl\\\\:prose-indigo :where(a) {
+      +   .xl\\\\:prose-indigo a {
+
+      ---
+
+      -   .xl\\\\:prose-indigo :where(a code) {
+      +   .xl\\\\:prose-indigo a code {
+
+      ---
+
+      -   .xl\\\\:prose-purple :where(a) {
+      +   .xl\\\\:prose-purple a {
+
+      ---
+
+      -   .xl\\\\:prose-purple :where(a code) {
+      +   .xl\\\\:prose-purple a code {
+
+      ---
+
+      -   .xl\\\\:prose-pink :where(a) {
+      +   .xl\\\\:prose-pink a {
+
+      ---
+
+      -   .xl\\\\:prose-pink :where(a code) {
+      +   .xl\\\\:prose-pink a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where([class~='lead']) {
+      +   .\\\\32xl\\\\:prose [class~='lead'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(a) {
+      +   .\\\\32xl\\\\:prose a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(strong) {
+      +   .\\\\32xl\\\\:prose strong {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='A']) {
+      +   .\\\\32xl\\\\:prose ol[type='A'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='a']) {
+      +   .\\\\32xl\\\\:prose ol[type='a'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='A' s]) {
+      +   .\\\\32xl\\\\:prose ol[type='A' s] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='a' s]) {
+      +   .\\\\32xl\\\\:prose ol[type='a' s] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='I']) {
+      +   .\\\\32xl\\\\:prose ol[type='I'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='i']) {
+      +   .\\\\32xl\\\\:prose ol[type='i'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='I' s]) {
+      +   .\\\\32xl\\\\:prose ol[type='I' s] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='i' s]) {
+      +   .\\\\32xl\\\\:prose ol[type='i' s] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol[type='1']) {
+      +   .\\\\32xl\\\\:prose ol[type='1'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol > li) {
+      +   .\\\\32xl\\\\:prose ol > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol > li)::before {
+      +   .\\\\32xl\\\\:prose ol > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ul > li) {
+      +   .\\\\32xl\\\\:prose ul > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ul > li)::before {
+      +   .\\\\32xl\\\\:prose ul > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(hr) {
+      +   .\\\\32xl\\\\:prose hr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(blockquote) {
+      +   .\\\\32xl\\\\:prose blockquote {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(blockquote p:first-of-type)::before {
+      +   .\\\\32xl\\\\:prose blockquote p:first-of-type::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(blockquote p:last-of-type)::after {
+      +   .\\\\32xl\\\\:prose blockquote p:last-of-type::after {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h1) {
+      +   .\\\\32xl\\\\:prose h1 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h1 strong) {
+      +   .\\\\32xl\\\\:prose h1 strong {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h2) {
+      +   .\\\\32xl\\\\:prose h2 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h2 strong) {
+      +   .\\\\32xl\\\\:prose h2 strong {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h3) {
+      +   .\\\\32xl\\\\:prose h3 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h3 strong) {
+      +   .\\\\32xl\\\\:prose h3 strong {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h4) {
+      +   .\\\\32xl\\\\:prose h4 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h4 strong) {
+      +   .\\\\32xl\\\\:prose h4 strong {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(figure figcaption) {
+      +   .\\\\32xl\\\\:prose figure figcaption {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(code) {
+      +   .\\\\32xl\\\\:prose code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(code)::before {
+      +   .\\\\32xl\\\\:prose code::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(code)::after {
+      +   .\\\\32xl\\\\:prose code::after {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(a code) {
+      +   .\\\\32xl\\\\:prose a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(pre) {
+      +   .\\\\32xl\\\\:prose pre {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(pre code) {
+      +   .\\\\32xl\\\\:prose pre code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(pre code)::before {
+      +   .\\\\32xl\\\\:prose pre code::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(pre code)::after {
+      +   .\\\\32xl\\\\:prose pre code::after {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(table) {
+      +   .\\\\32xl\\\\:prose table {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(thead) {
+      +   .\\\\32xl\\\\:prose thead {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(thead th) {
+      +   .\\\\32xl\\\\:prose thead th {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(tbody tr) {
+      +   .\\\\32xl\\\\:prose tbody tr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(tbody tr:last-child) {
+      +   .\\\\32xl\\\\:prose tbody tr:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(tbody td) {
+      +   .\\\\32xl\\\\:prose tbody td {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(p) {
+      +   .\\\\32xl\\\\:prose p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(img) {
+      +   .\\\\32xl\\\\:prose img {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(video) {
+      +   .\\\\32xl\\\\:prose video {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(figure) {
+      +   .\\\\32xl\\\\:prose figure {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(figure > *) {
+      +   .\\\\32xl\\\\:prose figure > * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h2 code) {
+      +   .\\\\32xl\\\\:prose h2 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h3 code) {
+      +   .\\\\32xl\\\\:prose h3 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ol) {
+      +   .\\\\32xl\\\\:prose ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ul) {
+      +   .\\\\32xl\\\\:prose ul {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(li) {
+      +   .\\\\32xl\\\\:prose li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> ul > li p) {
+      +   .\\\\32xl\\\\:prose > ul > li p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose > ul > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose > ul > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose > ol > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose > ol > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:prose ul ul, .\\\\32xl\\\\:prose ul ol, .\\\\32xl\\\\:prose ol ul, .\\\\32xl\\\\:prose ol ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(hr + *) {
+      +   .\\\\32xl\\\\:prose hr + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h2 + *) {
+      +   .\\\\32xl\\\\:prose h2 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h3 + *) {
+      +   .\\\\32xl\\\\:prose h3 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(h4 + *) {
+      +   .\\\\32xl\\\\:prose h4 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:prose thead th:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:prose thead th:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:prose tbody td:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:prose tbody td:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> :first-child) {
+      +   .\\\\32xl\\\\:prose > :first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose :where(> :last-child) {
+      +   .\\\\32xl\\\\:prose > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(p) {
+      +   .\\\\32xl\\\\:prose-sm p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where([class~='lead']) {
+      +   .\\\\32xl\\\\:prose-sm [class~='lead'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(blockquote) {
+      +   .\\\\32xl\\\\:prose-sm blockquote {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h1) {
+      +   .\\\\32xl\\\\:prose-sm h1 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h2) {
+      +   .\\\\32xl\\\\:prose-sm h2 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h3) {
+      +   .\\\\32xl\\\\:prose-sm h3 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h4) {
+      +   .\\\\32xl\\\\:prose-sm h4 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(img) {
+      +   .\\\\32xl\\\\:prose-sm img {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(video) {
+      +   .\\\\32xl\\\\:prose-sm video {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(figure) {
+      +   .\\\\32xl\\\\:prose-sm figure {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(figure > *) {
+      +   .\\\\32xl\\\\:prose-sm figure > * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(figure figcaption) {
+      +   .\\\\32xl\\\\:prose-sm figure figcaption {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(code) {
+      +   .\\\\32xl\\\\:prose-sm code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h2 code) {
+      +   .\\\\32xl\\\\:prose-sm h2 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h3 code) {
+      +   .\\\\32xl\\\\:prose-sm h3 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(pre) {
+      +   .\\\\32xl\\\\:prose-sm pre {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ol) {
+      +   .\\\\32xl\\\\:prose-sm ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ul) {
+      +   .\\\\32xl\\\\:prose-sm ul {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(li) {
+      +   .\\\\32xl\\\\:prose-sm li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li) {
+      +   .\\\\32xl\\\\:prose-sm ol > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ol > li)::before {
+      +   .\\\\32xl\\\\:prose-sm ol > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li) {
+      +   .\\\\32xl\\\\:prose-sm ul > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ul > li)::before {
+      +   .\\\\32xl\\\\:prose-sm ul > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li p) {
+      +   .\\\\32xl\\\\:prose-sm > ul > li p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-sm > ul > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-sm > ul > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-sm > ol > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-sm > ol > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:prose-sm ul ul, .\\\\32xl\\\\:prose-sm ul ol, .\\\\32xl\\\\:prose-sm ol ul, .\\\\32xl\\\\:prose-sm ol ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(hr) {
+      +   .\\\\32xl\\\\:prose-sm hr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(hr + *) {
+      +   .\\\\32xl\\\\:prose-sm hr + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h2 + *) {
+      +   .\\\\32xl\\\\:prose-sm h2 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h3 + *) {
+      +   .\\\\32xl\\\\:prose-sm h3 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(h4 + *) {
+      +   .\\\\32xl\\\\:prose-sm h4 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(table) {
+      +   .\\\\32xl\\\\:prose-sm table {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(thead th) {
+      +   .\\\\32xl\\\\:prose-sm thead th {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:prose-sm thead th:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:prose-sm thead th:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td) {
+      +   .\\\\32xl\\\\:prose-sm tbody td {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:prose-sm tbody td:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:prose-sm tbody td:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> :first-child) {
+      +   .\\\\32xl\\\\:prose-sm > :first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-sm :where(> :last-child) {
+      +   .\\\\32xl\\\\:prose-sm > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(p) {
+      +   .\\\\32xl\\\\:prose-lg p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where([class~='lead']) {
+      +   .\\\\32xl\\\\:prose-lg [class~='lead'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(blockquote) {
+      +   .\\\\32xl\\\\:prose-lg blockquote {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h1) {
+      +   .\\\\32xl\\\\:prose-lg h1 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h2) {
+      +   .\\\\32xl\\\\:prose-lg h2 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h3) {
+      +   .\\\\32xl\\\\:prose-lg h3 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h4) {
+      +   .\\\\32xl\\\\:prose-lg h4 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(img) {
+      +   .\\\\32xl\\\\:prose-lg img {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(video) {
+      +   .\\\\32xl\\\\:prose-lg video {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(figure) {
+      +   .\\\\32xl\\\\:prose-lg figure {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(figure > *) {
+      +   .\\\\32xl\\\\:prose-lg figure > * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(figure figcaption) {
+      +   .\\\\32xl\\\\:prose-lg figure figcaption {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(code) {
+      +   .\\\\32xl\\\\:prose-lg code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h2 code) {
+      +   .\\\\32xl\\\\:prose-lg h2 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h3 code) {
+      +   .\\\\32xl\\\\:prose-lg h3 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(pre) {
+      +   .\\\\32xl\\\\:prose-lg pre {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ol) {
+      +   .\\\\32xl\\\\:prose-lg ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ul) {
+      +   .\\\\32xl\\\\:prose-lg ul {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(li) {
+      +   .\\\\32xl\\\\:prose-lg li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li) {
+      +   .\\\\32xl\\\\:prose-lg ol > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ol > li)::before {
+      +   .\\\\32xl\\\\:prose-lg ol > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li) {
+      +   .\\\\32xl\\\\:prose-lg ul > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ul > li)::before {
+      +   .\\\\32xl\\\\:prose-lg ul > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li p) {
+      +   .\\\\32xl\\\\:prose-lg > ul > li p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-lg > ul > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-lg > ul > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-lg > ol > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-lg > ol > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:prose-lg ul ul, .\\\\32xl\\\\:prose-lg ul ol, .\\\\32xl\\\\:prose-lg ol ul, .\\\\32xl\\\\:prose-lg ol ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(hr) {
+      +   .\\\\32xl\\\\:prose-lg hr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(hr + *) {
+      +   .\\\\32xl\\\\:prose-lg hr + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h2 + *) {
+      +   .\\\\32xl\\\\:prose-lg h2 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h3 + *) {
+      +   .\\\\32xl\\\\:prose-lg h3 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(h4 + *) {
+      +   .\\\\32xl\\\\:prose-lg h4 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(table) {
+      +   .\\\\32xl\\\\:prose-lg table {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(thead th) {
+      +   .\\\\32xl\\\\:prose-lg thead th {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:prose-lg thead th:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:prose-lg thead th:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td) {
+      +   .\\\\32xl\\\\:prose-lg tbody td {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:prose-lg tbody td:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:prose-lg tbody td:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> :first-child) {
+      +   .\\\\32xl\\\\:prose-lg > :first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-lg :where(> :last-child) {
+      +   .\\\\32xl\\\\:prose-lg > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(p) {
+      +   .\\\\32xl\\\\:prose-xl p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:prose-xl [class~='lead'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(blockquote) {
+      +   .\\\\32xl\\\\:prose-xl blockquote {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h1) {
+      +   .\\\\32xl\\\\:prose-xl h1 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h2) {
+      +   .\\\\32xl\\\\:prose-xl h2 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h3) {
+      +   .\\\\32xl\\\\:prose-xl h3 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h4) {
+      +   .\\\\32xl\\\\:prose-xl h4 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(img) {
+      +   .\\\\32xl\\\\:prose-xl img {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(video) {
+      +   .\\\\32xl\\\\:prose-xl video {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(figure) {
+      +   .\\\\32xl\\\\:prose-xl figure {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(figure > *) {
+      +   .\\\\32xl\\\\:prose-xl figure > * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:prose-xl figure figcaption {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(code) {
+      +   .\\\\32xl\\\\:prose-xl code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h2 code) {
+      +   .\\\\32xl\\\\:prose-xl h2 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h3 code) {
+      +   .\\\\32xl\\\\:prose-xl h3 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(pre) {
+      +   .\\\\32xl\\\\:prose-xl pre {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ol) {
+      +   .\\\\32xl\\\\:prose-xl ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ul) {
+      +   .\\\\32xl\\\\:prose-xl ul {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(li) {
+      +   .\\\\32xl\\\\:prose-xl li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li) {
+      +   .\\\\32xl\\\\:prose-xl ol > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:prose-xl ol > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li) {
+      +   .\\\\32xl\\\\:prose-xl ul > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:prose-xl ul > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:prose-xl > ul > li p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-xl > ul > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-xl > ul > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-xl > ol > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-xl > ol > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:prose-xl ul ul, .\\\\32xl\\\\:prose-xl ul ol, .\\\\32xl\\\\:prose-xl ol ul, .\\\\32xl\\\\:prose-xl ol ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(hr) {
+      +   .\\\\32xl\\\\:prose-xl hr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(hr + *) {
+      +   .\\\\32xl\\\\:prose-xl hr + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:prose-xl h2 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:prose-xl h3 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:prose-xl h4 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(table) {
+      +   .\\\\32xl\\\\:prose-xl table {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(thead th) {
+      +   .\\\\32xl\\\\:prose-xl thead th {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:prose-xl thead th:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:prose-xl thead th:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td) {
+      +   .\\\\32xl\\\\:prose-xl tbody td {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:prose-xl tbody td:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:prose-xl tbody td:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:prose-xl > :first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:prose-xl > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(p) {
+      +   .\\\\32xl\\\\:prose-2xl p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where([class~='lead']) {
+      +   .\\\\32xl\\\\:prose-2xl [class~='lead'] {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(blockquote) {
+      +   .\\\\32xl\\\\:prose-2xl blockquote {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h1) {
+      +   .\\\\32xl\\\\:prose-2xl h1 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h2) {
+      +   .\\\\32xl\\\\:prose-2xl h2 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h3) {
+      +   .\\\\32xl\\\\:prose-2xl h3 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h4) {
+      +   .\\\\32xl\\\\:prose-2xl h4 {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(img) {
+      +   .\\\\32xl\\\\:prose-2xl img {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(video) {
+      +   .\\\\32xl\\\\:prose-2xl video {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(figure) {
+      +   .\\\\32xl\\\\:prose-2xl figure {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(figure > *) {
+      +   .\\\\32xl\\\\:prose-2xl figure > * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(figure figcaption) {
+      +   .\\\\32xl\\\\:prose-2xl figure figcaption {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(code) {
+      +   .\\\\32xl\\\\:prose-2xl code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 code) {
+      +   .\\\\32xl\\\\:prose-2xl h2 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 code) {
+      +   .\\\\32xl\\\\:prose-2xl h3 code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(pre) {
+      +   .\\\\32xl\\\\:prose-2xl pre {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ol) {
+      +   .\\\\32xl\\\\:prose-2xl ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ul) {
+      +   .\\\\32xl\\\\:prose-2xl ul {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(li) {
+      +   .\\\\32xl\\\\:prose-2xl li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li) {
+      +   .\\\\32xl\\\\:prose-2xl ol > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ol > li)::before {
+      +   .\\\\32xl\\\\:prose-2xl ol > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li) {
+      +   .\\\\32xl\\\\:prose-2xl ul > li {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ul > li)::before {
+      +   .\\\\32xl\\\\:prose-2xl ul > li::before {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li p) {
+      +   .\\\\32xl\\\\:prose-2xl > ul > li p {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-2xl > ul > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> ul > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-2xl > ul > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:first-child) {
+      +   .\\\\32xl\\\\:prose-2xl > ol > li > *:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> ol > li > *:last-child) {
+      +   .\\\\32xl\\\\:prose-2xl > ol > li > *:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(ul ul, ul ol, ol ul, ol ol) {
+      +   .\\\\32xl\\\\:prose-2xl ul ul, .\\\\32xl\\\\:prose-2xl ul ol, .\\\\32xl\\\\:prose-2xl ol ul, .\\\\32xl\\\\:prose-2xl ol ol {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(hr) {
+      +   .\\\\32xl\\\\:prose-2xl hr {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(hr + *) {
+      +   .\\\\32xl\\\\:prose-2xl hr + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h2 + *) {
+      +   .\\\\32xl\\\\:prose-2xl h2 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h3 + *) {
+      +   .\\\\32xl\\\\:prose-2xl h3 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(h4 + *) {
+      +   .\\\\32xl\\\\:prose-2xl h4 + * {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(table) {
+      +   .\\\\32xl\\\\:prose-2xl table {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th) {
+      +   .\\\\32xl\\\\:prose-2xl thead th {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:first-child) {
+      +   .\\\\32xl\\\\:prose-2xl thead th:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(thead th:last-child) {
+      +   .\\\\32xl\\\\:prose-2xl thead th:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td) {
+      +   .\\\\32xl\\\\:prose-2xl tbody td {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:first-child) {
+      +   .\\\\32xl\\\\:prose-2xl tbody td:first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(tbody td:last-child) {
+      +   .\\\\32xl\\\\:prose-2xl tbody td:last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> :first-child) {
+      +   .\\\\32xl\\\\:prose-2xl > :first-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-2xl :where(> :last-child) {
+      +   .\\\\32xl\\\\:prose-2xl > :last-child {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-red :where(a) {
+      +   .\\\\32xl\\\\:prose-red a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-red :where(a code) {
+      +   .\\\\32xl\\\\:prose-red a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow :where(a) {
+      +   .\\\\32xl\\\\:prose-yellow a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-yellow :where(a code) {
+      +   .\\\\32xl\\\\:prose-yellow a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green :where(a) {
+      +   .\\\\32xl\\\\:prose-green a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-green :where(a code) {
+      +   .\\\\32xl\\\\:prose-green a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue :where(a) {
+      +   .\\\\32xl\\\\:prose-blue a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-blue :where(a code) {
+      +   .\\\\32xl\\\\:prose-blue a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-indigo :where(a) {
+      +   .\\\\32xl\\\\:prose-indigo a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-indigo :where(a code) {
+      +   .\\\\32xl\\\\:prose-indigo a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple :where(a) {
+      +   .\\\\32xl\\\\:prose-purple a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-purple :where(a code) {
+      +   .\\\\32xl\\\\:prose-purple a code {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink :where(a) {
+      +   .\\\\32xl\\\\:prose-pink a {
+
+      ---
+
+      -   .\\\\32xl\\\\:prose-pink :where(a code) {
+      +   .\\\\32xl\\\\:prose-pink a code {
+
+    "
+  `)
+})
+
 it('should be possible to change the default modifiers', async () => {
   expect(await diffOnly({ modifiers: ['sm', 'lg', 'xl' /**, '2xl' */] })).toMatchInlineSnapshot(`
     "


### PR DESCRIPTION
This PR changes the output of this plugin to use the [:where pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:where) to reduce the specificity of the selectors, making it possible to easily override typography styles with utilities.

Here's an example of how the output has changed:

```diff
- .prose a code {
+ .prose :where(a code) {
    color: #111827;
  }
```

Prior to this PR, using a utility like this to override a typography style like this wouldn't work unless you enabled the `important` option in your `tailwind.config.js` file:

```html
<div class="prose">
  <!-- ... -->
  <p>
    The <a href="#"><code class="text-green-500">:where pseudo-class</code></a> is awesome.
  </p>
</div>
```

After merging this PR, the code above will just work 🥳 This solves one of the most common pain points of working with this plugin, as people often want to make minor tweaks within a typographic block and out of the box they can't.

This CSS feature has great browser support these days, but it doesn't work in Safari < 14:

https://caniuse.com/mdn-css_selectors_where

Safari 15 was just released, so I expect to see Safari 13 quickly become something we don't have to worry about and I'm not too worried about this change. We could introduce an option to preserve the old behavior if needed, would be really easy.

This is technically a breaking change, so will target the next version of the plugin.