### PR TITLE
Use Node 22 in CI workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR bumps the Node versions to 22 in the CI workflows.

For the general tests I also added an older version of Node 20.

Once this is merged, then #353 should work automatically.

