### PR TITLE
Update peer dependency version to include 4.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Support installing with beta versions of Tailwind CSS v4 ([#365](https://github.com/tailwindlabs/tailwindcss-typography/pull/365))
 
 ## [0.5.15] - 2024-08-28
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release-notes": "node ./scripts/release-notes.js"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
   },
   "devDependencies": {
     "@mdx-js/loader": "^1.0.19",


### PR DESCRIPTION
Same as https://github.com/tailwindlabs/tailwindcss-typography/pull/358 but for beta releases.