### PR TITLE
rm content style, in pseudo class of code el

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1533,12 +1533,6 @@ module.exports = {
           color: 'var(--tw-prose-code)',
           fontWeight: '600',
         },
-        'code::before': {
-          content: '"`"',
-        },
-        'code::after': {
-          content: '"`"',
-        },
         'a code': {
           color: 'inherit',
         },


### PR DESCRIPTION
Due to the presence of `content`  in code::before and code::after, unintended designs are included, as shown in the image below.

<img width="152" alt="image" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/43776161/07682be9-b9ad-4c4a-8ed9-8be136dfca32">

ref
https://codepen.io/yanskun/pen/OJdgZZX
