### PR TITLE
Add print styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,6 +129,15 @@ module.exports = plugin.withOptions(
           ),
         }))
       )
+
+      addComponents({
+        '@media print': {
+            '.prose': {
+                '--tw-prose-body': 'black',
+                '--tw-prose-headings': 'black',
+            }
+        },
+      })
     }
   },
   () => {


### PR DESCRIPTION
I've been working on adding print styles to an app, and looking at [the example](https://www.youtube.com/watch?v=mSC6GwizOag&t=316s) when the `print:` modifier was introduced, I realized that the default text colors on the web are not the best choice for printing. It'd be nice if this worked out of the box :).

I realize the changes I made are not exhaustive, so this probably needs more work. But I don't know much about the plugin, so I figured I'd open the PR rather than an issue to get the conversation started. If you think this could get out of hand, go ahead and close it. But at least now it's here in case someone who's facing the same problem searches for it.

What do you think?