### PR TITLE
Add inherit theme for if theming is undesired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Here are the classes that are generated using a totally default Tailwind CSS v2.
 | `prose-zinc`             | Zinc       |
 | `prose-neutral`          | Neutral    |
 | `prose-stone`            | Stone      |
+| `prose-inherit`          | Inherit    |
 
 Modifier classes are designed to be used with the [multi-class modifier pattern](http://nicolasgallagher.com/about-html-semantics-front-end-architecture/#component-modifiers) and must be used in conjunction with the base `prose` class.
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1250,6 +1250,49 @@ let defaultModifiers = {
     },
   },
 
+  // Inherit color theme
+
+  inherit: {
+    css: {
+      '--tw-prose-body': "inherit",
+      '--tw-prose-headings': "inherit",
+      '--tw-prose-lead': "inherit",
+      '--tw-prose-links': "inherit",
+      '--tw-prose-bold': "inherit",
+      '--tw-prose-counters': "inherit",
+      '--tw-prose-bullets': "inherit",
+      '--tw-prose-hr': "inherit",
+      '--tw-prose-quotes': "inherit",
+      '--tw-prose-quote-borders': "inherit",
+      '--tw-prose-captions': "inherit",
+      '--tw-prose-kbd': "inherit",
+      '--tw-prose-kbd-shadows': "inherit",
+      '--tw-prose-code': "inherit",
+      '--tw-prose-pre-code': "inherit",
+      '--tw-prose-pre-bg': "inherit",
+      '--tw-prose-th-borders': "inherit",
+      '--tw-prose-td-borders': "inherit",
+      '--tw-prose-invert-body': "inherit",
+      '--tw-prose-invert-headings': "inherit",
+      '--tw-prose-invert-lead': "inherit",
+      '--tw-prose-invert-links': "inherit",
+      '--tw-prose-invert-bold': "inherit",
+      '--tw-prose-invert-counters': "inherit",
+      '--tw-prose-invert-bullets': "inherit",
+      '--tw-prose-invert-hr': "inherit",
+      '--tw-prose-invert-quotes': "inherit",
+      '--tw-prose-invert-quote-borders': "inherit",
+      '--tw-prose-invert-captions': "inherit",
+      '--tw-prose-invert-kbd': "inherit",
+      '--tw-prose-invert-kbd-shadows': "inherit",
+      '--tw-prose-invert-code': "inherit",
+      '--tw-prose-invert-pre-code': "inherit",
+      '--tw-prose-invert-pre-bg': "inherit",
+      '--tw-prose-invert-th-borders': "inherit",
+      '--tw-prose-invert-td-borders': "inherit",
+    },
+  },
+
   // Link-only themes (for backward compatibility)
 
   red: {


### PR DESCRIPTION
Sometimes a project will already have a colour scheme defined (that also reacts to media queries, etc), and the developer may wish to use that over having prose overwrite this with its own colours.