### PR TITLE
Bring back "Adding new modifiers" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,35 @@ When stacking these modifiers with other modifiers like `hover`, you most likely
 
 Read the Tailwind CSS documentation on [ordering stacked modifiers](https://tailwindcss.com/docs/hover-focus-and-other-states#ordering-stacked-modifiers) to learn more.
 
+### Adding new modifiers
+
+You can add a new modifier by creating a new key in the `typography` section of your theme and providing your own styles under the `css` key:
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      typography: {
+        '3xl': {
+          css: {
+            fontSize: '1.875rem',
+            h1: {
+              fontSize: '4rem',
+            },
+            // ...
+          },
+        },
+      },
+    }
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+    // ...
+  ],
+}
+```
+
 ### Overriding max-width
 
 Each size modifier comes with a baked in `max-width` designed to keep the content as readable as possible. This isn't always what you want though, and sometimes you'll want the content to just fill the width of its container.


### PR DESCRIPTION
Changes made to `README.md` have first removed and then brought code bits to README, but "Adding new modifiers" section was lost somewhere along the way,

I find it pretty important as it encourages customization  + it also broke one answer to and old issue which actually lead me here: https://github.com/tailwindlabs/tailwindcss-typography/issues/52#issuecomment-769755342

I simply propose to bring it back