### PR TITLE
Fix space between `<figcaption>` and `<video>`

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1522,6 +1522,7 @@ module.exports = {
         picture: {
           display: 'block',
         },
+        video: {}, // Required to maintain correct order when merging
         kbd: {
           fontWeight: '500',
           fontFamily: 'inherit',


### PR DESCRIPTION
Based off #313, ensure the video selector order is maintained so that the figure margin 0 overrides it correctly, allowing captions to be closer to the video.

Before:

<kbd><img width="715" alt="image" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/882133/168e9952-b5fa-4cd0-ac6e-749f0e187498"></kbd>

After:

<kbd><img width="721" alt="image" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/882133/63bf6936-ce50-493b-8414-e8723eb3a96f"></kbd>
