### PR TITLE
Update peer dependency version to include 4.0.0-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update peer dependency versions to include Tailwind `4.0.0-alpha.20` with support for this plugin
+- Update peer dependency versions to include Tailwind `4.0.0-alpha.20` with support for this plugin ([#358](https://github.com/tailwindlabs/tailwindcss-typography/pull/358))
 
 ## [0.5.14] - 2024-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Update peer dependency versions to include Tailwind `4.0.0-alpha.20` with support for this plugin
 
 ## [0.5.14] - 2024-08-07
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release-notes": "node ./scripts/release-notes.js"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || insiders"
+    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
   },
   "devDependencies": {
     "@mdx-js/loader": "^1.0.19",


### PR DESCRIPTION
Now that we have support for it, we should make `npm install @tailwindcss/forms` not fail 🙂 

The change was tested by installing it via a tarball. 