### PR TITLE
Update peer dependency version to include 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Include unit in `hr` border-width value ([#379](https://github.com/tailwindlabs/tailwindcss-typography/pull/379)
+- Support installing with release versions of Tailwind CSS v4 ([#389](https://github.com/tailwindlabs/tailwindcss-typography/pull/389))
 
 ## [0.5.16] - 2025-01-07
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release-notes": "node ./scripts/release-notes.js"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1 || >=4.0.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "^1.0.19",


### PR DESCRIPTION
Same as #365 but for release version.

Hello! 👋 I love this plugin, specially for markdown, I followed the same steps as previous versions of commits so we can get rid of that ugly warning.

Let me know if I have to do some change.