### PR TITLE
ci: add provenance to insider packages

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -49,7 +53,7 @@ jobs:
         run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force --no-git-tag-version
 
       - name: Publish
-        run: npm publish --tag insiders
+        run: npm publish --provenance --tag insiders
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This commit adds provenance for insider packages. See the NPM documentation [0].

Note: This will only affect the insiders build, because the normal package is sadly not being built within a workflow.
Should we add that too here or rather in another PR/later?

Provenance will allow people to verify that the packages were actually built on GH Actions and with the content of the corresponding commit. This will help with supply chain security.

For this to work, the `id-token` permission was added only where necessary.

[0]: https://docs.npmjs.com/generating-provenance-statements