### PR TITLE
Fix plugin import path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then add the plugin to your main `style.css` file:
 
 ```diff
   @import "tailwindcss";
-+ @plugin "tailwindcss/typography";
++ @plugin "@tailwindcss/typography";
 ```
 
 ---


### PR DESCRIPTION
I think this is what it should be! The earlier version gave me an error with vite:

```
[plugin:@tailwindcss/vite:generate:serve] Package path ./typography is not exported from package  
.../.../node_modules/tailwindcss (see exports field in
```


Thank you for this wonderful project!