### PR TITLE
Change the borderTopWidth value for hr from integer to a pixel value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Include unit in `hr` border-width value ([#379](https://github.com/tailwindlabs/tailwindcss-typography/pull/379)
 
 ## [0.5.16] - 2025-01-07
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1470,7 +1470,7 @@ module.exports = {
         },
         hr: {
           borderColor: 'var(--tw-prose-hr)',
-          borderTopWidth: 1,
+          borderTopWidth: '1px',
         },
         blockquote: {
           fontWeight: '500',


### PR DESCRIPTION
Noticed an invalid border width (`border-top-width`) value for the `hr` selector in DevTools. Despite that, the `hr` element is appearing as expected, inheriting the valid border width value from the preflight.

![Screenshot From 2025-02-07 21-29-16](https://github.com/user-attachments/assets/9902eb11-eaa0-4d53-8767-5fcaa15081bf)

- Add a pixel string value for `borderTopWidth` property in the `hr` object in `styles.js`