### PR TITLE
Allow to import such utils as round, rem, em

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1,12 +1,12 @@
 const colors = require('tailwindcss/colors')
 
-const round = (num) =>
+export const round = (num) =>
   num
     .toFixed(7)
     .replace(/(\.[0-9]+?)0+$/, '$1')
     .replace(/\.0$/, '')
-const rem = (px) => `${round(px / 16)}rem`
-const em = (px, base) => `${round(px / base)}em`
+export const rem = (px) => `${round(px / 16)}rem`
+export const em = (px, base) => `${round(px / base)}em`
 
 let defaultModifiers = {
   sm: {


### PR DESCRIPTION
When a person wants to extend the typography config not only colors, e.g.:

```
extend: {
      typography: ({ theme }) => ({
        lg: {
          css: {
            h1: {
              fontSize: em(38, 18),
              marginTop: '0',
              marginBottom: em(40, 48),
              lineHeight: round(48 / 48),
            },
          },
        },
```