### PR TITLE
Fix `prose-invert` when used with colors in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix space between `<figcaption>` and `<pre>` ([#313](https://github.com/tailwindlabs/tailwindcss-typography/pull/313))
 - Remove typography styles from `not-prose` elements in addition to their children ([#301](https://github.com/tailwindlabs/tailwindcss-typography/pull/301))
 - Add `<picture>` styles ([#314](https://github.com/tailwindlabs/tailwindcss-typography/pull/314))
+- Fix `prose-invert` when used with colors in light mode ([#315](https://github.com/tailwindlabs/tailwindcss-typography/pull/315))
 
 ## [0.5.9] - 2023-01-10
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -940,28 +940,6 @@ let defaultModifiers = {
     ],
   },
 
-  // Invert (for dark mode)
-  invert: {
-    css: {
-      '--tw-prose-body': 'var(--tw-prose-invert-body)',
-      '--tw-prose-headings': 'var(--tw-prose-invert-headings)',
-      '--tw-prose-lead': 'var(--tw-prose-invert-lead)',
-      '--tw-prose-links': 'var(--tw-prose-invert-links)',
-      '--tw-prose-bold': 'var(--tw-prose-invert-bold)',
-      '--tw-prose-counters': 'var(--tw-prose-invert-counters)',
-      '--tw-prose-bullets': 'var(--tw-prose-invert-bullets)',
-      '--tw-prose-hr': 'var(--tw-prose-invert-hr)',
-      '--tw-prose-quotes': 'var(--tw-prose-invert-quotes)',
-      '--tw-prose-quote-borders': 'var(--tw-prose-invert-quote-borders)',
-      '--tw-prose-captions': 'var(--tw-prose-invert-captions)',
-      '--tw-prose-code': 'var(--tw-prose-invert-code)',
-      '--tw-prose-pre-code': 'var(--tw-prose-invert-pre-code)',
-      '--tw-prose-pre-bg': 'var(--tw-prose-invert-pre-bg)',
-      '--tw-prose-th-borders': 'var(--tw-prose-invert-th-borders)',
-      '--tw-prose-td-borders': 'var(--tw-prose-invert-td-borders)',
-    },
-  },
-
   // Gray color themes
 
   slate: {
@@ -1267,6 +1245,28 @@ let defaultModifiers = {
     css: {
       '--tw-prose-links': colors.rose[600],
       '--tw-prose-invert-links': colors.rose[500],
+    },
+  },
+
+  // Invert (for dark mode)
+  invert: {
+    css: {
+      '--tw-prose-body': 'var(--tw-prose-invert-body)',
+      '--tw-prose-headings': 'var(--tw-prose-invert-headings)',
+      '--tw-prose-lead': 'var(--tw-prose-invert-lead)',
+      '--tw-prose-links': 'var(--tw-prose-invert-links)',
+      '--tw-prose-bold': 'var(--tw-prose-invert-bold)',
+      '--tw-prose-counters': 'var(--tw-prose-invert-counters)',
+      '--tw-prose-bullets': 'var(--tw-prose-invert-bullets)',
+      '--tw-prose-hr': 'var(--tw-prose-invert-hr)',
+      '--tw-prose-quotes': 'var(--tw-prose-invert-quotes)',
+      '--tw-prose-quote-borders': 'var(--tw-prose-invert-quote-borders)',
+      '--tw-prose-captions': 'var(--tw-prose-invert-captions)',
+      '--tw-prose-code': 'var(--tw-prose-invert-code)',
+      '--tw-prose-pre-code': 'var(--tw-prose-invert-pre-code)',
+      '--tw-prose-pre-bg': 'var(--tw-prose-invert-pre-bg)',
+      '--tw-prose-th-borders': 'var(--tw-prose-invert-th-borders)',
+      '--tw-prose-td-borders': 'var(--tw-prose-invert-td-borders)',
     },
   },
 }


### PR DESCRIPTION
Fixes #228

This PR fixes an issue where `prose-invert` wasn't working when used with a `prose-{color}` modifier while in light mode. For example:

```html
<div class="prose prose-invert prose-slate bg-slate-900 p-12">
  Lorem ipsum dolor sit amet...
</div>
```

Prior to this fix you'd get this:

<kbd><img width="653" alt="image" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/882133/4df3869f-b5b9-4732-97fe-3f0058bb14c5"></kbd>

With this change, you get this:

<kbd><img width="652" alt="image" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/882133/5a163182-e2b3-4e81-83ed-5be107c00fb7"></kbd>

The solution here is what @adamwathan [suggested](https://github.com/tailwindlabs/tailwindcss-typography/issues/228#issuecomment-1049023163) in the linked issue, where we need to make sure that the `invert` styles come last in the list of modifiers — which causes them to be generated last in the outputted CSS.