### PR TITLE
fix: remove underline links without an href

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1418,6 +1418,11 @@ module.exports = {
         },
         a: {
           color: 'var(--tw-prose-links)',
+          textDecoration: 'none',
+          fontWeight: '500',
+        },
+        'a[href]': {
+          color: 'var(--tw-prose-links)',
           textDecoration: 'underline',
           fontWeight: '500',
         },


### PR DESCRIPTION
### Only style links with an `href` attribute
### issue: #373

Apply link styling only to `<a>` elements that include an `href` attribute.

Anchor tags without `href` behave like normal text, so they should not be underlined or appear clickable.
