### PR TITLE
Clean up extra spread array

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ module.exports = {
         continue
       }
 
-      let values = new Set([...pseudos.map((p) => p.value)])
+      let values = new Set(pseudos.map((p) => p.value))
 
       // The pseudo elements are not the same
       if (values.size > 1) {


### PR DESCRIPTION
Map [returns a new array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), so we can just use that result directly, instead of spreading it into a new array!