### PR TITLE
Don't apply margins to `<br>` elements contained in an `<li>` in FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't apply margins to `<br>` elements contained in an `<li>` in FF ([#350](https://github.com/tailwindlabs/tailwindcss-typography/pull/350))
 
 ## [0.5.12] - 2024-03-27
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -128,16 +128,16 @@ let defaultModifiers = {
           marginTop: em(8, 14),
           marginBottom: em(8, 14),
         },
-        '> ul > li > *:first-child': {
+        '> ul > li > p:first-child': {
           marginTop: em(16, 14),
         },
-        '> ul > li > *:last-child': {
+        '> ul > li > p:last-child': {
           marginBottom: em(16, 14),
         },
-        '> ol > li > *:first-child': {
+        '> ol > li > p:first-child': {
           marginTop: em(16, 14),
         },
-        '> ol > li > *:last-child': {
+        '> ol > li > p:last-child': {
           marginBottom: em(16, 14),
         },
         'ul ul, ul ol, ol ul, ol ol': {
@@ -333,16 +333,16 @@ let defaultModifiers = {
           marginTop: em(12, 16),
           marginBottom: em(12, 16),
         },
-        '> ul > li > *:first-child': {
+        '> ul > li > p:first-child': {
           marginTop: em(20, 16),
         },
-        '> ul > li > *:last-child': {
+        '> ul > li > p:last-child': {
           marginBottom: em(20, 16),
         },
-        '> ol > li > *:first-child': {
+        '> ol > li > p:first-child': {
           marginTop: em(20, 16),
         },
-        '> ol > li > *:last-child': {
+        '> ol > li > p:last-child': {
           marginBottom: em(20, 16),
         },
         'ul ul, ul ol, ol ul, ol ol': {
@@ -538,16 +538,16 @@ let defaultModifiers = {
           marginTop: em(16, 18),
           marginBottom: em(16, 18),
         },
-        '> ul > li > *:first-child': {
+        '> ul > li > p:first-child': {
           marginTop: em(24, 18),
         },
-        '> ul > li > *:last-child': {
+        '> ul > li > p:last-child': {
           marginBottom: em(24, 18),
         },
-        '> ol > li > *:first-child': {
+        '> ol > li > p:first-child': {
           marginTop: em(24, 18),
         },
-        '> ol > li > *:last-child': {
+        '> ol > li > p:last-child': {
           marginBottom: em(24, 18),
         },
         'ul ul, ul ol, ol ul, ol ol': {
@@ -743,16 +743,16 @@ let defaultModifiers = {
           marginTop: em(16, 20),
           marginBottom: em(16, 20),
         },
-        '> ul > li > *:first-child': {
+        '> ul > li > p:first-child': {
           marginTop: em(24, 20),
         },
-        '> ul > li > *:last-child': {
+        '> ul > li > p:last-child': {
           marginBottom: em(24, 20),
         },
-        '> ol > li > *:first-child': {
+        '> ol > li > p:first-child': {
           marginTop: em(24, 20),
         },
-        '> ol > li > *:last-child': {
+        '> ol > li > p:last-child': {
           marginBottom: em(24, 20),
         },
         'ul ul, ul ol, ol ul, ol ol': {
@@ -948,16 +948,16 @@ let defaultModifiers = {
           marginTop: em(20, 24),
           marginBottom: em(20, 24),
         },
-        '> ul > li > *:first-child': {
+        '> ul > li > p:first-child': {
           marginTop: em(32, 24),
         },
-        '> ul > li > *:last-child': {
+        '> ul > li > p:last-child': {
           marginBottom: em(32, 24),
         },
-        '> ol > li > *:first-child': {
+        '> ol > li > p:first-child': {
           marginTop: em(32, 24),
         },
-        '> ol > li > *:last-child': {
+        '> ol > li > p:last-child': {
           marginBottom: em(32, 24),
         },
         'ul ul, ul ol, ol ul, ol ol': {


### PR DESCRIPTION
Before this change the following would have unexpected extra space between the two lines of text in Firefox (but not in Safari or Chrome):
```html
<div className="prose">
  <ul>
    <li>
      line 1
      <br />
      line 2
    </li>
  </ul>
</div>
```

Before, in FF:
<img width="169" alt="before" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/614993/8fec8b22-6be1-4bf8-8113-70976c69a3b7">

After, in FF — now matching other browsers:
<img width="170" alt="after" src="https://github.com/tailwindlabs/tailwindcss-typography/assets/614993/3c248c05-661d-4f53-b6ca-f368bfdb34c7">

The intent of the selectors I've changed were to target leading/trailing `p` tags in a list item but we are targeting `*` instead. This had the side effect of causing `<br>` elements inside list items to gain a margin _only in Firefox_. Other browsers treat the `<br>` element like any other inline element and as such don’t apply margins.

Fixes #349