### PR TITLE
Update tailwindcss peer dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Support installing with stable versions of Tailwind CSS v4 ([#424](https://github.com/tailwindlabs/tailwindcss-typography/pull/424))
 
 ## [0.5.19] - 2025-09-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "tailwindcss": "^3.2.2"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release-notes": "node ./scripts/release-notes.js"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+    "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
   },
   "devDependencies": {
     "@mdx-js/loader": "^1.0.19",


### PR DESCRIPTION
Fixes `pnpm peers check`:

```
Issues with peer dependencies found

✕ unmet peer tailwindcss
  Installed: 4.2.4
  Wanted:
    ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1":
      @tailwindcss/typography@0.5.19
```