### PR TITLE
ci: restrict nodejs workflow permissions to read-only

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes.

Setting `contents: read` explicitly on `.github/workflows/nodejs.yml` keeps the workflow token scoped to what the job actually uses. If a third-party action or transitive dependency in the run were ever compromised, a read-only token limits the damage (no pushes, no releases, no token-backed writes). The change is mechanical and does not alter any step.