### PR TITLE
Don't generate invalid CSS when given an array of property values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Don't generate invalid CSS when given an array of property values ([#224](https://github.com/tailwindlabs/tailwindcss-typography/pull/224))
 
 ## [0.5.0] - 2021-12-09
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ function configToCss(config = {}, { target, className, prefix }) {
       return [k, v]
     }
 
+    if (Array.isArray(v)) {
+      return [k, v]
+    }
+
     if (isObject(v)) {
       let nested = Object.values(v).some(isObject)
       if (nested) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -803,3 +803,31 @@ test('element variants with custom class name', async () => {
     `)
   })
 })
+
+test.only("customizing defaults with multiple values does not result in invalid css", async () => {
+  let config = {
+    plugins: [typographyPlugin()],
+    content: [
+      {
+        raw: html`<div class="prose"></div>`,
+      },
+    ],
+    theme: {
+      typography: {
+        DEFAULT: {
+          css: {
+            textAlign: ['-webkit-match-parent', 'match-parent'],
+          }
+        }
+      }
+    },
+  }
+  return run(config).then((result) => {
+    // TODO: Fix this test. It should list both properties but there's a bug in tailwind that's overriding them.
+    expect(result.css).toMatchFormattedCss(css`
+      .prose {
+        text-align: match-parent;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Partial fix for https://github.com/tailwindlabs/tailwindcss/issues/6336

You can customize the config to control the default CSS that's generated and multiple values are intended to support fallback values for properties.

For example:
```js
css: {
  textAlign: ['-webkit-match-parent', 'match-parent'],
}
```

should result in:
```css
.prose {
  text-align: -webkit-match-parent;
  text-align: match-parent;
}
```

However passing in an array resulted in invalid CSS. This fixes that. There is a second problem in tailwind itself which causes the above to only take the last value in the array so instead you end up with this:
```css
.prose {
  text-align: match-parent;
}
```

That problem will need to be solved separately but we are at least now generating valid css.