### PR TITLE
Add color and scale plugin options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-declare function plugin(options?: Partial<{ className: string; target: 'modern' | 'legacy' }>): {
+declare function plugin(options?: Partial<{ className: string; target: 'modern' | 'legacy'; color: string; scale: string }>): {
   handler: () => void
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const plugin = require('tailwindcss/plugin')
 const merge = require('lodash.merge')
 const castArray = require('lodash.castarray')
+const isPlainObject = require('lodash.isplainobject')
 const styles = require('./styles')
 const { commonTrailingPseudos } = require('./utils')
 
@@ -69,7 +70,7 @@ function configToCss(config = {}, { target, className, modifier, prefix }) {
 }
 
 module.exports = plugin.withOptions(
-  ({ className = 'prose', target = 'modern' } = {}) => {
+  ({ className = 'prose', target = 'modern', color, scale } = {}) => {
     return function ({ addVariant, addComponents, theme, prefix }) {
       let modifiers = theme('typography')
 
@@ -115,6 +116,20 @@ module.exports = plugin.withOptions(
           target === 'legacy' ? selector : `& :is(${inWhere(selector, options)})`
         )
       }
+
+      // Inject default gray/color scale
+      const safeColor =
+        isPlainObject(modifiers[color]) && isPlainObject(modifiers[color].css)
+          ? color
+          : 'gray'
+      modifiers.DEFAULT.css.push(modifiers[safeColor].css)
+
+      // Inject default type scale
+      const safeScale =
+        isPlainObject(modifiers[scale]) && Array.isArray(modifiers[scale].css)
+          ? scale
+          : 'base'
+      modifiers.DEFAULT.css.push(...modifiers[safeScale].css)
 
       addComponents(
         Object.keys(modifiers).map((modifier) => ({


### PR DESCRIPTION
Adds the ability to specify default `color` (gray scale) and `scale` (type scale) - this saves an implementor from specifying their preferences on every element where they utilise `prose`.

The associated PR for the documentation website is 