### PR TITLE
Fix for the table `text-align: start`

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1587,7 +1587,6 @@ module.exports = {
         table: {
           width: '100%',
           tableLayout: 'auto',
-          textAlign: 'start',
           marginTop: em(32, 16),
           marginBottom: em(32, 16),
         },
@@ -1616,6 +1615,9 @@ module.exports = {
         },
         'tfoot td': {
           verticalAlign: 'top',
+        },
+        'th, td': {
+          textAlign: 'start',
         },
         'figure > *': {}, // Required to maintain correct order when merging
         figcaption: {


### PR DESCRIPTION
After this [commit](https://github.com/tailwindlabs/tailwindcss-typography/commit/f520c53470630e3ad4d43e3c2306882d33bf5c52), text alignment in tables no longer works as intended. It appears that `text-align: start;` does not apply correctly to the `table` tag.

To address this, I propose applying `text-align: start;` directly to the `th` and `td` tags, ensuring correct alignment.