### PR TITLE
Feature/add rtl support

### DIFF
--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -29,5 +29,5 @@ module.exports = {
     },
   },
   variants: {},
-  plugins: [require('../src/index.js')({rtl:true})],
+  plugins: [require('../src/index.js')],
 }

--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -29,5 +29,5 @@ module.exports = {
     },
   },
   variants: {},
-  plugins: [require('../src/index.js')],
+  plugins: [require('../src/index.js')({rtl:true})],
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const plugin = require('tailwindcss/plugin')
 const merge = require('lodash.merge')
 const castArray = require('lodash.castarray')
 const styles = require('./styles')
-const { commonTrailingPseudos } = require('./utils')
+const { commonTrailingPseudos, convertRtlProperties } = require('./utils')
 
 const computed = {
   // Reserved for future "magic properties", for example:
@@ -29,8 +29,12 @@ function isObject(value) {
   return typeof value === 'object' && value !== null
 }
 
-function configToCss(config = {}, { target, className, modifier, prefix }) {
+function configToCss(config = {}, { target, className, modifier, prefix, rtl }) {
   function updateSelector(k, v) {
+    if (rtl) {
+      v = convertRtlProperties(v)
+    } 
+
     if (target === 'legacy') {
       return [k, v]
     }
@@ -69,11 +73,11 @@ function configToCss(config = {}, { target, className, modifier, prefix }) {
 }
 
 module.exports = plugin.withOptions(
-  ({ className = 'prose', target = 'modern' } = {}) => {
+  ({ className = 'prose', target = 'modern', rtl = false } = {}) => {
     return function ({ addVariant, addComponents, theme, prefix }) {
       let modifiers = theme('typography')
 
-      let options = { className, prefix }
+      let options = { className, prefix , rtl}
 
       for (let [name, ...selectors] of [
         ['headings', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'th'],
@@ -125,6 +129,7 @@ module.exports = plugin.withOptions(
               className,
               modifier,
               prefix,
+              rtl
             }
           ),
         }))

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,4 +59,30 @@ module.exports = {
 
     return [null, selector]
   },
+  convertRtlProperties(v) {
+    const ltrToRtlMapping = {
+      'paddingLeft': 'paddingInlineStart',
+      'paddingRight': 'paddingInlineEnd',
+      'marginLeft': 'marginInlineStart',
+      'marginRight': 'marginInlineEnd',
+      'left': 'right',
+      // Add more mappings as needed
+    };
+
+    if ((typeof v === 'object' && v !== null)) {
+      v = Object.entries(v).reduce((result, [key, value]) => {
+        // Check if there is a mapping for the current property
+        if (ltrToRtlMapping[key]) {
+          // If there is a mapping, use the mapped property name
+          result[ltrToRtlMapping[key]] = value;
+        } else {
+          // If there is no mapping, use the original property name
+          result[key] = value;
+        }
+        return result;
+      }, {});
+    }
+
+    return v
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,7 +65,6 @@ module.exports = {
       'paddingRight': 'paddingInlineEnd',
       'marginLeft': 'marginInlineStart',
       'marginRight': 'marginInlineEnd',
-      'left': 'right',
       // Add more mappings as needed
     };
 


### PR DESCRIPTION
Added RTL support with passing test, for backwards compatibility I created a new utility function that converts RTL properties using a mapping of sorts, added an RTL flag that now when a user is interested in RTL he can turn that on. @adamwathan.

P.S: worth noting on moving `isObject` into `utils.js`, I think that might be a more appropriate place for it.