### PR TITLE
Update README with 'not-prose' usage clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ If you have a block of markup embedded in some content that shouldn't inherit th
 
 Note that you can't nest new `prose` instances within a `not-prose` block at this time.
 
+If using a `prefix(...)`, use `not-prose` without the prefix.
+
 ### Adding custom color themes
 
 To customize the color theme beyond simple CSS overrides, you can use the JavaScript based theme API. To do that, use the `@config` directive:


### PR DESCRIPTION
Clarify usage of `not-prose` when setting a Tailwind prefix

I ran into this the other day.