### PR TITLE
Update `strong` and `code` colors to inherit from parent

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1249,6 +1249,15 @@ module.exports = {
           color: 'var(--tw-prose-bold)',
           fontWeight: '600',
         },
+        'a strong': {
+          color: 'inherit',
+        },
+        'blockquote strong': {
+          color: 'inherit',
+        },
+        'thead th strong': {
+          color: 'inherit',
+        },
         ol: {
           listStyleType: 'decimal',
         },
@@ -1313,6 +1322,7 @@ module.exports = {
         },
         'h1 strong': {
           fontWeight: '900',
+          color: 'inherit',
         },
         h2: {
           color: 'var(--tw-prose-headings)',
@@ -1320,6 +1330,7 @@ module.exports = {
         },
         'h2 strong': {
           fontWeight: '800',
+          color: 'inherit',
         },
         h3: {
           color: 'var(--tw-prose-headings)',
@@ -1327,6 +1338,7 @@ module.exports = {
         },
         'h3 strong': {
           fontWeight: '700',
+          color: 'inherit',
         },
         h4: {
           color: 'var(--tw-prose-headings)',
@@ -1334,6 +1346,7 @@ module.exports = {
         },
         'h4 strong': {
           fontWeight: '700',
+          color: 'inherit',
         },
         // TODO: Figure out how to not need these, it's a merging issue
         img: {},
@@ -1352,7 +1365,25 @@ module.exports = {
           content: '"`"',
         },
         'a code': {
-          color: 'var(--tw-prose-links)',
+          color: 'inherit',
+        },
+        'h1 code': {
+          color: 'inherit',
+        },
+        'h2 code': {
+          color: 'inherit',
+        },
+        'h3 code': {
+          color: 'inherit',
+        },
+        'h4 code': {
+          color: 'inherit',
+        },
+        'blockquote code': {
+          color: 'inherit',
+        },
+        'thead th code': {
+          color: 'inherit',
         },
         pre: {
           color: 'var(--tw-prose-pre-code)',


### PR DESCRIPTION
Resolves #275

This PR updates the `strong` and `code` color styles in the typography plugin to inherit parent colors. Right now this isn't the case, and if you add a custom color to say a heading or blockquote, and then include either a `<strong>` or `<code>` tag within that element, they will get their default colors...not the custom color of the parent.

For example, like this: 

<img width="903" alt="image" src="https://user-images.githubusercontent.com/882133/178374366-45d42e19-1465-41f0-a805-1eaffe366335.png">

With this change the `<strong>` and `<code>` elements will now automatically inherit the custom color from the parent:

<img width="886" alt="image" src="https://user-images.githubusercontent.com/882133/178374392-88abe469-25f1-402b-bda3-aa1456cba995.png">

This feels like a more sensible way of handling these child element colors.