### PR TITLE
Fix variable declaration in opacity function

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -12,7 +12,7 @@ const opacity = (color, opacity) => {
   // only handled these values. We keep the old behavior for backward
   // compatibility with v3 codebases but use color-mix for any other color
   // values.
-  hex = color.replace('#', '')
+  let hex = color.replace('#', '')
   hex = hex.length === 3 ? hex.replace(/./g, '$&$&') : hex
   const r = parseInt(hex.substring(0, 2), 16)
   const g = parseInt(hex.substring(2, 4), 16)


### PR DESCRIPTION
Fixes bug where `hex` isn't defined due to [these recent changes](https://github.com/tailwindlabs/tailwindcss-typography/commit/f822222ae6e289e8cc0b23636891dc3545d5682a#diff-f3331a84c51a6f085fad8f853ae9dc1eb9188eca02f0ff692310780e4dfc58a0R10-R16) 

<img width="494" height="262" alt="image" src="https://github.com/user-attachments/assets/adf93b9c-707e-4e74-abe1-c0255264808f" />

<img width="585" height="219" alt="image" src="https://github.com/user-attachments/assets/e1fd518e-89d8-4c05-a1cd-caaafd6af19b" />
